### PR TITLE
Added note on creating Helpers for Plugins

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -359,6 +359,13 @@ component. For example::
 
 The same technique applies to Helpers and Behaviors.
 
+.. note::
+
+    When creating Helpers you may find AppHelper is not automatically available. You should declare the resources you need with Uses::
+    
+    <?php
+    //Declare use of AppHelper for your Plugin's Helper
+    App::uses('AppHelper', 'View/Helper');
 
 Expand Your Plugin
 ------------------


### PR DESCRIPTION
It seems you can not just extend AppHelper from your plugin in some cases and as it is also best practice to declare your dependencies I added a small note to that effect.
