### PR TITLE
Line 294 generated a syntax error. $suite->addTestDirectory(TESTS . 'Case

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -291,7 +291,7 @@ could would create ``app/Test/Case/AllModelTest.php``. Put the following in it::
     class AllModelTest extends CakeTestSuite {
         public static function suite() {
             $suite = new CakeTestSuite('All model tests');
-            $suite->addTestDirectory(TESTS . 'Case' . DS 'Model');
+            $suite->addTestDirectory(TESTS . 'Case' . DS . 'Model');
             return $suite;
         }
     }


### PR DESCRIPTION
Line 294 generated a syntax error. $suite->addTestDirectory(TESTS . 'Case' . DS 'Model'); Added a period after the directory separator so there is no syntax error.
