### PR TITLE
Update API link to 2.0 docs

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -624,7 +624,7 @@ for building more feature-rich applications.
 
 Now that you've created a basic Cake application you're ready for
 the real thing. Start your own project, read the rest of the
-`Manual </>`_ and `API <http://api.cakephp.org>`_.
+`Manual </>`_ and `API <http://api20.cakephp.org>`_.
 
 If you need help, come see us in #cakephp. Welcome to CakePHP!
 


### PR DESCRIPTION
My first contribution!  The API link pointed to api.cakephp.org, updated it to api20.cakephp.org.
