### PR TITLE
Replace "var" with "public" wherever possible

### DIFF
--- a/en/appendices/2-0-migration-guide.rst
+++ b/en/appendices/2-0-migration-guide.rst
@@ -1000,7 +1000,7 @@ Or just declare the property in the model class::
 
     <?php
     class Post {
-        var $nonexistantProperty = array();
+        public $nonexistantProperty = array();
     }
 
 Either of these approaches will solve the notice errors.
@@ -1126,7 +1126,7 @@ Would look in the controller's plugin before checking app/core components. It
 will now only look in the app/core components. If you wish to use objects from a
 plugin you must put the plugin name::
 
-    var $components = array('Session', 'Comment.Comments');
+    public $components = array('Session', 'Comment.Comments');
 
 This was done to reduce hard to debug issues caused by magic misfiring. It also
 improves consistency in an application, as objects have one authoritative way to
@@ -1237,4 +1237,3 @@ need to pass the package they are located in. Example::
         'password' => 'root',
         'database' => 'cake',
     );
-

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -156,7 +156,7 @@ through which we can access an instance of it::
     <?php
     /* Make the new component available at $this->Math,
     as well as the standard $this->Session */
-    var $components = array('Math', 'Session');
+    public $components = array('Math', 'Session');
 
 Components declared in ``AppController`` will be merged with those
 in your other controllers. So there is no need to re-declare the
@@ -168,7 +168,7 @@ constructor. These parameters can then be handled by
 the Component::
 
     <?php
-    var $components = array(
+    public $components = array(
         'Math' => array(
             'precision' => 2,
             'randomGenerator' => 'srand'
@@ -194,7 +194,7 @@ way you include them in controllers - using the ``$components`` var::
     <?php
     class CustomComponent extends Component {
         // the other component your component uses
-        var $components = array('Existing'); 
+        public $components = array('Existing'); 
     
         function initialize($controller) {
             $this->Existing->foo();

--- a/en/controllers/scaffolding.rst
+++ b/en/controllers/scaffolding.rst
@@ -40,7 +40,7 @@ $scaffold variable::
     <?php
     
     class CategoriesController extends AppController {
-        var $scaffold;
+        public $scaffold;
     }
     
 Assuming you’ve created even the most basic Category model class
@@ -67,9 +67,9 @@ following code, the view displays a select input populated with IDs
 or names from the Group table in the New User form::
 
     // In group.php
-    var $hasMany = 'User';
+    public $hasMany = 'User';
     // In user.php
-    var $belongsTo = 'Group';
+    public $belongsTo = 'Group';
 
 If you’d rather see something besides an ID (like the user’s first
 name), you can set the $displayField variable in the model. Let’s
@@ -81,8 +81,8 @@ in many instances::
     <?php
 
     class User extends AppModel {
-        var $name = 'User';
-        var $displayField = 'first_name';
+        public $name = 'User';
+        public $displayField = 'first_name';
     }
 
 
@@ -96,7 +96,7 @@ use scaffolding to generate an admin interface.
 Once you have enabled admin routing assign your admin prefix to the
 scaffolding variable::
 
-    var $scaffold = 'admin';
+    public $scaffold = 'admin';
 
 You will now be able to access admin scaffolded actions::
 

--- a/en/core-libraries/behaviors/acl.rst
+++ b/en/core-libraries/behaviors/acl.rst
@@ -12,7 +12,7 @@ AROs::
 
     <?php
     class User extends AppModel {
-        var $actsAs = array('Acl' => array('type' => 'requester'));
+        public $actsAs = array('Acl' => array('type' => 'requester'));
     }
 
 This would attach the Acl behavior in ARO mode. To join the ACL
@@ -20,7 +20,7 @@ behavior in ACO mode use::
 
     <?php
     class Post extends AppModel {
-        var $actsAs = array('Acl' => array('type' => 'controlled'));
+        public $actsAs = array('Acl' => array('type' => 'controlled'));
     }
 
 You can also attach the behavior on the fly like so::

--- a/en/core-libraries/behaviors/containable.rst
+++ b/en/core-libraries/behaviors/containable.rst
@@ -20,7 +20,7 @@ your model::
 
     <?php
     class Post extends AppModel {
-        var $actsAs = array('Containable');
+        public $actsAs = array('Containable');
     }
 
 You can also attach the behavior on the fly::

--- a/en/core-libraries/behaviors/translate.rst
+++ b/en/core-libraries/behaviors/translate.rst
@@ -33,8 +33,8 @@ following example.::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate'
         );
     }
@@ -53,8 +53,8 @@ value with another array, like so::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate' => array(
                 'fieldOne', 'fieldTwo', 'and_so_on'
             )
@@ -68,8 +68,8 @@ our current example the model should now look something like this::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate' => array(
                 'name'
             )
@@ -107,8 +107,8 @@ setup as shown below. The naming is completely up to you.::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate' => array(
                 'name' => 'nameTranslation'
             )
@@ -231,7 +231,7 @@ your controller or you can define it directly in the model.
 
     <?php
     class PostsController extends AppController {
-        var $name = 'Posts';
+        public $name = 'Posts';
 
         function add() {
             if ($this->data) {
@@ -249,15 +249,15 @@ your controller or you can define it directly in the model.
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate' => array(
                 'name'
             )
         );
 
         // Option 1) just define the property directly
-        var $locale = 'en_us';
+        public $locale = 'en_us';
 
         // Option 2) create a simple method
         function setLanguage($locale) {
@@ -282,15 +282,15 @@ you need to setup your model like this::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate' => array(
                 'name'
             )
         );
         
         // Use a different model (and table)
-        var $translateModel = 'PostI18n';
+        public $translateModel = 'PostI18n';
     }
     ?>
 
@@ -312,7 +312,7 @@ Make sure that you change the ``$displayField`` to ``'field'``.::
 
     <?php
     class PostI18n extends AppModel { 
-        var $displayField = 'field'; // important
+        public $displayField = 'field'; // important
     }
     // filename: post_i18n.php
     ?>
@@ -330,18 +330,18 @@ $translateTable in your model, like so::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
-        var $actsAs = array(
+        public $name = 'Post';
+        public $actsAs = array(
             'Translate' => array(
                 'name'
             )
         );
         
         // Use a different model
-        var $translateModel = 'PostI18n';
+        public $translateModel = 'PostI18n';
         
         // Use a different table for translateModel
-        var $translateTable = 'post_translations';
+        public $translateTable = 'post_translations';
     }
     ?>
 

--- a/en/core-libraries/behaviors/tree.rst
+++ b/en/core-libraries/behaviors/tree.rst
@@ -80,7 +80,7 @@ tree to see what it looks like. With a simple controller::
     <?php
     class CategoriesController extends AppController {
     
-        var $name = 'Categories';
+        public $name = 'Categories';
     
         function index() {
             $this->data = $this->Category->generateTreeList(null, null, null, '&nbsp;&nbsp;&nbsp;');
@@ -94,8 +94,8 @@ and an even simpler model definition:::
     <?php
     // app/models/category.php
     class Category extends AppModel {
-        var $name = 'Category';
-        var $actsAs = array('Tree');
+        public $name = 'Category';
+        public $actsAs = array('Tree');
     }
     ?>
 

--- a/en/core-libraries/components/access-control-lists.rst
+++ b/en/core-libraries/components/access-control-lists.rst
@@ -493,7 +493,7 @@ ACL Component in your controller's $components array:
 
 ::
 
-    var $components = array('Acl');
+    public $components = array('Acl');
 
 Once we've got that done, let's see what some examples of creating
 these objects might look like. The following code could be placed
@@ -756,7 +756,7 @@ because permissions are managed by the Acl Component.
         // You might want to place this in the AppController
         // instead, but here works great too.
     
-        var $components = array('Acl');
+        public $components = array('Acl');
     
     }
 

--- a/en/core-libraries/components/cookie.rst
+++ b/en/core-libraries/components/cookie.rst
@@ -58,7 +58,7 @@ a secure connection, is available on the path
 ::
     
     <?php
-    var $components    = array('Cookie');
+    public $components    = array('Cookie');
     function beforeFilter() {
       $this->Cookie->name = 'baker_id';
       $this->Cookie->time =  3600;  // or '1 hour'

--- a/en/core-libraries/components/pagination.rst
+++ b/en/core-libraries/components/pagination.rst
@@ -31,7 +31,7 @@ here that the order key must be defined in an array structure like below::
     <?php
     class PostsController extends AppController {
     
-        var $paginate = array(
+        public $paginate = array(
             'limit' => 25,
             'order' => array(
                 'Post.title' => 'asc'
@@ -45,7 +45,7 @@ You can also include other :php:meth:`~Model::find()` options, such as
     <?php
     class PostsController extends AppController {
     
-        var $paginate = array(
+        public $paginate = array(
             'fields' => array('Post.id', 'Post.created'),
             'limit' => 25,        
             'order' => array(
@@ -66,7 +66,7 @@ pagination::
     <?php
     class RecipesController extends AppController {
     
-        var $paginate = array(
+        public $paginate = array(
             'limit' => 25,
             'contain' => array('Article')
         );
@@ -79,7 +79,7 @@ array after the model you wish to configure::
     <?php
     class PostsController extends AppController {
     
-        var $paginate = array(
+        public $paginate = array(
             'Post' => array (...),
             'Author' => array (...)
         );
@@ -188,7 +188,7 @@ the keyword in controller's ``$paginate`` class variable::
     /**
      * Add GROUP BY clause
      */
-    var $paginate = array(
+    public $paginate = array(
         'MyModel' => array(
             'limit' => 20, 
             'order' => array('week' => 'desc'),
@@ -235,7 +235,7 @@ that can be fetched to 100.  If this default is not appropriate for your
 application, you can adjust it as part of the pagination options::
 
     <?php
-    var $paginate = array(
+    public $paginate = array(
         // other keys here.
         'maxLimit' => 10
     );
@@ -257,7 +257,7 @@ type, and the :php:class:`PaginatorHelper` will generate links with the chosen t
 parameter::
     
     <?php
-    var $paginate = array(
+    public $paginate = array(
         'paramType' => 'querystring'
     );
 

--- a/en/core-libraries/components/request-handling.rst
+++ b/en/core-libraries/components/request-handling.rst
@@ -25,7 +25,7 @@ RequestHandler it must be included in your $components array::
     <?php
     class WidgetController extends AppController {
 
-        var $components = array('RequestHandler');
+        public $components = array('RequestHandler');
 
         //rest of controller
     }
@@ -47,7 +47,7 @@ the client and its request.
         <?php
         class PostsController extends AppController {
         
-            var $components = array('RequestHandler');
+            public $components = array('RequestHandler');
     
             function beforeFilter () {
                 if ($this->RequestHandler->accepts('html')) {

--- a/en/core-libraries/helpers/cache.rst
+++ b/en/core-libraries/helpers/cache.rst
@@ -67,7 +67,7 @@ created with ``CacheHelper``. To do so you must use the array
 format for ``$cacheAction`` and create an array like the following::
 
     <?php
-    var $cacheAction = array(
+    public $cacheAction = array(
         'view' => array('callbacks' => true, 'duration' => 21600),
         'add' => array('callbacks' => true, 'duration' => 36000),
         'index'  => array('callbacks' => true, 'duration' => 48000)

--- a/en/core-libraries/helpers/js.rst
+++ b/en/core-libraries/helpers/js.rst
@@ -80,7 +80,7 @@ To override the "$" shortcut, use the jQueryObject variable::
 
     <?php
     $this->Js->JqueryEngine->jQueryObject = '$j';
-    print $this->Html->scriptBlock('var $j = jQuery.noConflict();', 
+    print $this->Html->scriptBlock('public $j = jQuery.noConflict();', 
         array('inline' => false)); //Tell jQuery to go into noconflict mode
 
 Using the JsHelper inside customHelpers
@@ -756,8 +756,8 @@ include ``RequestHandlerComponent`` in your components. Add the
 following to your controller::
 
     <?php
-    var $components = array('RequestHandler');
-    var $helpers = array('Js');
+    public $components = array('RequestHandler');
+    public $helpers = array('Js');
 
 Next link in the javascript library you want to use. For this
 example we'll be using jQuery::

--- a/en/core-utility-libraries/httpsocket.rst
+++ b/en/core-utility-libraries/httpsocket.rst
@@ -80,7 +80,7 @@ HTTP methods.
     $request is a keyed array of various options. Here is the format
     and default settings::
 
-        var $request = array(
+        public $request = array(
             'method' => 'GET',
             'uri' => array(
                 'scheme' => 'http',

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -73,7 +73,7 @@ this::
     
     class RecipesController extends AppController {
     
-        var $components = array('RequestHandler');
+        public $components = array('RequestHandler');
     
         function index() {
             $recipes = $this->Recipe->find('all');

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -39,7 +39,7 @@ debug is equal to 0.  Before running any tests you should be sure to add a
 fixture tables and data::
 
     <?php
-    var $test = array(
+    public $test = array(
         'datasource' => 'Database/Mysql',
         'persistent' => false,
         'host' => 'dbhost',
@@ -1028,7 +1028,7 @@ a *shell script step* to the build that contains the following::
     cat > app/Config/database.php <<'DATABASE_PHP'
     <?php
     class DATABASE_CONFIG {
-      var $test = array(
+      public $test = array(
         'datasource' => 'Database/Mysql',
         'host' => 'localhost',
         'database' => 'jenkins_test',

--- a/en/models/associations-linking-models-together.rst
+++ b/en/models/associations-linking-models-together.rst
@@ -50,9 +50,9 @@ multidimensional array used to define association specifics.
     <?php
     
     class User extends AppModel {
-        var $name = 'User';
-        var $hasOne = 'Profile';
-        var $hasMany = array(
+        public $name = 'User';
+        public $hasOne = 'Profile';
+        public $hasMany = array(
             'Recipe' => array(
                 'className'  => 'Recipe',
                 'conditions' => array('Recipe.approved' => '1'),
@@ -73,21 +73,21 @@ appropriate to have
 
     <?php
     class User extends AppModel {
-        var $name = 'User';
-        var $hasMany = array(
+        public $name = 'User';
+        public $hasMany = array(
             'MyRecipe' => array('className' => 'Recipe'),
         );
-        var $hasAndBelongsToMany => array('Member' => array('className' => 'User'));
+        public $hasAndBelongsToMany => array('Member' => array('className' => 'User'));
     }
     
     class Group extends AppModel {
-        var $name = 'Group';
-        var $hasMany = array(
+        public $name = 'Group';
+        public $hasMany = array(
             'MyRecipe' => array(
                 'className'  => 'Recipe',
             )
         );
-        var $hasAndBelongsToMany => array('MemberOf' => array('className' => 'Group'));
+        public $hasAndBelongsToMany => array('MemberOf' => array('className' => 'Group'));
     }
     ?>
 
@@ -96,21 +96,21 @@ but the following will not work well in all circumstances:
 
     <?php
     class User extends AppModel {
-        var $name = 'User';
-        var $hasMany = array(
+        public $name = 'User';
+        public $hasMany = array(
             'MyRecipe' => 'Recipe',
         );
-        var $hasAndBelongsToMany => array('Member' => 'User');
+        public $hasAndBelongsToMany => array('Member' => 'User');
     }
     
     class Group extends AppModel {
-        var $name = 'Group';
-        var $hasMany = array(
+        public $name = 'Group';
+        public $hasMany = array(
             'MyRecipe' => array(
                 'className'  => 'Recipe',
             )
         );
-        var $hasAndBelongsToMany => array('Member' => 'Group');
+        public $hasAndBelongsToMany => array('Member' => 'Group');
     }
     ?>
 
@@ -177,8 +177,8 @@ property to the model class. Remember to have a Profile model in
     <?php
     
     class User extends AppModel {
-        var $name = 'User';                
-        var $hasOne = 'Profile';   
+        public $name = 'User';                
+        public $hasOne = 'Profile';   
     }
     ?>
 
@@ -196,8 +196,8 @@ to include only certain records.
     <?php
     
     class User extends AppModel {
-        var $name = 'User';          
-        var $hasOne = array(
+        public $name = 'User';          
+        public $hasOne = array(
             'Profile' => array(
                 'className'    => 'Profile',
                 'conditions'   => array('Profile.published' => '1'),
@@ -289,8 +289,8 @@ We can define the belongsTo association in our Profile model at
     <?php
     
     class Profile extends AppModel {
-        var $name = 'Profile';                
-        var $belongsTo = 'User';   
+        public $name = 'Profile';                
+        public $belongsTo = 'User';   
     }
     ?>
 
@@ -300,8 +300,8 @@ syntax::
     <?php
     
     class Profile extends AppModel {
-        var $name = 'Profile';                
-        var $belongsTo = array(
+        public $name = 'Profile';                
+        public $belongsTo = array(
             'User' => array(
                 'className'    => 'User',
                 'foreignKey'    => 'user_id'
@@ -395,8 +395,8 @@ We can define the hasMany association in our User model at
     <?php
     
     class User extends AppModel {
-        var $name = 'User';                
-        var $hasMany = 'Comment';   
+        public $name = 'User';                
+        public $hasMany = 'Comment';   
     }
     ?>
 
@@ -406,8 +406,8 @@ syntax::
     <?php
     
     class User extends AppModel {
-        var $name = 'User';                
-        var $hasMany = array(
+        public $name = 'User';                
+        public $hasMany = array(
             'Comment' => array(
                 'className'     => 'Comment',
                 'foreignKey'    => 'user_id',
@@ -536,7 +536,7 @@ and set the value to ``true``::
 
     <?php
     class Image extends AppModel {
-        var $belongsTo = array(
+        public $belongsTo = array(
             'ImageAlbum' => array('counterCache' => true)
         );
     }
@@ -553,7 +553,7 @@ Using our Image model example, we can specify it like so::
 
     <?php
     class Image extends AppModel {
-        var $belongsTo = array(
+        public $belongsTo = array(
             'ImageAlbum' => array(
                 'counterCache' => true,
                 'counterScope' => array('Image.active' => 1) // only count if "Image" is active = 1
@@ -626,8 +626,8 @@ array syntax this time::
     <?php
     
     class Recipe extends AppModel {
-        var $name = 'Recipe';   
-        var $hasAndBelongsToMany = array(
+        public $name = 'Recipe';   
+        public $hasAndBelongsToMany = array(
             'Ingredient' =>
                 array(
                     'className'              => 'Ingredient',
@@ -832,9 +832,9 @@ work. We'll start with two models::
     <?php
     
     class Leader extends AppModel {
-        var $name = 'Leader';
+        public $name = 'Leader';
      
-        var $hasMany = array(
+        public $hasMany = array(
             'Follower' => array(
                 'className' => 'Follower',
                 'order'     => 'Follower.rank'
@@ -847,7 +847,7 @@ work. We'll start with two models::
     <?php
     
     class Follower extends AppModel {
-        var $name = 'Follower';
+        public $name = 'Follower';
     }
     
     ?>
@@ -901,7 +901,7 @@ Here’s the basic usage pattern for unbindModel()::
 Now that we've successfully removed an association on the fly,
 let's add one. Our as-of-yet unprincipled Leader needs some
 associated Principles. The model file for our Principle model is
-bare, except for the var $name statement. Let's associate some
+bare, except for the public $name statement. Let's associate some
 Principles to our Leader on the fly (but remember–only for just the
 following find operation). This function appears in the
 LeadersController::
@@ -961,8 +961,8 @@ recipient\_id. Now your Message model can look something like::
 
     <?php
     class Message extends AppModel {
-        var $name = 'Message';
-        var $belongsTo = array(
+        public $name = 'Message';
+        public $belongsTo = array(
             'Sender' => array(
                 'className' => 'User',
                 'foreignKey' => 'user_id'
@@ -980,8 +980,8 @@ User model would look like::
 
     <?php
     class User extends AppModel {
-        var $name = 'User';
-        var $hasMany = array(
+        public $name = 'User';
+        public $hasMany = array(
             'MessageSent' => array(
                 'className' => 'Message',
                 'foreignKey' => 'user_id'
@@ -998,16 +998,16 @@ It is also possible to create self associations as shown below::
 
     <?php
     class Post extends AppModel {
-        var $name = 'Post';
+        public $name = 'Post';
         
-        var $belongsTo = array(
+        public $belongsTo = array(
             'Parent' => array(
                 'className' => 'Post',
                 'foreignKey' => 'parent_id'
             )
         );
     
-        var $hasMany = array(
+        public $hasMany = array(
             'Children' => array(
                 'className' => 'Post',
                 'foreignKey' => 'parent_id'

--- a/en/models/datasources.rst
+++ b/en/models/datasources.rst
@@ -174,7 +174,7 @@ And the configuration settings in your ``app/Config/database.php``
 would resemble something like this::
 
     <?php
-        var $twitter = array(
+        public $twitter = array(
             'datasource' => 'TwitterSource',
             'login' => 'username',
             'password' => 'password',
@@ -204,7 +204,7 @@ Simply place your datasource file into
 ``Plugin/[your_plugin]/Model/Datasource/[your_datasource].php``
 and refer to it using the plugin notation::
 
-    var $twitter = array(
+    public $twitter = array(
         'datasource' => 'Twitter.TwitterSource',
         'username' => 'test@example.com',
         'password' => 'hi_mom',

--- a/en/models/model-attributes.rst
+++ b/en/models/model-attributes.rst
@@ -26,7 +26,7 @@ Example usage:
 
     <?php
     class Example extends AppModel {
-       var $useDbConfig = 'alternate';
+       public $useDbConfig = 'alternate';
     }
 
 useTable
@@ -42,14 +42,14 @@ Example usage::
 
     <?php
     class Example extends AppModel {
-       var $useTable = false; // This model does not use a database table
+       public $useTable = false; // This model does not use a database table
     }
 
 Alternatively::
 
     <?php
     class Example extends AppModel {
-       var $useTable = 'exmp'; // This model uses a database table 'exmp'
+       public $useTable = 'exmp'; // This model uses a database table 'exmp'
     }
 
 tablePrefix
@@ -64,7 +64,7 @@ the model.
 Example usage::
 
     class Example extends AppModel {
-       var $tablePrefix = 'alternate_'; // will look for 'alternate_examples'
+       public $tablePrefix = 'alternate_'; // will look for 'alternate_examples'
     }
 
 .. _model-primaryKey:
@@ -80,7 +80,7 @@ Example usage::
 
     <?php
     class Example extends AppModel {
-        var $primaryKey = 'example_id'; // example_id is the field name in the database
+        public $primaryKey = 'example_id'; // example_id is the field name in the database
     }
     
 
@@ -98,7 +98,7 @@ For example, to use the ``username`` field::
 
     <?php
     class User extends AppModel {
-       var $displayField = 'username';
+       public $displayField = 'username';
     }
 
 Multiple field names cannot be combined into a single display
@@ -172,7 +172,7 @@ Each field is described by:
 Example Usage::
 
     <?php
-    var $_schema = array(
+    public $_schema = array(
         'first_name' => array(
             'type' => 'string', 
             'length' => 30
@@ -213,7 +213,7 @@ other fields in a model but will not be saveable.
 Example usage for MySQL::
 
     <?php
-    var $virtualFields = array(
+    public $virtualFields = array(
         'name' => "CONCAT(User.first_name, ' ', User.last_name)"
     );
 
@@ -237,7 +237,7 @@ Example usage::
 
     <?php
     class Example extends AppModel {
-       var $name = 'Example';
+       public $name = 'Example';
     }
 
 cacheQueries

--- a/en/models/virtual-fields.rst
+++ b/en/models/virtual-fields.rst
@@ -17,14 +17,14 @@ would be:
 
 ::
 
-    var $virtualFields = array(
+    public $virtualFields = array(
         'full_name' => 'CONCAT(User.first_name, " ", User.last_name)'
     );
 
 And with PostgreSQL:
 ::
 
-    var $virtualFields = array(
+    public $virtualFields = array(
         'name' => 'User.first_name || \' \' || User.last_name'
     );
 

--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -191,7 +191,7 @@ So, we place our new ContactsController in
     <?php
     // /app/Plugin/ContactManager/Controller/ContactsController.php
     class ContactsController extends ContactManagerAppController {
-        var $uses = array('ContactManager.Contact');
+        public $uses = array('ContactManager.Contact');
 
         function index() {
             //...
@@ -355,7 +355,7 @@ component. For example::
     }
     
     // within your controllers:
-    var $components = array('ContactManager.Example'); 
+    public $components = array('ContactManager.Example'); 
 
 The same technique applies to Helpers and Behaviors.
 

--- a/ja/appendices/2-0-migration-guide.rst
+++ b/ja/appendices/2-0-migration-guide.rst
@@ -920,7 +920,7 @@ PHPUnitによって全てのコマンドラインオプションがサポート�
 
     <?php
     class Post {
-        var $nonexistantProperty = array();
+        public $nonexistantProperty = array();
     }
 
 これらのどちらかのアプローチでnoticeエラーを回避できることでしょう。
@@ -1034,7 +1034,7 @@ AclBehaviorとTreeBehavior
 これはアプリケーション・コアのコンポーネントのみを見るようになりました。
 プラグインからオブジェクトを使いたい場合は、プラグインの名前を指定しなければなりません::
 
-    var $components = array('Session', 'Comment.Comments');
+    public $components = array('Session', 'Comment.Comments');
 
 これは、マジックの失敗によって起こされていた問題をデバッグすることの煩雑さを減らすために為されました。
 また、オブジェクトの参照が単一の信頼できる方法になったことで、アプリケーションでの矛盾をなくします。
@@ -1121,4 +1121,3 @@ ConnectionManager
         'password' => 'root',
         'database' => 'cake',
     );
-


### PR DESCRIPTION
The "var" keyword should not be used anymore, prefer "public" as PHP5's OOP style.
