### PR TITLE
Changing correct naming conventions for custom cache engines

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -88,8 +88,8 @@ You can provide custom ``Cache`` adapters in ``app/Lib`` as well
 as in plugins using ``$plugin/Lib``. App/plugin cache engines can
 also override the core engines. Cache adapters must be in a cache
 directory. If you had a cache engine named ``MyCustomCacheEngine``
-it would be placed in either ``app/Lib/Cache/MyCustomCache.php``
-as an app/libs. Or in ``$plugin/Lib/Cache/MyCustomCache.php`` as
+it would be placed in either ``app/Lib/Cache/Engine/MyCustomCacheEngine.php``
+as an app/libs. Or in ``$plugin/Lib/Cache/Engine/MyCustomCacheEngine.php`` as
 part of a plugin. Cache configs from plugins need to use the plugin
 dot syntax.::
 


### PR DESCRIPTION
Cache engines should be found in app/Plugin/PluginName/lib/Cache/Engine/CacheNameEngine.php instead of app/PluginName/Lib/Cache/CacheName.php
