### PR TITLE
changing language directive in conf.py

### DIFF
--- a/pt/conf.py
+++ b/pt/conf.py
@@ -19,4 +19,4 @@ sys.path.insert(0, os.path.abspath('..'))
 # Pull in all the configuration options defined in the global config file..
 from config.all import *
 
-language = 'pt'
+language = 'pt_BR'


### PR DESCRIPTION
Sphinx doesn't support the current language defined in conf.py.
So "pt_BR" is the best choice. Because there is no support for "pt_PT" and the documentation doesn't cover the differences in dialects.
