### PR TITLE
Fixing class paths and some examples.

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -33,7 +33,7 @@ is done by calling ``CakeLog::config()``. Configuring our
 DataBaseLogger would look like::
     
     <?php
-    //for app/libs
+    //for app/Lib
     CakeLog::config('otherFile', array(
         'engine' => 'DatabaseLogger',
         'model' => 'LogEntry',

--- a/en/core-utility-libraries/app.rst
+++ b/en/core-utility-libraries/app.rst
@@ -18,7 +18,7 @@ CakePHP expects to find it.
 
 For instance if you'd like to use your own HttpSocket class, put it under::
 
-    app/libs/Network/Http/HttpSocket.php
+    app/Lib/Network/Http/HttpSocket.php
 
 Once you've done this App will load your override file instead of the file
 inside CakePHP.

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -237,11 +237,11 @@ Session
     * 'database' - Uses CakePHP's database sessions.
     * 'cache' - Use the Cache class to save sessions.
 
-    To define a custom session handler, save it at ``app/libs/session/<name>.php``.
+    To define a custom session handler, save it at ``app/Model/Datasource/Session/<name>.php``.
     Make sure the class implements :php:interface:`CakeSessionHandlerInterface` 
     and set Session.handler to <name>
 
-    To use database sessions, run the ``app/config/schema/sessions.php`` schema using
+    To use database sessions, run the ``app/Config/Schema/sessions.php`` schema using
     the cake shell command: ``cake schema create Sessions``
 
 Security.level
@@ -429,7 +429,7 @@ using :php:meth:`Configure::config()`::
 
     <?php
     App::uses('PhpReader', 'Configure');
-    // Read config files from app/config
+    // Read config files from app/Config
     Configure::config('default', new PhpReader());
 
     // Read config files from another path.
@@ -523,10 +523,13 @@ If you really like XML files, you could create a simple Xml config
 reader for you application::
 
     <?php
-    // in app/Lib/Config/XmlReader.php
+    // in app/Lib/Configure/XmlReader.php
     App::uses('Xml', 'Utility');
     class XmlReader implements ConfigReaderInterface {
-        function __construct($path = CONFIGS) {
+        function __construct($path = null) {
+            if (!$path) {
+                $path = APP . 'Config' . DS;
+            }
             $this->_path = $path;
         }
 
@@ -536,10 +539,10 @@ reader for you application::
         }
     }
 
-In your ``app/config/bootstrap.php`` you could attach this reader and use it::
+In your ``app/Config/bootstrap.php`` you could attach this reader and use it::
 
     <?php
-    App::uses('XmlReader', 'Lib/Config');
+    App::uses('XmlReader', 'Configure');
     Configure::config('xml', new XmlReader());
     ...
 

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -52,7 +52,7 @@ use a class called ``AppError`` to handle your errors.  The following would
 need to be done::
 
     <?php
-    //in app/config/core.php
+    //in app/Config/core.php
     Configure::write('Error.handler', 'AppError::handleError');
 
     //in app/config/bootstrap.php


### PR DESCRIPTION
- CONFIGS constant is deprecated and session handler is moved to Model/Datasource
