### PR TITLE
Typos in examples/docs

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -274,6 +274,7 @@ PostsController:
 
     <?php
     class PostsController extends AppController {
+        public $helpers = array('Html', 'Form');
         public $name = 'Posts';
         public $components = array('Session');
     
@@ -320,7 +321,7 @@ redirection. In the layout we have
 :php:func:`SessionHelper::flash` which displays the
 message and clears the corresponding session variable. The
 controller's :php:meth:`Controller::redirect <redirect>` function
-redirects to another URL. The param ``array('action'=>'index)``
+redirects to another URL. The param ``array('action'=>'index')``
 translates to URL /posts i.e the index action of posts controller.
 You can refer to :php:func:`Router::url()` function on the api to see 
 the formats in which you can specify a URL for various cake functions.


### PR DESCRIPTION
Under the section 'Adding a post', $helpers is no longer defined in the example. Added this to the example code.
Also under 'Adding a post' array('action' => 'index) should have an closing single quote around index. Added this to the docs.
