### PR TITLE
index.ctp example code corrected

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -484,16 +484,13 @@ posts::
             <td><?php echo $post['Post']['id']; ?></td>
             <td>
                 <?php echo $this->Html->link($post['Post']['title'], array('action' => 'view', $post['Post']['id']));?>
-                    </td>
-                    <td>
-                <?php echo $this->Form->postLink(
-                    'Delete',
-                    array('action' => 'delete', $post['Post']['id']),
-                    array('confirm' => 'Are you sure?')
-                )?>
+            </td>
+            <td>
                 <?php echo $this->Html->link('Edit', array('action' => 'edit', $post['Post']['id']));?>
             </td>
-            <td><?php echo $post['Post']['created']; ?></td>
+            <td>
+                <?php echo $post['Post']['created']; ?>
+            </td>
         </tr>
     <?php endforeach; ?>
 
@@ -547,16 +544,19 @@ links that allow users to delete posts, however::
         <tr>
             <td><?php echo $post['Post']['id']; ?></td>
             <td>
-            <?php echo $this->Html->link($post['Post']['title'], array('action' => 'view', $post['Post']['id']));?>
+                <?php echo $this->Html->link($post['Post']['title'], array('action' => 'view', $post['Post']['id']));?>
             </td>
             <td>
-            <?php echo $this->Form->postLink(
-                'Delete', 
-                array('action' => 'delete', $post['Post']['id']),
-                array('confirm' => 'Are you sure?')); 
-            ?>
+                <?php echo $this->Form->postLink(
+                    'Delete', 
+                    array('action' => 'delete', $post['Post']['id']),
+                    array('confirm' => 'Are you sure?')); 
+                ?>
+                <?php echo $this->Html->link('Edit', array('action' => 'edit', $post['Post']['id']));?>
             </td>
-            <td><?php echo $post['Post']['created']; ?></td>
+            <td>
+                <?php echo $post['Post']['created']; ?>
+            </td>
         </tr>
         <?php endforeach; ?>
     


### PR DESCRIPTION
The index.ctp example code had the Delete link in the code prior to the Delete portion of the tutorial. Also, in the Delete portion of the tutorial, the index.ctp example code did not contain a link to Edit, even though the Edit feature had already been implemented in the previous section of the tutorial.
