### PR TITLE
Scaffold view fixes and incorrect File/Folder migration info

### DIFF
--- a/en/appendices/2-0-migration-guide.rst
+++ b/en/appendices/2-0-migration-guide.rst
@@ -550,8 +550,8 @@ Scaffold
 -  Scaffold 'edit' views should be renamed to 'form'. This was done to make
    scaffold and bake templates consistent.
 
-   -  ``views/scaffolds/edit.ctp -> ``views/scaffolds/form.ctp``
-   -  ``views/posts/scaffold.edit.ctp -> ``views/posts/scaffold.form.ctp``
+   -  ``views/scaffolds/edit.ctp -> ``View/Scaffolds/form.ctp``
+   -  ``views/posts/scaffold.edit.ctp -> ``View/Posts/scaffold.form.ctp``
 
 Xml
 ---

--- a/en/controllers/scaffolding.rst
+++ b/en/controllers/scaffolding.rst
@@ -131,14 +131,11 @@ Custom scaffolding views for a specific controller
 (PostsController in this example) should be placed like so::
 
     /app/View/Posts/scaffold.index.ctp
-    /app/View/Posts/scaffold.show.ctp
-    /app/View/Posts/scaffold.edit.ctp
-    /app/View/Posts/scaffold.new.ctp
+    /app/View/Posts/scaffold.form.ctp
+    /app/View/Posts/scaffold.view.ctp
 
 Custom scaffolding views for all controllers should be placed like so::
 
     /app/View/Scaffolds/index.ctp
-    /app/View/Scaffolds/show.ctp
-    /app/View/Scaffolds/edit.ctp
-    /app/View/Scaffolds/new.ctp
-    /app/View/Scaffolds/add.ctp
+    /app/View/Scaffolds/form.ctp
+    /app/View/Scaffolds/view.ctp


### PR DESCRIPTION
Sorry for the back to back pull requests... this just caught my eye randomly while in the migration guide. I believe the File and Folder info in the migration guide is incorrect. Here is the blame from back in June: vitorpc@615f762fae4b66bc0eba915d93b5b377e5815a57 The File class and claimed removed Folder methods are definitely still in 2.0 and I didn't see any tickets related to deprecating them.
