### PR TITLE
Adding $fixtures to "Testing Controllers" example

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -773,6 +773,8 @@ Create a file named ``ArticlesControllerTest.php`` in your
     <?php
     class ArticlesControllerTest extends ControllerTestCase {
 
+        public $fixtures = array('app.article');
+
         function testIndex() {
             $result = $this->testAction('/articles/index');
             debug($result);


### PR DESCRIPTION
The original code example for "Testing Controllers" didn't include the "public $fixtures" line - if you just copy and paste it, it will run using the default database connection instead of the test one. This might have been omitted to make the example simpler, but I think the consequences of forgetting this line are potentially very dangerous (you might delete or update live data accidentally!). So I suggest adding it here too...
