### PR TITLE
Development Testing Section

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -945,7 +945,7 @@ for redirects::
             )
         ));
 
-        $this->assertEquals($this->headers['Location'], '/posts/index');
+        $this->assertEquals($this->headers['Location'], 'http://localhost/blog/posts/index');
         $this->assertEquals($this->vars['post']['Post']['name'], 'New Post');
         $this->assertRegExp('/<html/', $this->contents);
         $this->assertRegExp('/<form/', $this->view);


### PR DESCRIPTION
Hello, 

Got an error when following along with the complex testing example in the 2.0 docs.

http://new.book.cakephp.org/2.0/en/development/testing.html?highlight=testing#a-more-complex-example

 $this->headers['Location'] is the hostname + path, but the example is using only the path. I added in the hostname.

I'd love it to work the way the manual says as the benefits of not having to add the hostname and or project directory would be great. Maybe a solution is to have an extra key LocationParts and you could access it from there. 

Similar to what http://php.net/parse_url returns.

$this->headers['LocationParts']['path'] = /posts/index
$this->headers['LocationParts']['query']
$this->headers['LocationParts']['fragment']

UPDATE: maybe those 
