### PR TITLE
Fix small typo + removal of old 1.3 book code

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -990,8 +990,8 @@ prefix your plugin fixtures with ``plugin.blog.blog_post``::
     class BlogPostTest extends CakeTestCase {
 
         // Plugin fixtures located in /app/Plugin/Blog/Test/Fixture/
-        public $fixtures = array('plugin.pizza.pizza_order');
-        public $PizzaOrderTest;
+        public $fixtures = array('plugin.blog.blog_post');
+        public $BlogPost;
 
         function testSomething() {
             // ClassRegistry makes the model use the test database connection


### PR DESCRIPTION
If I'm correct line 994: " public $BlogPost; " can be removed all together.
