### PR TITLE
RssHelper->header() seems to be gone.

### DIFF
--- a/en/core-libraries/helpers/rss.rst
+++ b/en/core-libraries/helpers/rss.rst
@@ -82,7 +82,6 @@ An Rss layout is very simple, put the following contents in
 ``app/View/Layout/rss/default.ctp``::
 
     <?php
-    echo $this->Rss->header();
     if (!isset($documentData)) {
         $documentData = array();
     }


### PR DESCRIPTION
Couldn't find it in the api. Also, the example is confusing because it looks like 2 separate layout files
