### PR TITLE
Added return type to testAction in complex example.

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -752,7 +752,8 @@ for redirects::
         $this->testAction('/posts/add', array(
             'data' => array(
                 'Post' => array('name' => 'New Post')
-            )
+            ),
+            'return' => 'vars'
         ));
 
         $this->assertEquals($this->headers['Location'], 'http://localhost/blog/posts/index');
@@ -770,6 +771,11 @@ of example, we also check to see if the layout was loaded by checking the entire
 rendered contents, and checks the view for a form tag. As you can see, your
 freedom to test controllers and easily mock its classes is greatly expanded with
 these changes.
+
+.. note::
+
+    $this->vars, $this->view and $this->contents are only available when the return 
+    type of ``testAction()`` is not 'result' in the example above it is set to 'vars'.
 
 When doing controller tests using mocks that use static methods you'll have to
 use a different method to register your mock expectations.  For example if you


### PR DESCRIPTION
Hello,

Noticed on the more complex testing example the code is using the default return type of 'result'. People might get confused when trying to access the testAction properties vars, contents, view.

http://book.cakephp.org/2.0/en/development/testing.html#a-more-complex-example

Merry Christmas, Thank you for Cake 2.0 it is very good.

kind regards,

Leigh
