### PR TITLE
changed assertEquals to assertContains

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -755,7 +755,7 @@ for redirects::
             )
         ));
 
-        $this->assertEquals($this->headers['Location'], 'http://localhost/blog/posts/index');
+        $this->assertContains('/posts/index', $this->headers['Location']);
         $this->assertEquals($this->vars['post']['Post']['name'], 'New Post');
         $this->assertRegExp('/<html/', $this->contents);
         $this->assertRegExp('/<form/', $this->view);


### PR DESCRIPTION
Hello,

This change will help people testing redirects when using testAction.

Asked about it here and Mark gave me the answer.

https://github.com/cakephp/docs/pull/160#issuecomment-3291237

Thank you!
