### PR TITLE
Replaces deprecated assertion

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -719,7 +719,7 @@ case::
     <?php
     public function testIndex() {
         $this->testAction('/posts/index');
-        $this->assertIsA($this->vars['posts'], 'array');
+        $this->assertInternalType('array', $this->vars['posts']);
     }
 
 


### PR DESCRIPTION
According to this http://cakephp.lighthouseapp.com/projects/42648/tickets/2264 assertIsA() is deprecated. Indeed I get erros when using it on my tests.
