### PR TITLE
Change link color in sidebar "table of contents" like with book 1.3 ,… … easier to see

### DIFF
--- a/themes/cakephp/static/default.css
+++ b/themes/cakephp/static/default.css
@@ -129,8 +129,17 @@ div.sphinxsidebar ul {
     color: #000;
 }
 
-div.sphinxsidebar a {
-    color: #088;
+div.sphinxsidebar .toctree-l1 a{
+    color: #000;
+    font-weight:bold;
+}
+div.sphinxsidebar .toctree-l2 a{
+    font-size: 12px;
+    font-weight:normal;
+}
+div.sphinxsidebar .toctree-l3 a{
+    font-size: 12px;
+    font-weight:normal;
 }
 
 div.sphinxsidebar input {


### PR DESCRIPTION
I think sidebar in book cakephp 2.0 looks bad , It is low contrast hard to read, too.
 I write some line css to change it look like book 1.3.
