### PR TITLE
We should escape least title and body when showing as text.

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -246,11 +246,11 @@ Now let's create the view for our new 'view' action and place it in
 
     <!-- File: /app/View/Posts/view.ctp -->
     
-    <h1><?php echo $post['Post']['title']?></h1>
+    <h1><?php echo h($post['Post']['title'])?></h1>
     
     <p><small>Created: <?php echo $post['Post']['created']?></small></p>
     
-    <p><?php echo $post['Post']['body']?></p>
+    <p><?php echo h($post['Post']['body'])?></p>
 
 Verify that this is working by trying the links at ``/posts/index`` or
 manually requesting a post by accessing ``/posts/view/1``.


### PR DESCRIPTION
As long as framework doesn't escape automatically, we should escape text.
This document might be able to promote XSS vulnerability. 
