### PR TITLE
Error in View blocks section sample code

### DIFF
--- a/en/views.rst
+++ b/en/views.rst
@@ -87,7 +87,7 @@ un-captured content from the extending view. Assuming our view file has a
 
     // app/View/Posts/view.ctp
     <?php
-    $this->extend('Common/view');
+    $this->extend('/Common/view');
 
     $this->assign('title', $post)
 
@@ -115,8 +115,8 @@ more than once in a view file will override the parent view that will be
 processed next::
 
     <?php
-    $this->extend('Common/view');
-    $this->extend('Common/index');
+    $this->extend('/Common/view');
+    $this->extend('/Common/index');
 
 The above will result in ``/Common/index.ctp`` being rendered as the parent view
 to the current view.


### PR DESCRIPTION
This has been raised as [ticket #83 in Lighthouse](http://cakephp.lighthouseapp.com/projects/43067/tickets/83-error-in-view-blocks-section-example).

In the second sample code, `View::extend` is called with `'Common/view'`, and that would render `app/Views/Posts/Common/view.ctp` instead of `app/Views/Common/view.ctp`, which is the where the view is according to the description in previous paragraphs.
