### PR TITLE
Replacing pt_BR by pt

### DIFF
--- a/pt/conf.py
+++ b/pt/conf.py
@@ -19,4 +19,4 @@ sys.path.insert(0, os.path.abspath('..'))
 # Pull in all the configuration options defined in the global config file..
 from config.all import *
 
-language = 'pt_BR'
+language = 'pt'


### PR DESCRIPTION
The searches are not working in Portuguese.
I know they used pt_BR to differentiate the Portuguese from Portugal. But in all other places were using only pt.
Someone will have to run "make html-pt"
