### PR TITLE
little typo in documentation

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -639,7 +639,7 @@ Create a file named ``ArticlesControllerTest.php`` in your
         public function testIndexShortGetRenderedHtml() {
             $result = $this->testAction(
                '/articles/index/short',
-                array('return' => 'render')
+                array('return' => 'contents')
             );
             debug($result);
         }


### PR DESCRIPTION
return type "render" does not exists - instead it should be "contents"
