### PR TITLE
Fixed a very very small 'bug' i EN doc

### DIFF
--- a/en/core-libraries/components/authentication.rst
+++ b/en/core-libraries/components/authentication.rst
@@ -260,8 +260,8 @@ Authentication objects can implement a ``getUser()`` method that can be
 used to support user login systems that don't rely on cookies.  A
 typical getUser method looks at the request/environment and uses the
 information there to confirm the identity of the user.  HTTP Basic
-authentication for example uses ``$_SERVER['PHP_AUTH_USER]`` and
-``$_SERVER['PHP_AUTH_PW]`` for the username and password fields.  On each
+authentication for example uses ``$_SERVER['PHP_AUTH_USER']`` and
+``$_SERVER['PHP_AUTH_PW']`` for the username and password fields.  On each
 request, if a client doesn't support cookies, these values are used to
 re-identify the user and ensure they are valid user.  As with
 authentication object's ``authenticate()`` method the ``getUser()`` method


### PR DESCRIPTION
Fixed a very small 'bug' in English Doc.
$_SERVER['PHP_AUTH_USER]
->
$_SERVER['PHP_AUTH_USER']

$_SERVER['PHP_AUTH_PW]
->
$_SERVER['PHP_AUTH_PW']
