### PR TITLE
Fixed a method name in sample code

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -562,7 +562,7 @@ this::
     class ArticleTest extends CakeTestCase {
         public $fixtures = array('app.article');
 
-        public function setup() {
+        public function setUp() {
             parent::setUp();
             $this->Article = ClassRegistry::init('Article');
         }


### PR DESCRIPTION
This is a little fix. But, I think that newbies hang up here.
