### PR TITLE
Fixed variable name in example code Helper constructor

### DIFF
--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -70,7 +70,7 @@ attribute values or modify behavior of a helper::
     class AwesomeHelper extends AppHelper {
         public function __construct(View $view, $settings = array()) {
             parent::__construct($view, $settings);
-            debug($options);
+            debug($settings);
         }
     }
 


### PR DESCRIPTION
Fixed variable name in example code about passing options/settings to a Helper constructor. `$options -> $settings`.
