### PR TITLE
Use $document_root rather then absolute path for SCRIPT_FILENAME

### DIFF
--- a/en/installation/advanced-installation.rst
+++ b/en/installation/advanced-installation.rst
@@ -322,7 +322,7 @@ you will need PHP running as a FastCGI instance.
             include /etc/nginx/fcgi.conf;
             fastcgi_pass    127.0.0.1:10005;
             fastcgi_index   index.php;
-            fastcgi_param SCRIPT_FILENAME /var/www/example.com/public/app/webroot$fastcgi_script_name;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }
 

--- a/es/installation/advanced-installation.rst
+++ b/es/installation/advanced-installation.rst
@@ -316,7 +316,7 @@ nginx es un servidor web que está ganando mucha popularidad. Igual que Lighttpd
             include /etc/nginx/fcgi.conf;
             fastcgi_pass    127.0.0.1:10005;
             fastcgi_index   index.php;
-            fastcgi_param SCRIPT_FILENAME /var/www/example.com/public/app/webroot$fastcgi_script_name;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }
 

--- a/ja/installation/advanced-installation.rst
+++ b/ja/installation/advanced-installation.rst
@@ -281,7 +281,7 @@ nginxはポピュラーなサーバーで、Lighttpdのように少ないシス�
             include /etc/nginx/fcgi.conf;
             fastcgi_pass    127.0.0.1:10005;
             fastcgi_index   index.php;
-            fastcgi_param SCRIPT_FILENAME /var/www/example.com/public/app/webroot$fastcgi_script_name;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }
 

--- a/pt/installation/advanced-installation.rst
+++ b/pt/installation/advanced-installation.rst
@@ -290,7 +290,7 @@ mas no mínimo, você irá precisar do PHP sendo executado como FastCGI.
             include /etc/nginx/fcgi.conf;
             fastcgi_pass    127.0.0.1:10005;
             fastcgi_index   index.php;
-            fastcgi_param SCRIPT_FILENAME /var/www/example.com/public/app/webroot$fastcgi_script_name;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }
 


### PR DESCRIPTION
As according to the Nginx Pitfalls document, there is no need to provide the full path of SCRIPT_FILENAME when $document_root is available.

http://wiki.nginx.org/Pitfalls#FastCGI_Path_in_Script_Filename
