### PR TITLE
Use of false values in 'default' option of FormHelper::input

### DIFF
--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -731,6 +731,12 @@ common options shared by all input methods are as follows:
     Date and datetime fields' default values can be set by using the
     'selected' key.
 
+  .. note::
+
+    Beware of using false to assign a default value. A false value is used to
+    disable/exclude options of an input field, so ``'default' => false`` would
+    not set any value at all. Instead use ``'default' => 0``.
+
 In addition to the above options, you can mixin any html attribute you wish to
 use.  Any non-special option name will be treated as an HTML attribute, and
 applied to the generated HTML input element.


### PR DESCRIPTION
As discussed in ticket [2866](http://cakephp.lighthouseapp.com/projects/42648/tickets/2866-inconsistent-behavior-of-default-values-for-hidden-input-fields), I added a note to warn readers about assigning boolean values in `default` option of `FormHelper::input`.
