### PR TITLE
Small typo fixes

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -108,7 +108,7 @@ Adding cake to your system path
 If you are on a \*nix system (linux, MacOSX) the following steps will let you add the 
 cake executable to your system path.
 
-#. Locate where your cakephp install, and cake executable are.  For example
+#. Locate where your CakePHP install, and cake executable are.  For example
    ``/Users/mark/cakephp/lib/Cake/Console/cake``
 #. Edit your ``.bashrc`` or ``.bash_profile`` file in your home directory, and add the following::
 
@@ -118,7 +118,7 @@ cake executable to your system path.
 
 If you are on Windows Vista or 7, you should follow the steps below.
 
-#. Locate where your cakephp install and cake executable are.  For example
+#. Locate where your CakePHP install and cake executable are.  For example
    ``C:\xampp\htdocs\cakephp\lib\Cake\Console``
 #. Open System Properties window from My Computer. You want to try the shortcut Windows Key + Pause or Windows Key + Break. Or, from the Desktop, right-click My Computer, click Properties then click Advanced System Settings link in the left column
 #. Go under Advanced tab and click on Environment Variables button

--- a/en/core-utility-libraries/time.rst
+++ b/en/core-utility-libraries/time.rst
@@ -42,7 +42,7 @@ Formatting
 
         // called as CakeTime
         App::uses('CakeTime', 'Utility');
-        echo CakeTime::convert(time(), new DataTimeZone('Asia/Jakarta'));
+        echo CakeTime::convert(time(), new DateTimeZone('Asia/Jakarta'));
 
     .. versionchanged:: 2.2
        ``$timezone`` parameter replaces ``$userOffset`` parameter used in 2.1 and below.
@@ -386,16 +386,16 @@ Testing Time
        ``$dateString`` parameter now also accepts a DateTime object.
 
     All of the above functions return true or false when passed a date
-    string. ``wasWithinLast`` takes an additional ``$time_interval``
+    string. ``wasWithinLast`` takes an additional ``$timeInterval``
     option::
 
         <?php
         // called via TimeHelper
-        $this->Time->wasWithinLast($time_interval, $dateString);
+        $this->Time->wasWithinLast($timeInterval, $dateString);
 
         // called as CakeTime
         App::uses('CakeTime', 'Utility');
-        CakeTime::wasWithinLast($time_interval, $dateString);
+        CakeTime::wasWithinLast($timeInterval, $dateString);
 
     ``wasWithinLast`` takes a time interval which is a string in the
     format "3 months" and accepts a time interval of seconds, minutes,

--- a/en/installation/advanced-installation.rst
+++ b/en/installation/advanced-installation.rst
@@ -154,7 +154,7 @@ httpd.conf rather than a user- or site-specific httpd.conf).
            RewriteRule ^(.*)$ index.php/$1 [QSA,L]
        </IfModule>
 
-   If your cakephp site still has problems with mod\_rewrite you might 
+   If your CakePHP site still has problems with mod\_rewrite you might 
    want to try and modify settings for virtualhosts. If on ubuntu, 
    edit the file /etc/apache2/sites-available/default (location is 
    distribution dependent). In this file, ensure that 

--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -71,7 +71,7 @@ than serving those assets without invoking PHP. And while the core team has
 taken steps to make plugin and theme asset serving as fast as possible, there
 may be situations where more performance is required. In these situations it's
 recommended that you either symlink or copy out plugin/theme assets to
-directories in ``app/webroot`` with paths matching those used by cakephp.
+directories in ``app/webroot`` with paths matching those used by CakePHP.
 
 
 -  ``app/Plugin/DebugKit/webroot/js/my_file.js`` becomes


### PR DESCRIPTION
- In a couple places the brandname was typed as "cakephp", changed them to "CakePHP".
- In a code example, fixing up the variable name to use the proper naming conventions
- Fixing a typo for the DateTimeZone object name
