### PR TITLE
Typos and Tweaks for ACL Tutorial

### DIFF
--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -373,19 +373,19 @@ a small modification to our ``AuthComponent`` configuration.
 ``AuthComponent`` needs to know about the existence of this root
 node, so that when making ACL checks it can use the correct node
 path when looking up controllers/actions. In ``AppController`` ensure
-that your ``$components`` array contains the ``actionPath`` defined earlier:
+that your ``$components`` array contains the ``actionPath`` defined earlier::
 
-<?php
+    <?php
     class AppController extends Controller {
-      public $components = array(
-        'Acl',
-        'Auth' => array(
-          'authorize' => array(
-            'Actions' => array('actionPath' => 'controllers')
-          )
-        ),
-        'Session'
-      );
+        public $components = array(
+            'Acl',
+            'Auth' => array(
+                'authorize' => array(
+                    'Actions' => array('actionPath' => 'controllers')
+                )
+            ),
+            'Session'
+        );
 
 Continue to :doc:`part-two` to continue the tutorial.
 


### PR DESCRIPTION
Corrected typo in last paragraph and added code sample "defined earlier" for clarity.
