### PR TITLE
Fix: variable name typo

### DIFF
--- a/en/core-utility-libraries/security.rst
+++ b/en/core-utility-libraries/security.rst
@@ -64,7 +64,7 @@ Security API
     :rtype: string
 
     Create a hash from string using given method. Fallback on next
-    available method. If ``$type`` is set to true, the applications salt
+    available method. If ``$salt`` is set to true, the applications salt
     value will be used.
 
     ::


### PR DESCRIPTION
Hi, I found a typo in English document : core-utility-libraries/security.rst
