### PR TITLE
Adding an example of saveAssociated with more than two levels deep association

### DIFF
--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -329,7 +329,8 @@ association, the data array should be like this::
         ),
     )
 
-And for saving a record along with its related records having hasMany with more than two levels deep associations, the data array should be as follow::
+And for saving a record along with its related records having hasMany with more than two
+levels deep associations, the data array should be as follow::
 
     <?php
     array(


### PR DESCRIPTION
Last night I've face some troubles on understanding how to format an array data with more than two levels deep association property for saveAssociated (with deep = true). After chatting with jose_zap at @cakephp IRC channel, I realized that would be useful to let it registered for other programmers.
