### PR TITLE
Adding missing '}' on the last line of UsersController.php

### DIFF
--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -127,6 +127,7 @@ with CakePHP::
             $this->Session->setFlash(__('User was not deleted'));
             $this->redirect(array('action' => 'index'));
         }
+    }
 
 In the same way we created the views for our blog posts or by using the code
 generation tool, we implement the views. For the purpose of this tutorial, we


### PR DESCRIPTION
I found error on UsersController.php when I tried to follow the tutorial [here](http://book.cakephp.org/2.0/en/tutorials-and-examples/blog-auth-example/auth.html).

```
Error: syntax error, unexpected $end, expecting T_FUNCTION
File: /home/william/Public/temp/blog/app/Controller/UsersController.php
Line: 69
```

Seems like it is missing a `}` on the last line of the file.
