### PR TITLE
Fix the method documentation for Shell::nl()

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -922,8 +922,10 @@ Shell API
     Loads tasks defined in public :php:attr:`Shell::$tasks`
 
 .. php:method:: nl($multiplier = 1)
-
-    Outputs a number of newlines.
+    
+    :param int $multiplier Number of times the linefeed sequence should be repeated
+    
+    Returns a number of linefeed sequences.
 
 .. php:method:: out($message = null, $newlines = 1, $level = Shell::NORMAL)
 


### PR DESCRIPTION
Shell::nl() returns instead of outputs newlines.
