### PR TITLE
Added $options parameter to beforeSave, otherwise cake triggers a "Strict"-warning

### DIFF
--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -154,7 +154,7 @@ AuthComponent will expect that your passwords are hashed.  In
     class User extends AppModel {
         // other code.
 
-        public function beforeSave() {
+        public function beforeSave($options = array()) {
             $this->data['User']['password'] = AuthComponent::password($this->data['User']['password']);
             return true;
         }


### PR DESCRIPTION
...e-acl-controlled-application.rst

Added $options = array() parameter to beforeSave Codesnippet, otherwise CakePHP complains with the following warning:
"Strict (2048): Declaration of User::beforeSave() should be compatible with Model::beforeSave($options = Array) [ROOT/Model/User.php, line 112]"
