### PR TITLE
add `url` option to JsHelper::submit()

### DIFF
--- a/en/core-libraries/helpers/js.rst
+++ b/en/core-libraries/helpers/js.rst
@@ -654,6 +654,7 @@ CakePHP core. Whenever you see separate lists for ``Options`` and
 
     **Options**
 
+    - ``url`` - The url you wish the XHR request to submit to.
     -  ``confirm`` - Confirm message displayed before sending the
        request. Using confirm, does not replace any ``before`` callback
        methods in the generated XmlHttpRequest.


### PR DESCRIPTION
It's not clear without reading the source (comments) how to specify a submit-URL.
