### PR TITLE
Fixing a typo.

### DIFF
--- a/en/models/associations-linking-models-together.rst
+++ b/en/models/associations-linking-models-together.rst
@@ -77,7 +77,7 @@ appropriate to have::
         );
         public $hasAndBelongsToMany => array(
             'Member' => array(
-                'className' => 'User',
+                'className' => 'Group',
             )
         );
     }
@@ -91,7 +91,7 @@ appropriate to have::
         );
         public $hasAndBelongsToMany => array(
             'MemberOf' => array(
-                'className' => 'Group',
+                'className' => 'User',
             )
         );
     }


### PR DESCRIPTION
Fixing a typo so the models are referring to the correct models (as explained in the sentence following the code sample).
