### PR TITLE
Update en/controllers/request-response.rst

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -96,7 +96,7 @@ that contains a ``data`` prefix, will have that data prefix removed.  For exampl
 
     <?php
     // An input with a name attribute equal to 'data[Post][title]' is accessible at
-    $this->request->data['Post']['title'];
+    $this->request->data['MyModel']['title'];
 
 You can either directly access the data property, or you can use
 :php:meth:`CakeRequest::data()` to read the data array in an error free manner.


### PR DESCRIPTION
It's confusing to have the model 'Post' in instructions about how to receive "POST data".  It may make the user think they need ['Post'] to retrieve the POST data instead of the model itself.
