### PR TITLE
Case insensitive routes example

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -249,6 +249,16 @@ in your controller.  For example, to map all urls to actions of the
     <?php
     Router::connect('/:action', array('controller' => 'home'));
 
+If you would like to provide a case insensitive url, you can use regular 
+expression inline modifiers::
+
+    <?php
+    Router::connect(
+        '/:userShortcut', 
+        array('controller' => 'teachers', 'action' => 'profile', 1),
+        array('userShortcut' => '(?i:principal)')
+    );
+
 One more example, and you'll be a routing pro::
 
     <?php


### PR DESCRIPTION
This topic was killing me for a long while, since the way to create 
a case insensitive URL was well documented on 1.2 but there is no 
reference in 2.0 other than using regular expressions, but I was 
not aware of how to use inline modifiers for this. The example was
provided in Stackoverflow recently: http://stackoverflow.com/questions/12526099/cakephp-routing-in-php-too
