### PR TITLE
Adding opensearch declaration XML, so browsers will offer Cake Book search in their search box

### DIFF
--- a/themes/cakephp/layout.html
+++ b/themes/cakephp/layout.html
@@ -5,6 +5,7 @@
 
 {% block extrahead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="search" type="application/opensearchdescription+xml" title="CakePHP Book 2.x Search" href="_static/opensearchdescription-book-2-x.xml">
 <script type="text/javascript">
 window.lang = "{{ language }}";
 </script>

--- a/themes/cakephp/static/opensearchdescription-book-2-x.xml
+++ b/themes/cakephp/static/opensearchdescription-book-2-x.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>CakePHP Book 2.x</ShortName>
+  <Description>The CakePHP cookbook, is an openly developed community editable documentation project.</Description>
+	<Image height="16" width="16" type="image/x-icon">http://book.cakephp.org/favicon.ico</Image>  
+  
+  <Url type="text/html"
+       method="get"
+       template="http://book.cakephp.org/2.0/en/search.html?q={searchTerms}&amp;check_keywords=yes&amp;area=default">
+  </Url>
+  <OutputEncoding>UTF-8</OutputEncoding>
+  <InputEncoding>UTF-8</InputEncoding>
+</OpenSearchDescription>


### PR DESCRIPTION
See
https://developer.mozilla.org/en-US/docs/Creating_OpenSearch_plugins_for_Firefox
and the test
https://addons.mozilla.org/de/firefox/addon/cakephp-book-2x/
