### PR TITLE
Document TimeHelper::nice takes $format as param 

### DIFF
--- a/en/core-utility-libraries/time.rst
+++ b/en/core-utility-libraries/time.rst
@@ -182,12 +182,12 @@ Formatting
     .. versionchanged:: 2.2
        ``$timezone`` parameter replaces ``$userOffset`` parameter used in 2.1 and below.
 
-.. php:method:: nice($dateString = NULL, $timezone = NULL)
+.. php:method:: nice($dateString = NULL, $timezone = NULL, $format = null)
 
     :rtype: string
 
     Takes a date string and outputs it in the format "Tue, Jan
-    1st 2008, 19:25"::
+    1st 2008, 19:25" or as per optional ``$format`` param passed::
 
         <?php
         // called via TimeHelper


### PR DESCRIPTION
As per the [TimeHelper::nice source code](https://github.com/cakephp/cakephp/blob/master/lib/Cake/Utility/CakeTime.php#L349), it can take $format as param. 

So Documented that in the [book](http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::nice)
