### PR TITLE
Fixing pagination examples using 'dir' and not 'direction'

### DIFF
--- a/en/core-libraries/helpers/paginator.rst
+++ b/en/core-libraries/helpers/paginator.rst
@@ -37,21 +37,21 @@ Assuming you are paginating some posts, and are on page one::
     <?php
     echo $this->Paginator->sort('user_id');
     // creates
-    <a href="/posts/index/page:1/sort:user_id/dir:asc/">User Id</a>
+    <a href="/posts/index/page:1/sort:user_id/direction:asc/">User Id</a>
 
 You can use the title parameter to create custom text for your link::
 
     <?php
     echo $this->Paginator->sort('user_id', 'User account');
     // creates
-    <a href="/posts/index/page:1/sort:user_id/dir:asc/">User account</a>
+    <a href="/posts/index/page:1/sort:user_id/direction:asc/">User account</a>
 
 If you are using HTML like images in your links remember to set escaping off::
 
     <?php
     echo $this->Paginator->sort('user_id', '<em>User account</em>', array('escape' => false));
     // creates
-    <a href="/posts/index/page:1/sort:user_id/dir:asc/"><em>User account</em></a>
+    <a href="/posts/index/page:1/sort:user_id/direction:asc/"><em>User account</em></a>
 
 The direction option can be used to set the default direction for a link.  Once a
 link is active, it will automatically switch directions like normal::
@@ -59,7 +59,7 @@ link is active, it will automatically switch directions like normal::
     <?php
     echo $this->Paginator->sort('user_id', null, array('direction' => 'desc'));
     // creates
-    <a href="/posts/index/page:1/sort:user_id/dir:desc/">User Id</a>
+    <a href="/posts/index/page:1/sort:user_id/direction:desc/">User Id</a>
 
 .. php:method:: sortDir(string $model = null, mixed $options = array())
 

--- a/fr/core-libraries/helpers/paginator.rst
+++ b/fr/core-libraries/helpers/paginator.rst
@@ -40,7 +40,7 @@ En considérant que vous paginez des posts, qu'ils sont sur la page un::
     <?php
     echo $this->Paginator->sort('id_utilisateur');
     // créé
-    <a href="/posts/index/page:1/sort:id_utilisateur/dir:asc/">User Id</a>
+    <a href="/posts/index/page:1/sort:id_utilisateur/direction:asc/">User Id</a>
 
 Vous pouvez utiliser le paramètre titre pour créer des textes personnalisés 
 pour votre lien::
@@ -48,7 +48,7 @@ pour votre lien::
     <?php
     echo $this->Paginator->sort('id_utilisateur', 'Compte utilisateur');
     // creates
-    <a href="/posts/index/page:1/sort:id_utilisateur/dir:asc/">Compte utilisateur</a>
+    <a href="/posts/index/page:1/sort:id_utilisateur/direction:asc/">Compte utilisateur</a>
 
 Si vous utilisez du html comme des images dans vos liens rappelez-vous de 
 paramétrer l'échappement à off::
@@ -56,7 +56,7 @@ paramétrer l'échappement à off::
     <?php
     echo $this->Paginator->sort('id_utilisateur', '<em>Compte utilisateur</em>', array('escape' => false));
     // creates
-    <a href="/posts/index/page:1/sort:id_utilisateur/dir:asc/"><em>Compte utilisateur</em></a>
+    <a href="/posts/index/page:1/sort:id_utilisateur/direction:asc/"><em>Compte utilisateur</em></a>
 
 L'option de direction peut être utilisés pour paramétrer la direction par 
 défaut pour un lien. Une fois qu'un lien est activé, il changera 
@@ -65,7 +65,7 @@ automatiquement de direction comme normalement::
     <?php
     echo $this->Paginator->sort('id_utilisateur', null, array('direction' => 'desc'));
     // créé
-    <a href="/posts/index/page:1/sort:id_utilisateur/dir:desc/">Id Utilisateur</a>
+    <a href="/posts/index/page:1/sort:id_utilisateur/direction:desc/">Id Utilisateur</a>
 
 .. php:method:: sortDir(string $model = null, mixed $options = array())
 


### PR DESCRIPTION
As seen in the whitelist, the key is "direction" and not "dir":
https://github.com/cakephp/cakephp/blob/master/lib/Cake/Controller/Component/PaginatorComponent.php#L86
