### PR TITLE
Model::_findFirst() returns an empty array when no rows are found.

### DIFF
--- a/en/appendices/2-2-migration-guide.rst
+++ b/en/appendices/2-2-migration-guide.rst
@@ -58,13 +58,14 @@ I18N extract shell
 Models
 ======
 
-- ``Model::_findCount()`` will now call the custom find methods with
+- ``Model::find('count')`` will now call the custom find methods with
   ``$state = 'before'`` and ``$queryData['operation'] = 'count'``.
   In many cases custom finds already return correct counts for pagination,
   but ``'operation'`` key allows more flexibility to build other queries,
   or drop joins which are required for the custom finder itself.
   As the pagination of custom find methods never worked quite well it required
-  workarounds for this in the model level, which are now no longer needed
+  workarounds for this in the model level, which are now no longer needed.
+- ``Model::find('first')`` will now return an empty array when no records are found.
 
 Datasources
 ===========

--- a/en/appendices/2-3-migration-guide.rst
+++ b/en/appendices/2-3-migration-guide.rst
@@ -101,12 +101,13 @@ Model
 - Support for ``FULLTEXT`` indexes was added for the MySQL driver.
 
 
-Model
+Models
 -----
 
 - ``Model::find('list')`` now sets the ``recursive`` based on the max
   containment depth or recursive value.  When list is used with
   ContainableBehavior.
+- ``Model::find('first')`` will now return an empty array when no records are found.
 
 Validation
 ----------


### PR DESCRIPTION
From https://github.com/cakephp/cakephp/pull/917#issuecomment-10057948
