### PR TITLE
Update en/tutorials-and-examples/blog/blog.rst

### DIFF
--- a/en/tutorials-and-examples/blog/blog.rst
+++ b/en/tutorials-and-examples/blog/blog.rst
@@ -73,6 +73,7 @@ statements into your database::
     /* First, create our posts table: */
     CREATE TABLE posts (
         id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        user_id INT (10),
         title VARCHAR(50),
         body TEXT,
         created DATETIME DEFAULT NULL,


### PR DESCRIPTION
While using the tutorial to create a blog, it set-up the database table and inserted posts.  However, later on when you need to edit/delete the post, I received and issue stating there was no 'user_id' column in the 'posts' table.  By adding the 'user_id' column, it fixed this issue and is fully functional again.
