### PR TITLE
SaveField params options

### DIFF
--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -190,6 +190,17 @@ For example, to update the title of a blog post, the call to
     You can't stop the updated field being updated with this method, you
     need to use the save() method.
 
+The saveField method also has an alternate syntax::
+
+    saveField(string $fieldName, string $fieldValue, array $params = array())
+
+``$params`` array can have any of the following available options
+as keys:
+
+* ``validate`` Set to true/false to enable disable validation.
+* ``callbacks`` Set to false to disable callbacks.  Using 'before' or 'after'
+  will enable only those callbacks.
+
 :php:meth:`Model::updateAll(array $fields, array $conditions)`
 ==============================================================
 


### PR DESCRIPTION
The actual saveField method supports a $params array, which isn't show in the documentation.
The 2.0 code shows that FieldList isn't supported for saveField, thus it was removed from the options.
