### PR TITLE
Update en/appendices/glossary.rst

### DIFF
--- a/en/appendices/glossary.rst
+++ b/en/appendices/glossary.rst
@@ -13,10 +13,10 @@ Glossary
         An array of key => values that are composed into html attributes. For example::
             
             // Given
-            array('class' => 'my-class', '_target' => 'blank')
+            array('class' => 'my-class', 'target' => '_blank')
 
             // Would generate
-            class="my-class" _target="blank"
+            class="my-class" target="_blank"
 
         If an option can be minimized or accepts it's name as the value, then ``true`` 
         can be used::


### PR DESCRIPTION
fixed wrong '_target' => 'blank' to 'target' => '_blank'
