### PR TITLE
Update AppHelper path in CakePHP 2.0 migration guide

### DIFF
--- a/en/appendices/2-0-migration-guide.rst
+++ b/en/appendices/2-0-migration-guide.rst
@@ -99,7 +99,7 @@ AppController / AppModel / AppHelper / AppShell
 ===============================================
 
 The ``app/app_controller.php``, ``app/app_model.php``, ``app/app_helper.php`` are now located and 
-named as ``app/Controller/AppController.php``, ``app/Model/AppModel.php`` and ``app/Helper/AppHelper.php`` respectively.
+named as ``app/Controller/AppController.php``, ``app/Model/AppModel.php`` and ``app/View/Helper/AppHelper.php`` respectively.
 
 Also all shell/task now extend AppShell. You can have your custom AppShell.php at ``app/Console/Command/AppShell.php``
 

--- a/fr/appendices/2-0-migration-guide.rst
+++ b/fr/appendices/2-0-migration-guide.rst
@@ -115,7 +115,7 @@ AppController / AppModel / AppHelper / AppShell
 Les fichiers ``app/app_controller.php``, ``app/app_model.php``, 
 ``app/app_helper.php`` sont situés et nommés respectivement comme ceci 
 ``app/Controller/AppController.php``, ``app/Model/AppModel.php`` et 
-``app/Helper/AppHelper.php``.
+``app/View/Helper/AppHelper.php``.
 
 Aussi, les shell/task sont étendus (extend) Appshell. Vous pouvez avoir votre 
 propre AppShell.php dans ``app/Console/Command/AppShell.php``.

--- a/ja/appendices/2-0-migration-guide.rst
+++ b/ja/appendices/2-0-migration-guide.rst
@@ -86,7 +86,7 @@ AppController / AppModel / AppHelper / AppShell
 ===============================================
 
 ``app/app_controller.php`` 、 ``app/app_model.php`` 、 ``app/app_helper.php`` はそれぞれ、
-``app/Controller/AppController.php`` 、 ``app/Model/AppModel.php`` 、 ``app/Helper/AppHelper.php`` に配置・名称変更されました。
+``app/Controller/AppController.php`` 、 ``app/Model/AppModel.php`` 、 ``app/View/Helper/AppHelper.php`` に配置・名称変更されました。
 
 また、全てのシェル・タスクはAppShellを継承するようになりました。
 独自のAppShell.phpを ``app/Console/Command/AppShell.php`` にもつことができます。


### PR DESCRIPTION
Replaced for 3 languages.
