### PR TITLE
Allow all actions for controller in the 'Simple Acl controller Application' tutorial

### DIFF
--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -199,7 +199,12 @@ and users. In **both** your ``GroupsController`` and your
 
     public function beforeFilter() {
         parent::beforeFilter();
+
+        // For CakePHP 2.0
         $this->Auth->allow('*');
+
+        // For CakePHP 2.1 and up
+        $this->Auth->allow();
     }
 
 These statements tell AuthComponent to allow public access to all


### PR DESCRIPTION
When trying out the 'Simple Acl controller Application' tutorial I found the line `$this->Auth->allow('*');` wasn't working for the version I was working with (2.3).
When looking through the Authentication documentation I found `$this->Auth->allow();` does work.
