### PR TITLE
Update documentation for Security::cipher method to be less confusing

### DIFF
--- a/en/core-utility-libraries/security.rst
+++ b/en/core-utility-libraries/security.rst
@@ -16,10 +16,10 @@ Security API
 
     Encrypts/Decrypts a text using the given key.::
 
-        // Encrypt your secret password with my_key
-        $secret = Security::cipher('my secret password', 'my_key');
+        // Encrypt your text with my_key
+        $secret = Security::cipher('hello world', 'my_key');
 
-        // Later decrypt your secret password
+        // Later decrypt your text
         $nosecret = Security::cipher($secret, 'my_key');
 
     ``cipher()`` uses a **weak** XOR cipher and should **not** be used for


### PR DESCRIPTION
The example for Security::cipher should not show encrypting and decrypting a password when it then goes on to say that this method should not be used for important data
