### PR TITLE
Updated Cache::read example

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -187,7 +187,7 @@ A method that uses Cache to store results could look like::
     class Post extends AppModel {
 
         public function newest() {
-            $result = Cache::read('newest_posts', 'longterm');
+            $result = Cache::read('newest_posts');
             if (!$result) {
                 $result = $this->find('all', array('order' => 'Post.updated DESC', 'limit' => 10));
                 Cache::write('newest_posts', $result, 'longterm');


### PR DESCRIPTION
The 'Using Cache to store common query results' example had an improper use of Cache::read, which caused some issues with users.

$result = Cache::read('newest_posts', 'longterm');
updated to:
$result = Cache::read('newest_posts'); 
