### PR TITLE
Added App::uses() and an explanation to the model defintion example

### DIFF
--- a/en/models.rst
+++ b/en/models.rst
@@ -44,7 +44,7 @@ Model class by the magic of inheritance. The Ingredient model
 extends the application model, AppModel, which extends CakePHP's
 internal Model class. It is this core Model class that bestows the
 functionality onto your Ingredient model. ``App::uses('AppModel', 'Model')``
-ensures that the model is lazy loaded in every instance of the controller.
+ensures that the model is lazy loaded in every instance of its usage.
 
 This intermediate class, AppModel, is empty and if you haven't
 created your own, is taken from within the CakePHP core folder. Overriding


### PR DESCRIPTION
Added App::uses() to the code block and a brief explanation in order to avoid confusion with CakePHP's lazy loading, such as in the case where someone tries to make a static call and a normal class call has not yet been made.  This can occur whenever someone is creating a model from scratch and is using this doc for reference, and didn't use the Bake console to generate their model.  -- beakman on freenode
