### PR TITLE
cleanup and replace should with can

### DIFF
--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -42,7 +42,6 @@ CakePHP core library. As such, AppController is defined in
 
     class AppController extends Controller {
     }
-    
 
 Controller attributes and methods created in your AppController
 will be available to all of your application's controllers. It is
@@ -76,7 +75,7 @@ controller callbacks for best results::
     public function beforeFilter() {
         parent::beforeFilter();
     }
- 
+
 Request parameters
 ==================
 
@@ -102,16 +101,16 @@ name.  Returning to our online bakery example, our RecipesController might conta
 in ``/app/Controller/RecipesController.php`` and contain::
 
         # /app/Controller/RecipesController.php
-        
+
         class RecipesController extends AppController {
             public function view($id) {
                 //action logic goes here..
             }
-        
+
             public function share($customerId, $recipeId) {
                 //action logic goes here..
             }
-        
+
             public function search($query) {
                 //action logic goes here..
             }
@@ -131,7 +130,7 @@ rendering and delivering the View.
 If for some reason you'd like to skip the default behavior.  Both of the
 following techniques will by-pass the default view rendering behavior.
 
-* If you return a string, or an object that can be converted to a string from 
+* If you return a string, or an object that can be converted to a string from
   your controller action, it will be used as the response body.
 * You can return a :php:class:`CakeResponse` object with the completely created
   response.
@@ -244,10 +243,10 @@ rendered from the controller.
             'base_price' => 23.95
         );
 
-        // make $color, $type, and $base_price 
+        // make $color, $type, and $base_price
         // available to the view:
 
-        $this->set($data);  
+        $this->set($data);
 
 
     The attribute ``$pageTitle`` no longer exists, use ``set()`` to set
@@ -494,7 +493,7 @@ Other Useful Methods
         $conditions = $this->postConditions(
             $this->request->data,
             array(
-                'num_items' => '>=', 
+                'num_items' => '>=',
                 'referrer' => 'LIKE'
             )
         );
@@ -600,7 +599,7 @@ Other Useful Methods
     named args array into the key 'named'; Additional members in the ``$option``
     array will also be made available in the requested action's
     Controller::params array::
-        
+
         echo $this->requestAction('/articles/featured/limit:3');
         echo $this->requestAction('/articles/view/5');
 
@@ -633,7 +632,7 @@ Other Useful Methods
     The ``loadModel`` function comes handy when you need to use a model
     which is not the controller's default model or its associated
     model::
-    
+
         $this->loadModel('Article');
         $recentArticles = $this->Article->find('all', array('limit' => 5, 'order' => 'Article.created DESC'));
 
@@ -652,14 +651,14 @@ visit the CakePHP API. Check out
 
     The ``$name`` attribute should be set to the
     name of the controller. Usually this is just the plural form of the
-    primary model the controller uses. This property is not required,
+    primary model the controller uses. This property can be omitted,
     but saves CakePHP from inflecting it::
 
         // $name controller attribute usage example
         class RecipesController extends AppController {
            public $name = 'Recipes';
         }
-        
+
 
 $components, $helpers and $uses
 -------------------------------
@@ -722,7 +721,7 @@ given by ``$helpers`` to the view as an object reference variable
 .. php:attr:: components
 
     The components array allows you to set which :doc:`/controllers/components`
-    a controller will use.  Like ``$helpers`` and ``$uses`` components in your 
+    a controller will use.  Like ``$helpers`` and ``$uses`` components in your
     controllers are merged with those in ``AppController``.  As with
     ``$helpers`` you can pass settings into components.  See :ref:`configuring-components`
     for more information.

--- a/en/models/model-attributes.rst
+++ b/en/models/model-attributes.rst
@@ -78,7 +78,7 @@ Example usage::
     class Example extends AppModel {
         public $primaryKey = 'example_id'; // example_id is the field name in the database
     }
-    
+
 
 .. _model-displayField:
 
@@ -166,11 +166,11 @@ Example Usage::
 
     public $_schema = array(
         'first_name' => array(
-            'type' => 'string', 
+            'type' => 'string',
             'length' => 30
         ),
         'last_name' => array(
-            'type' => 'string', 
+            'type' => 'string',
             'length' => 30
         ),
         'email' => array(


### PR DESCRIPTION
"This property can be omitted" is more accurate since inflecting it is really cheap and usually the way to go here.
Setting the attribute has caused more harm as it can easily be misspelled and is only additional redundancy that is not necessary here (anymore).

But maybe we could just refactor that whole sentence? Ideas?
