### PR TITLE
Replace reference to EmailComponent in examples

### DIFF
--- a/en/appendices/2-0-migration-guide.rst
+++ b/en/appendices/2-0-migration-guide.rst
@@ -442,9 +442,9 @@ Some examples on using :php:meth:`App::uses()` when migrating from
     // becomes 
     App::uses('PagesController', 'Controller');
 
-    App::import('Component', 'Email');
+    App::import('Component', 'Auth');
     // becomes 
-    App::uses('EmailComponent', 'Controller/Component');
+    App::uses('AuthComponent', 'Controller/Component');
 
     App::import('View', 'Media');
     // becomes 


### PR DESCRIPTION
Probably shouldn't be citing it as an example if it's deprecated.  I assume AuthComponent is interchangeable for the example's sake.
