### PR TITLE
Added sanity check regarding i18n behavior when setting the Config.language property

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -149,7 +149,9 @@ should configure ``Configure`` as well::
 
     class AppController extends Controller {
         public function beforeFilter() {
-            Configure::write('Config.language', $this->Session->read('Config.language'));
+            if ($this->Session->check('Config.language')) {
+                Configure::write('Config.language', $this->Session->read('Config.language'));
+            }
         }
     }
 


### PR DESCRIPTION
$this->Session->read('Config.language) returns null when the property
doesn't exist in the Session object, and so sets the Config.language
property to null, overriding the default setting that was set by the
bootstrap file, as suggested in the previous paragraph.

Adding this simple sanity check ensures that no change is made to the
property if no locale information exists in the Session object.
