### PR TITLE
Fixed typo on Dispatcher.filters key name in docs

### DIFF
--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -21,7 +21,7 @@ Configuring Filters
 Filters are usually configured in the ``bootstrap.php`` file, but you could easily
 load them from any other configuration file before the request is dispatched.
 Adding and removing filters is done through the `Configure` class, using the
-special key ``Dispatch.filters``. By default CakePHP comes with a couple filter
+special key ``Dispatcher.filters``. By default CakePHP comes with a couple filter
 classes already enabled for all requests, let's take a look at how they are
 added::
 


### PR DESCRIPTION
In the Configuring Filters section of the docs:
http://book.cakephp.org/2.0/en/development/dispatch-filters.html#configuring-filters

There was a typo in the paragraph above the code. 

The code is fine.

Here is the typo correction.
