### PR TITLE
Provided another example when the $route supplied uses default routing

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -819,7 +819,7 @@ a destination within your application or an outside location::
     Router::redirect(
         '/home/*',
         array('controller' => 'posts', 'action' => 'view'),
-        array('persist' => true)
+        array('persist' => true) // or array('persist'=>array('id')) for default routing where the view action expects $id as an argument
     );
 
 Redirects ``/home/*`` to ``/posts/view`` and passes the parameters to


### PR DESCRIPTION
Showed errors when I used array('persist'=>true) in redirecting '/home/myPosts/1' to '/posts/view/1'

Invalid argument supplied for foreach() in [.../lib/Cake/Routing/Route/CakeRoute.php, line 380]
