### PR TITLE
Update data-validation.rst

### DIFF
--- a/en/models/data-validation.rst
+++ b/en/models/data-validation.rst
@@ -299,6 +299,11 @@ identified with an arbitrary name.
 When using multiple rules per field the 'required' and 'allowEmpty'
 keys need to be used only once in the first rule.
 
+.. tip::
+
+    When using multiple rules per field, listing rules that use the default value for 'required' or 'allowEmpty' before
+    rules that do not only helps avoid unintended validation, but can also reduce validation code by up to 50%
+
 last
 -------
 


### PR DESCRIPTION
Added a new Tip to the 'Using Multiple Validation Rules' section.  This tip emphasizes the critical importance of knowing that the default values for 'allowEmpty' and 'required' are dependent upon the previous validation rules for the field.  There is short sentence above the new Tip regarding the default value dependency. I feel strongly that this short sentence should stay there in additional to the new Tip and that the two complement each other very well and only give a better understanding of this subtle, but critical to be aware of, feature.

Additionally, the new Tip points out a way to not only help avoid serious validation consequences if the field rules are changed without regard for the dependent default values, but it also provide an optimization. By listing rules that use default values first, those default values may be excluded from the rule as oppose to listing them later and having to toggle the value back explicitly.
