### PR TITLE
Update to create() description in saving-your-data.rst

### DIFF
--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -153,18 +153,13 @@ your are passing the primary key field into the data array::
 
 This method resets the model state for saving new information.
 It does not actually create a record in the database but clears
-Model::$id if previously set and sets the default values in
-Model::$data based on your database field defaults.
+Model::$id and sets Model::$data based on your database field defaults. If you have
+not defined defaults for your database fields, Model::$data will be set to an empty array.
 
-If the ``$data`` parameter (using the array format outlined above)
-is passed, the model instance will be ready to save with that data
-(accessible at ``$this->data``).
+If the ``$data`` parameter (using the array format outlined above) is passed, it will be merged with the database 
+field defaults and the model instance will be ready to save with that data (accessible at ``$this->data``).
 
-If ``false`` is passed instead of an array, the model instance will
-not initialize fields from the model schema that are not already
-set, it will only reset fields that have already been set, and
-leave the rest unset. Use this to avoid updating fields in the
-database that were already set.
+If ``false`` or ``null`` are passed for the ``$data`` parameter, Model::data will be set to an empty array. 
 
 .. tip::
 


### PR DESCRIPTION
The wording of the description for `create()` was very vague, misleading, complicated to understand.  The 2.3 API description of `create()` is much better, but still a bit lacking.  After tracing through the code to discover just what `create()` actually does, when it does it, and then doing some tests of my own, I've written some changes to the description which more accurately and effectively communicate the true functionality.

1.) The previous description strongly hinted that `create()` actually had no effect on fields that **_"have already been set"**_ prior to calling `create()` and only upon fields which **_"have already been set"**_, which is not the case. Any data that is set prior to calling `create()` is actually overwritten completely.  I've updated this description to accurately describe the true effect upon `Model::$data`.

2.) I've added the fact that `null` may also be passed as the `$data` param, not just `false`.  This was in the API but not yet added here in the docs.

3.) I've added clarity to what happens when there are no database defaults AND no parameters passed for `$data`. In this case, `Model::$data` is set to an empty array.

4.) I've added clarity to what happens when `false` or `null` are passed for `$data`, regardless of there being any database defaults. In this case, `Model::$data` is set to an empty array.
