### PR TITLE
Added admonition for default validation failure message

### DIFF
--- a/en/models/data-validation.rst
+++ b/en/models/data-validation.rst
@@ -246,6 +246,10 @@ message for the rule::
         )
     );
 
+.. note::
+
+    Regardless of the rule, validation failure without a defined message defaults to "This field cannot be left blank."
+
 Multiple Rules per Field
 ========================
 


### PR DESCRIPTION
Adding an admonition to the 'message' section as ceeram suggested in reference to pull request #1363.
