### PR TITLE
Added proper asset exclusion for production

### DIFF
--- a/en/installation/url-rewriting.rst
+++ b/en/installation/url-rewriting.rst
@@ -125,6 +125,26 @@ httpd.conf rather than a user- or site-specific httpd.conf).
    The details of those changes will depend on your setup, and can
    include additional things that are not Cake related. Please refer
    to Apache's online documentation for more information.
+   
+#. (Optional) To improve production setup, you should prevent invalid assets
+   from being parsed by CakePHP. Modify your webroot .htaccess to something like::
+
+       <IfModule mod_rewrite.c>
+           RewriteEngine On
+           RewriteBase /path/to/cake/app
+           RewriteCond %{REQUEST_FILENAME} !-d
+           RewriteCond %{REQUEST_FILENAME} !-f
+           RewriteCond %{REQUEST_URI} !^/(app/webroot/)?(img|css|js)/(.*)$
+           RewriteRule ^(.*)$ index.php [QSA,L]
+       </IfModule>
+       
+   The above will simply prevent incorrect assets from being sent to index.php
+   and instead display your webserver's 404 page.
+   
+   Additionally you can create a matching HTML 404 page, or use the default 
+   built-in CakePHP 404 by adding an ``ErrorDocument`` directive::
+       
+       ErrorDocument 404 /404-not-found
 
 Pretty URLs on nginx
 ====================


### PR DESCRIPTION
Assets currently are parsed by the controller, when they should simply be ignored and sent to a webserver 404 when in a production environment.

A 404 ErrorDocument is added so that bad assets are sent to a cakePHP 404 page or could be modified to load a 'static' page

This removes bad assets from the Controller logic and prevents overloading the server when improper asset requests are made
