### PR TITLE
note about private visibility

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -292,7 +292,7 @@ Private methods or variable names start with double underscore ("\_\_"). Example
 
 Try to avoid private methods or variables, though, in favor of protected ones.
 The latter can be accessed or modified by subclasses, whereas private ones
-prevent extension or re-use.
+prevent extension or re-use. Private visibility also makes testing much more difficult.
 
 Method Chaining
 ---------------


### PR DESCRIPTION
protected should be used instead of private in a framework context.
