### PR TITLE
Corrected some grammar in Time helper docs

### DIFF
--- a/en/core-libraries/helpers/time.rst
+++ b/en/core-libraries/helpers/time.rst
@@ -11,10 +11,10 @@ Time Helper has two main tasks that it can perform:
 #. It can test time (but cannot bend time, sorry).
 
 .. versionchanged:: 2.1
-   ``TimeHelper`` have been refactored into :php:class:`CakeTime` class to allow
+   ``TimeHelper`` have been refactored into the :php:class:`CakeTime` class to allow
    easier use outside of the ``View`` layer.
    Within a view, these methods are accessible via the `TimeHelper`
-   class and you can called it as you would call a normal helper method:
+   class and you can call it as you would call a normal helper method:
    ``$this->Time->method($args);``.
 
 Using the Helper


### PR DESCRIPTION
Added 'the' before a reference to a class.  Corrected past-tense 'called' to 'call'.
