### PR TITLE
add tip to datasources.rst

### DIFF
--- a/en/models/datasources.rst
+++ b/en/models/datasources.rst
@@ -255,8 +255,8 @@ We can retrieve data from our remote source using the familiar model methods::
 
 .. tip::
 
-    Using find types other than `'all'` can have unexpected results if the 
-    result of your `read` method is not a numerically indexed array.
+    Using find types other than ``'all'`` can have unexpected results if the 
+    result of your ``read`` method is not a numerically indexed array.
 
 Similarly we can save a new message::
 


### PR DESCRIPTION
Ran into this problem when coding a datasource to talk to a JSON API.  Especially because the example is for an API, it could be helpful to mention that find('first') (which is what I used out of habit) won't work-- you must use find('all').
