### PR TITLE
deprecate read() in favor of find()

### DIFF
--- a/en/models/retrieving-your-data.rst
+++ b/en/models/retrieving-your-data.rst
@@ -801,6 +801,9 @@ field.
     ``beforeSave``. Generally the ``find`` function provides a more robust and easy to work
     with API than the ``read`` method.
 
+    Also note, that in future versions this method will be deprecated and removed in favor of
+    the mentioned ``find`` function.
+
 Complex Find Conditions
 =======================
 


### PR DESCRIPTION
We should probably also add

```
@deprecated Will be removed in 3.0. Use find() instead.
```

To https://github.com/cakephp/cakephp/blob/2.5/lib/Cake/Model/Model.php#L1579

or any upcoming 2.x branch (2.4/2.5) in general.

This helps to avoid new apps being developed with a method that we know will already be removed.
