### PR TITLE
Added opening php tag to db configuration written by jenkins

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1203,6 +1203,7 @@ database in a database server that jenkins can access (usually localhost).  Add
 a *shell script step* to the build that contains the following::
 
     cat > app/Config/database.php <<'DATABASE_PHP'
+    <?php
     class DATABASE_CONFIG {
         public $test = array(
             'datasource' => 'Database/Mysql',


### PR DESCRIPTION
Without the opening php tag cakephp was unable to find the db configuration of connection "test".
