### PR TITLE
Fix spelling/grammar in paragraph 3 of Dispatching Events in Events System docs

### DIFF
--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -92,7 +92,7 @@ do it. So we need another solution, let's rewrite that using the event manager::
         }
     }
 
-That looks a lot cleaner, at gives us the opportunity to introduce the event
+That looks a lot cleaner, as it gives us the opportunity to introduce the event
 classes and methods. The first thing you may notice is the call to ``getEventManager()``
 this is a method that is available by default in all Models, Controller and Views.
 This method will not return the same manager instance across models, and it is not


### PR DESCRIPTION
Small fix to the spelling/grammar in the 3rd paragraph of the dispatching events section just after the 2nd code example
