### PR TITLE
Small grammar fix to Events System docs

### DIFF
--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -93,8 +93,8 @@ do it. So we need another solution, let's rewrite that using the event manager::
     }
 
 That looks a lot cleaner, as it gives us the opportunity to introduce the event
-classes and methods. The first thing you may notice is the call to ``getEventManager()``
-this is a method that is available by default in all Models, Controller and Views.
+classes and methods. The first thing you may notice is the call to ``getEventManager()``,
+this is a method that is available by default in all Models, Controllers and Views.
 This method will not return the same manager instance across models, and it is not
 shared between controllers and models, but they are between controllers and views,
 nevertheless. We will review later how to overcome this implementation detail.


### PR DESCRIPTION
Minor grammar update to the 3rd para of the Dispatching events section after the 2nd code example.
