### PR TITLE
Added a few readability and consistency edits to sessions

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -4,15 +4,14 @@ Sessions
 CakePHP provides a wrapper and suite of utility features on top of PHP's native
 ``session`` extension.  Sessions allow you to identify unique users across the
 requests and store persistent data for specific users. Unlike Cookies, session
-data is not available on the client side.  Usage of the ``$_SESSION`` is generally
+data is not available on the client side.  Usage of ``$_SESSION`` is generally
 avoided in CakePHP, and instead usage of the Session classes is preferred.
 
 
 Session Configuration
 =====================
 
-Session configuration is stored in ``Configure``, and the session classes will
-retrieve it from there as needed. Session configuration is stored under the top
+Session configuration is stored in ``Configure`` under the top
 level ``Session`` key, and a number of options are available:
 
 * ``Session.cookie`` - Change the name of the session cookie.
@@ -25,10 +24,10 @@ level ``Session`` key, and a number of options are available:
   This affects the session cookie, and is handled by PHP itself.
 
 * ``Session.checkAgent`` - Should the user agent be checked, on each request.  If
-  the useragent does not match the session will be destroyed.
+  the user agent does not match the session will be destroyed.
 
 * ``Session.autoRegenerate`` - Enabling this setting, turns on automatic
-  renewal of sessions, and sessionids that change frequently. Enabling this
+  renewal of sessions, and session ids that change frequently. Enabling this
   value will use the session's ``Config.countdown`` value to keep track of requests.
   Once the countdown reaches 0, the session id will be regenerated.  This is a
   good option to use for applications that need frequently
@@ -294,7 +293,7 @@ writing session data.
 Reading & writing session data
 ==============================
 
-Depending on the context you are in your application you have different classes
+Depending on the context you are in, your application has different classes
 that provide access to the session.  In controllers you can use
 :php:class:`SessionComponent`.  In the view, you can use
 :php:class:`SessionHelper`.  In any part of your application you can use


### PR DESCRIPTION
- $_SESSION is more-so of a proper noun since it is a predefined variable in PHP, therefore doesn't necessitate a "the."
- Compressed the first two sentences under "Session Configuration."  I felt that it read weird when both sentences started with the same phrase.
- Missing space in user agent.
- Missing space between "sessions" and "ids."
- Edited the first "Reading & writing session data" sentence to remove a shared "in" between "Depending on the context you are" and "your application you have different classes."
