### PR TITLE
Fix a small PHP syntax error in 'Using and Configuring Helpers'.

### DIFF
--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -42,10 +42,10 @@ do not use the helper as well as help keep the controller better
 organized::
 
     class BakeriesController extends AppController {
-        public function bake {
+        public function bake() {
             $this->helpers[] = 'Time';
         }
-        public function mix {
+        public function mix() {
             // The Time helper is not loaded here and thus not available
         }
     }


### PR DESCRIPTION
The lack of parentheses distracted me from the documentation, so I thought I'd try to fix it.

(My first pull request, please tell me if I did anything incorrectly!)
