### PR TITLE
[FR] Fix a small PHP syntax error in 'Using and Configuring Helpers'

### DIFF
--- a/fr/views/helpers.rst
+++ b/fr/views/helpers.rst
@@ -48,7 +48,7 @@ mieux organisé::
         }
         public function mix() {
             // Le Helper Time n'est pas chargé ici et n'est par conséquent
-            pas disponible
+            // pas disponible
         }
     }
 


### PR DESCRIPTION
Previously fixed in English in #686.
