### PR TITLE
Removed reference to sanitize docs on deployment page

### DIFF
--- a/en/deployment.rst
+++ b/en/deployment.rst
@@ -9,9 +9,8 @@ Check your security
 
 If you're throwing your application out into the wild, it's a good idea to make
 sure it doesn't have any leaks. Check the :doc:`/core-libraries/components/security-component` to guard against
-CSRF attacks, form field tampering, and others. Doing :doc:`/models/data-validation`, and/or 
-:doc:`/core-utility-libraries/sanitize` is also a great idea, for protecting your
-database and also against XSS attacks. Check that only your ``webroot`` directory 
+CSRF attacks, form field tampering, and others. Doing :doc:`/models/data-validation` is also a great idea
+for protecting your database and also against XSS attacks. Check that only your ``webroot`` directory
 is publicly visible, and that your secrets (such as your app salt, and
 any security keys) are private and unique as well!
 


### PR DESCRIPTION
Since the sanitize docs have been removed, the reference to this page is just spitting out the relative URL.
