### PR TITLE
3.0 cache set

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -45,6 +45,9 @@ Cache
 * Cache configurations are now immutable. If you need to change configuration
   you must first drop the configuration and then re-create it. This prevents
   synchronization issues with configuration options.
+* ``Cache::set()`` has been removed. It is recommended that you create multiple
+  cache configurations to replace runtime configuration tweaks previously
+  possible with ``Cache::set()``.
 
 Console
 =======

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -383,27 +383,6 @@ Cache API
     ``Cache::delete()`` will allow you to completely remove a cached
     object from the Cache store.
 
-.. php:staticmethod:: set($settings = array(), $value = null, $config = 'default')
-
-    ``Cache::set()`` allows you to temporarily override a cache config's
-    settings for one operation (usually a read or write). If you use
-    ``Cache::set()`` to change the settings for a write, you should
-    also use ``Cache::set()`` before reading the data back in. If you
-    fail to do so, the default settings will be used when the cache key
-    is read.::
-
-        Cache::set(array('duration' => '+30 days'));
-        Cache::write('results', $data);
-
-        // Later on
-
-        Cache::set(array('duration' => '+30 days'));
-        $results = Cache::read('results');
-
-    If you find yourself repeatedly calling ``Cache::set()`` perhaps
-    you should configure a separate cache engine. This will remove the
-    need to call ``Cache::set()``.
-
 .. php:staticmethod:: increment($key, $offset = 1, $config = 'default')
 
     Atomically increment a value stored in the cache engine. Ideal for


### PR DESCRIPTION
Update docs for Cache::set() being removed.
