### PR TITLE
Make explicit insert and remove cannot use attribute matching

### DIFF
--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -91,7 +91,7 @@ elements you can use attribute matching with methods like ``extract()``.
 
     :rtype: array
 
-    Inserts $data into an array as defined by $path. This method only supports
+    Inserts $data into an array as defined by $path. This method **only** supports
     the expression types of :ref:`hash-path-syntax`::
 
         $a = array(
@@ -121,8 +121,8 @@ elements you can use attribute matching with methods like ``extract()``.
 
     :rtype: array
 
-    Removes all elements from an array that match $path. This method supports
-    all the expression elements of :ref:`hash-path-syntax`::
+    Removes all elements from an array that match $path. This method **only** supports
+    the expression types of :ref:`hash-path-syntax`::
 
         $a = array(
             'pages' => array('name' => 'page'),


### PR DESCRIPTION
See https://cakephp.lighthouseapp.com/projects/42648/tickets/4011-hashremove-with-regex-fails-to-remove

and https://github.com/cakephp/docs/pull/704 for details.
