### PR TITLE
Make explicit what methods can use attribute matching

### DIFF
--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -37,8 +37,10 @@ elements.  You apply matchers to expression elements.
 | ``Foo``                        | Matches keys with the exact same value.    |
 +--------------------------------+--------------------------------------------+
 
-All expression elements are supported all methods.  In addition to expression
-elements you can use attribute matching with methods like ``extract()``.
+All expression elements are supported by all methods.  In addition to expression
+elements, you can use attribute matching with certain methods. They are ``extract()``, 
+``combine()``, ``format()``, ``check()``, ``map()``, ``reduce()``, 
+``apply()``, ``sort()`` and ``nest()``.
 
 +--------------------------------+--------------------------------------------+
 | Matcher                        | Definition                                 |


### PR DESCRIPTION
See https://cakephp.lighthouseapp.com/projects/42648/tickets/4011-hashremove-with-regex-fails-to-remove'

and

https://github.com/cakephp/docs/pull/704#discussion_r5920707
