### PR TITLE
Added a note about MissingTableException and CakePHP's model cache

### DIFF
--- a/en/development/exceptions.rst
+++ b/en/development/exceptions.rst
@@ -147,7 +147,10 @@ be thrown from a number of CakePHP core components:
 
 .. php:exception:: MissingTableException
 
-    A model's table is missing.
+    A model's table is missing from CakePHP's cache or the datasource. Upon adding
+    a new table to a datasource, the model cache (found in tmp/cache/models by default)
+    must be removed.
+    
 
 .. php:exception:: MissingActionException
 


### PR DESCRIPTION
The common error of not clearing the cache after updating a datasource often leads to a MissingTableException. Without this note, the Exception description is not helpful in diagnosing this problem.
