### PR TITLE
Correcting the --skell parameter in 'cake bake project' command.

### DIFF
--- a/en/console-and-shells/code-generation-with-bake.rst
+++ b/en/console-and-shells/code-generation-with-bake.rst
@@ -92,7 +92,7 @@ your views
 Pass the skeleton path parameter to the project task
 ::
 
-    cake bake project -skel Console/Templates/skel
+    cake bake project --skel Console/Templates/skel
 
 .. note::
 


### PR DESCRIPTION
The command 'cake bake project' in the documentation is wrong as it is using '-skell' param instead of '--skell'.
