### PR TITLE
Update Router::baseUrl reference to Router::fullBaseUrl

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -997,7 +997,7 @@ Router API
       when using requestAction.
     * ``?`` - Takes an array of query string parameters
     * ``#`` - Allows you to set URL hash fragments.
-    * ``full_base`` - If true the value of :php:meth:`Router::baseUrl()` will
+    * ``full_base`` - If true the value of :php:meth:`Router::fullBaseUrl()` will
       be prepended to generated URLs.
 
 .. php:staticmethod:: mapResources($controller, $options = array())

--- a/fr/development/routing.rst
+++ b/fr/development/routing.rst
@@ -1053,7 +1053,7 @@ API du Router
       URLs Cake relative sont nécessaires quand on utilise requestAction.
     * ``?`` - Prend un tableau de paramètres de chaîne requêté.
     * ``#`` - Vous permet de définir les fragments hashés d'URL.
-    * ``full_base`` - Si à true, la valeur de :php:meth:`Router::baseUrl()`
+    * ``full_base`` - Si à true, la valeur de :php:meth:`Router::fullBaseUrl()`
       sera ajoutée avant aux urls générées.
 
 .. php:staticmethod:: mapResources($controller, $options = array())


### PR DESCRIPTION
This method was updated, and Router::baseUrl() no longer exists
