### PR TITLE
Clarified Containable filtering limitations

### DIFF
--- a/en/core-libraries/behaviors/containable.rst
+++ b/en/core-libraries/behaviors/containable.rst
@@ -252,7 +252,7 @@ by Daniel::
 There is an important caveat to using Containable when filtering on a deeper association. In the previous example,
 assume you had 3 posts in your database and Daniel had commented on 2 of those posts. The operation
 $this->Post->find('all', array('contain' => 'Comment.author = "Daniel"')); would return ALL 3 posts, not
-just the 3 posts that Daniel had commented on. It won't return all comments however, just comments by Daniel.
+just the 3 posts that Daniel had commented on. It won't return all comments however, just comments by Daniel.::
 
     [0] => Array
             (
@@ -313,6 +313,14 @@ just the 3 posts that Daniel had commented on. It won't return all comments howe
                             )
                     )
             )
+
+If you want to filter the posts by the comments, so that posts without a comment by Daniel won't be
+returned, the easiest way is to find all the comments by Daniel and contain the Posts.::
+
+    $this->Comment->find('all', array(
+        'conditions' => 'Comment.author = "Daniel"',
+        'contain' => 'Post'
+    ));
 
 Additional filtering can be performed by supplying the standard :ref:`model-find` options::
 


### PR DESCRIPTION
It isn't clear when using containable that an INNER JOIN isn't happening when filtering by a deeper level association, when it really is only affecting the subquery. I added an explanation and an example.
