### PR TITLE
3.0 - Add example on splitting configuration

### DIFF
--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -102,7 +102,7 @@ Asset.timestamp
     Valid values:
     (bool) false - Doesn't do anything (default)
     (bool) true - Appends the timestamp when debug > 0
-    (string) 'force' - Appends the timestamp when debug >= 0
+    (string) 'force' - Always appends the timestamp.
 Acl.classname, Acl.database
     Used for CakePHP’s Access Control List functionality. See
     the Access Control Lists chapter for more information.


### PR DESCRIPTION
To go with the most recent configuration changes, add examples to the docs to show how to do split/load multiple configuration files.
