### PR TITLE
Fix CakePlugin::loadAll() example

### DIFF
--- a/en/appendices/2-3-migration-guide.rst
+++ b/en/appendices/2-3-migration-guide.rst
@@ -98,7 +98,7 @@ CakePlugin
   prevent file include errors when you try to load routes or bootstrap but they don't exist for a plugin.
   So essentially you can now use the following statement which will load all plugins and their routes and
   bootstrap for whatever plugin it can find::
-  ``CakePlugin::loadAll(array('routes' => true, 'bootstrap' => true, 'ignoreMissing' => true))``
+  ``CakePlugin::loadAll(array(array('routes' => true, 'bootstrap' => true, 'ignoreMissing' => true)))``
 
 
 Configure


### PR DESCRIPTION
Global options need to be passed as a array of array in CakePlugin::loadAll method.
