### PR TITLE
Infinity looping bug

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -253,11 +253,8 @@ something like::
 
         // destroy a session.
         public function destroy($id) {
-            $result = Cache::delete($id, $this->cacheKey);
-            if ($result) {
-                return parent::destroy($id);
-            }
-            return false;
+            Cache::delete($id, $this->cacheKey);
+            return parent::destroy($id);
         }
 
         // removes expired sessions.


### PR DESCRIPTION
Whenever Cache lost the session data and Database has a copy of the expired data, ComboSession will not be able to destroy the expired session from Database and hence infinity looping happens (CakeSession rejected the expired data and attempted to do destroy-start-destroy-start-destroy-start...). This modification is to ensure ComboSession delete them from both Cache and Database regardless if Cache deletion succeeded or not.
