### PR TITLE
Update rss.rst

### DIFF
--- a/en/core-libraries/helpers/rss.rst
+++ b/en/core-libraries/helpers/rss.rst
@@ -152,7 +152,7 @@ associative array into an element for each key value pair.
         );
 
         // Remove & escape any HTML to make sure the feed content will validate.
-        $bodyText = h(strip_tags($bodyText));
+        $bodyText = h(strip_tags($post['Post']['body']));
         $bodyText = $this->Text->truncate($bodyText, 400, array(
             'ending' => '...',
             'exact'  => true,


### PR DESCRIPTION
fixed error in sample code, $bodyText should be $post['Post']['body'] on line 155.  Or we could set $bodyText = $post['Post']['body'] above this line.
