### PR TITLE
Update simple-acl-controlled-application.rst

### DIFF
--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -327,7 +327,12 @@ implement ``bindNode()`` in ``User`` model::
 This method will tell ACL to skip checking ``User`` Aro's and to
 check only ``Group`` Aro's.
 
-Every user has to have assigned ``group_id`` for this to work.
+Every user has to have assigned ``group_id`` for this to work. Besides, you have 
+to change in ``User`` model::
+
+    var $actsAs = array('Acl' => array('type' => 'requester', 'enabled' => false));
+
+this avoids the afterSave to be called.
 
 In this case our ``aros`` table will look like this::
 


### PR DESCRIPTION
What I did
http://book.cakephp.org/view/1547/Acts-As-a-Requester
Followed the books docs on creating user and group models
setup my user model to use the bindNode function defined, so that user aros are not created

What happened
i add groups and they insert their correct aros
but when i add users, aros are still created

What I expected to happen
Only group aros to be created, not user ones.
