### PR TITLE
Add missing semicolon to request-response 'Sending a string as file' code sample

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -480,7 +480,7 @@ to serve the generated string as file you can do that by using::
         $this->response->type('ics');
 
         //Optionally force file download
-        $this->response->download('filename_for_download.ics')
+        $this->response->download('filename_for_download.ics');
 
         //Return response object to prevent controller from trying to render a view
         return $this->response;

--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -512,7 +512,7 @@ générée en fichier, vous pouvez faire cela en utilisant::
         $this->response->type('ics');
 
         //Force le téléchargement de fichier en option
-        $this->response->download('filename_for_download.ics')
+        $this->response->download('filename_for_download.ics');
 
         //Retourne l'object pour éviter au controller d'essayer de rendre une vue
         return $this->response;


### PR DESCRIPTION
There's a missing semicolon in a code sample on the "request-response" page.
