### PR TITLE
Fix warings while making html-en

### DIFF
--- a/config/all.py
+++ b/config/all.py
@@ -49,7 +49,11 @@ release = '2.x'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['themes', 'core-libraries/components/email.rst']
+exclude_patterns = [
+    'themes',
+    'core-libraries/components/email.rst',
+    'pdf-contents.rst'
+]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -24,9 +24,8 @@ Configuring Components
 
 Many of the core components require configuration. Some examples of
 components requiring configuration are
-:doc:`/core-libraries/components/authentication`, :doc:`/core-libraries/components/cookie`
-and :doc:`/core-libraries/components/email`. Configuration for these
-components, and for components in general, is usually done in the
+:doc:`/core-libraries/components/authentication` and :doc:`/core-libraries/components/cookie`.
+Configuration for these components, and for components in general, is usually done in the
 ``$components`` array or your controller's ``beforeFilter()``
 method::
 

--- a/en/core-libraries/components/access-control-lists.rst
+++ b/en/core-libraries/components/access-control-lists.rst
@@ -271,7 +271,7 @@ Merry                   Deny Ale         Denying ale.
 ======================= ================ =======================
 
 Defining Permissions: CakePHP's INI-based ACL
-==========================================
+=============================================
 
 CakePHP's first ACL implementation was based on INI files stored in
 the CakePHP installation. While it's useful and stable, we recommend
@@ -365,7 +365,7 @@ using the ACL component.
 
 
 Defining Permissions: CakePHP's Database ACL
-=========================================
+============================================
 
 Now that we've covered INI-based ACL permissions, let's move on to
 the (more commonly used) database ACL.


### PR DESCRIPTION
I'm not sure why core-libraries/components/email was excluded.

Also there's still one warning:
./en/development/debugging.rst:13: WARNING: duplicate object description of debug, other instance in ./en/core-libraries/global-constants-and-functions.rst

The recommended way to avoid it is to add :noindex:, but it doesn't work for some reason.
https://groups.google.com/forum/#!topic/sphinx-users/lzQEf7Jswgg
