### PR TITLE
Official CakePHP Facebook group link added

### DIFF
--- a/en/cakephp-overview/where-to-get-help.rst
+++ b/en/cakephp-overview/where-to-get-help.rst
@@ -83,6 +83,14 @@ CakePHP also has a very active Google Group. It can be a great
 resource for finding archived answers, frequently asked questions,
 and getting answers to immediate problems.
 
+The Facebook Group
+==================
+`https://www.facebook.com/groups/cake.community <https://www.facebook.com/groups/cake.community>`_
+
+CakePHP has it's official group in Facebook. The Official CakePHP 
+Facebook Group is an open group for community discussions, sharing plugins 
+and framework related trends, as well as updates and announcements from the CakePHP project.
+
 CakePHP Questions
 =================
 


### PR DESCRIPTION
As well as **Google Group** we should mention the **Facebook Group URL** in the CakePHP documentation. Facebook is now a popular social community and it's great to see the official cakephp group in Facebook. So we should add it so that people can keep in touch with CakePHP from their own facebook account.
