### PR TITLE
Update migration guide for helper method removal.

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -426,8 +426,8 @@ Helper
   use a dedicated libray like HTMLPurifier.
 - :php:meth:`Cake\\View\\Helper::output()` was removed. This method was
   deprecated in 2.x.
-- Magic accessors to deprecated properties has been removed. The following
-  properties now need to be accessed on the request object:
+- Magic accessors to deprecated properties have been removed. The following
+  properties now need to be accessed from the request object:
 
   - base
   - here


### PR DESCRIPTION
Docs update for https://github.com/cakephp/cakephp/pull/2169
