### PR TITLE
Replace indices with indexes

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -28,7 +28,7 @@ also access it in Components by using the controller reference. Some of the duti
 * Provide environment introspection pertaining to the request. Things like the
   headers sent, the client's IP address, and the subdomain/domain information
   about the application the server is running on.
-* Provide access to request parameters both as array indices and object
+* Provide access to request parameters both as array indexes and object
   properties.
 
 Accessing request parameters
@@ -805,4 +805,4 @@ CakeResponse API
 
 .. meta::
     :title lang=en: Request and Response objects
-    :keywords lang=en: request controller,request parameters,array indices,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp
+    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp

--- a/en/models/data-validation.rst
+++ b/en/models/data-validation.rst
@@ -278,7 +278,7 @@ field, this is basically how it should look::
 As you can see, this is quite similar to what we did in the
 previous section. There, for each field we had only one array of
 validation parameters. In this case, each 'fieldName' consists of
-an array of rule indices. Each 'ruleName' contains a separate array
+an array of rule indexes. Each 'ruleName' contains a separate array
 of validation parameters.
 
 This is better explained with a practical example::

--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -278,7 +278,7 @@ numerically indexed array of records like this::
 
 .. note::
 
-    Note that we are passing numerical indices instead of usual
+    Note that we are passing numerical indexes instead of usual
     ``$data`` containing the Article key. When saving multiple records
     of same model the records arrays should be just numerically indexed
     without the model key.


### PR DESCRIPTION
Normalizing the use of indices/indexes.  Personally, I like indices better because of its mathematical/scientific background, but indexes is more common in American/Canadian English.  I'm open for comments on this.
