### PR TITLE
Indicate correct formatting for format()

### DIFF
--- a/en/core-utility-libraries/time.rst
+++ b/en/core-utility-libraries/time.rst
@@ -101,7 +101,7 @@ Formatting
     :rtype: string
 
     Will return a string formatted to the given format using the
-    `PHP date() formatting options <http://www.php.net/manual/en/function.date.php>`_::
+    `PHP strftime() formatting options <http://www.php.net/manual/en/function.strftime.php>`_::
 
         // called via TimeHelper
         echo $this->Time->format('%F %jS, %Y %h:%i %A', '2011-08-22 11:53:00');


### PR DESCRIPTION
The doc states to use formatting like in date() function. This is simply wrong as it uses formatting as in strftime().

For example: date('j') != strftime('%j')
