### PR TITLE
AfterSave declaration was not compatible with Model class in code exampl...

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -263,7 +263,7 @@ remove all entries associated to the ``post`` group::
 
     // Model/Post.php
 
-    public function afterSave($created) {
+    public function afterSave($created, $options = array()) {
         if ($created) {
             Cache::clearGroup('post', 'site_home');
         }
@@ -280,7 +280,7 @@ group and configurations, i.e.: having the same group::
      * A variation of previous example that clears all Cache configurations
      * having the same group
      */
-    public function afterSave($created) {
+    public function afterSave($created, $options = array()) {
         if ($created) {
             $configs = Cache::groupConfigs('post');
             foreach ($configs['post'] as $config) {


### PR DESCRIPTION
...e

Copy paste of the example gave an error, this changes prevents the error.

Error: Declaration of Category::afterSave() should be compatible with Model::afterSave($created, $options = Array)
