### PR TITLE
Fixed bug in ArticleController.php example.

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -668,9 +668,9 @@ model. The controller code looks like::
                 $this->Article->save($this->request->data);
             }
             if (!empty($short)) {
-                $result = $this->Article->findAll(null, array('id', 'title'));
+                $result = $this->Article->find('all', array('id', 'title'));
             } else {
-                $result = $this->Article->findAll();
+                $result = $this->Article->find('all');
             }
 
             if (isset($this->params['requested'])) {


### PR DESCRIPTION
I believe that there is a bug in this code example. I'm unsure about this as I'm new to CakePHP.
I would receive a syntax error when going to `http://localhost/cakephp/articles`:

```
Error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'findAll' at line 1
```

I used the blog tutorial, using `PostsController.php` as an example.
