### PR TITLE
Time helper format() method uses date() syntax, not strftime() syntax

### DIFF
--- a/en/core-utility-libraries/time.rst
+++ b/en/core-utility-libraries/time.rst
@@ -101,10 +101,10 @@ Formatting
     :rtype: string
 
     Will return a string formatted to the given format using the
-    `PHP strftime() formatting options <http://www.php.net/manual/en/function.strftime.php>`_::
+    `PHP date() formatting options <http://php.net/manual/en/function.date.php>`_::
 
         // called via TimeHelper
-        echo $this->Time->format('%F %jS, %Y %h:%i %A', '2011-08-22 11:53:00');
+        echo $this->Time->format('F jS, Y h:i A', '2011-08-22 11:53:00');
         // August 22nd, 2011 11:53 AM
 
         echo $this->Time->format('%r', '+2 days');

--- a/fr/core-utility-libraries/time.rst
+++ b/fr/core-utility-libraries/time.rst
@@ -104,13 +104,13 @@ Formatage
     :rtype: string
 
     Va retourner une chaîne formatée avec le format donné en utilisant les
-    `options de formatage de la fonction PHP strftime() <http://www.php.net/manual/en/function.strftime.php>`_::
+    `options de formatage de la fonction PHP date() <http://php.net/manual/en/function.date.php>`_::
 
         // appel via TimeHelper
-        echo $this->Time->format('%F %jS, %Y %h:%i %A', '2011-08-22 11:53:00');
+        echo $this->Time->format('F jS, Y h:i A', '2011-08-22 11:53:00');
         // August 22nd, 2011 11:53 AM
 
-        echo $this->Time->format('%r', '+2 days');
+        echo $this->Time->format('r', '+2 days');
         // 2 days from now formatted as Sun, 13 Nov 2011 03:36:10 +0800
 
         // appel avec CakeTime


### PR DESCRIPTION
The time helper examples claim that the format() helper uses the strftime format, however, only date() formatting works. See line 1039 of lib/Cake/Utility/CakeTime.php:

`return date($date, $time);`
