### PR TITLE
Add more side margins in tablet/phone layouts.

### DIFF
--- a/themes/cakephp/static/default.css
+++ b/themes/cakephp/static/default.css
@@ -197,6 +197,9 @@ body {
 	.root-link {
 		display: none;
 	}
+	.breadcrumb {
+		margin-left: 10px;
+	}
 	.dropdown {
 		display: none;
 	}
@@ -615,8 +618,8 @@ dt tt {
 @media only screen and (max-width: 767px) {
 	.footer .columns,
 	.row .document {
-		margin-left: 5px;
-		margin-right: 5px;
+		margin-left: 10px;
+		margin-right: 10px;
 	}
 
 	.related-pages,


### PR DESCRIPTION
I noticed the docs seemed a bit snug on my tablet, adding an extra 5px makes the docs feel less snug against the device edge and I feel makes the docs easier to read.
