### PR TITLE
Changed order of /webroot in Production

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -161,8 +161,8 @@ production setup will look like this on the file system::
         App/
         Plugin/
         tmp/
-        webroot/ (this directory is set as DocumentRoot)
         vendor/
+        webroot/ (this directory is set as DocumentRoot)
         .htaccess
         index.php
         README.md


### PR DESCRIPTION
The directory trees in Developer and Production are the same but before with a quick glance they looked different because of different order.
