### PR TITLE
Fixed rst syntax

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -159,8 +159,6 @@ methods.
 
 The required API for a CacheEngine is
 
-.. php:namespace:: Cake\Cache
-
 .. php:class:: CacheEngine
 
     The base class for all cache engines used with Cache.

--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -302,7 +302,7 @@ message. For example::
     Log::warning('this gets written to both shops.log and payments.log', 'payments');
     Log::warning('this gets written to both shops.log and payments.log', 'unknown');
 
-As of 3.0 the logging scope passed to :php:method:`Cake\\Log\\Log::write()` is
+As of 3.0 the logging scope passed to :php:meth:`Cake\\Log\\Log::write()` is
 forwarded to the log engines' ``write()`` method in order to provide better
 context to the engines.
 

--- a/en/core-utility-libraries/file-folder.rst
+++ b/en/core-utility-libraries/file-folder.rst
@@ -608,4 +608,3 @@ File API
     :title lang=en: Folder & File
     :description lang=en: The Folder and File utilities are convenience classes to help you read, write, and append to files; list files within a folder and other common directory related tasks.
     :keywords lang=en: file,folder,cakephp utility,read file,write file,append file,recursively copy,copy options,folder path,class folder,file php,php files,change directory,file utilities,new folder,directory structure,delete file
->>>>>>> 2.5

--- a/en/core-utility-libraries/validation.rst
+++ b/en/core-utility-libraries/validation.rst
@@ -261,8 +261,8 @@ the 'create' mode. If you'd like to apply 'update' rules you can do the followin
 .. note::
 
     If you need to validate entities you should use methods like
-    :php:method:`~Cake\\ORM\\Table::validate()` or
-    :php:method:`~Cake\\ORM\\Table::save()` as they are designed for that.
+    :php:meth:`~Cake\\ORM\\Table::validate()` or
+    :php:meth:`~Cake\\ORM\\Table::save()` as they are designed for that.
 
 Core Validation rules
 =====================

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -447,7 +447,7 @@ Instead, create a new query object using ``query()``::
         ->execute();
 
 Generally it is easier to insert data using entities and
-:php:method:`~Cake\\ORM\\Table::save()`. By composing a ``SELECT`` and
+:php:meth:`~Cake\\ORM\\Table::save()`. By composing a ``SELECT`` and
 ``INSERT`` query together you can create ``INSERT INTO ... SELECT`` style
 queries::
 
@@ -473,7 +473,7 @@ Instead, create new a query object using ``query()``::
         ->execute();
 
 Generally it is easier to delete data using entities and
-:php:method:`~Cake\\ORM\\Table::delete()`.
+:php:meth:`~Cake\\ORM\\Table::delete()`.
 
 Deleting data
 =============
@@ -487,7 +487,7 @@ Instead, create new a query object using ``query()``::
         ->execute();
 
 Generally it is easier to delete data using entities and
-:php:method:`~Cake\\ORM\\Table::delete()`.
+:php:meth:`~Cake\\ORM\\Table::delete()`.
 
 More complex queries
 ====================


### PR DESCRIPTION
- `:php:method` to `:php:meth`
- fixed error `SEVERE: Duplicate ID: "namespace-Cake\Cache”.`
- delete conflict mark
