### PR TITLE
add a note for deleteAll()

### DIFF
--- a/en/models/deleting-data.rst
+++ b/en/models/deleting-data.rst
@@ -66,10 +66,9 @@ deleted. This will often result in more queries being issued.
 
 .. note::
 
-   Associations will be reset before the matched records are deleted. If you
-   call bindModel() or unbindModel() to set the associations, you should set
-   *reset* to *false*.
-
+   Associations will be reset before the matched records are deleted in
+   deleteAll(). If you use bindModel() or unbindModel() to change the
+   associations, you should set *reset* to *false*.
 
 .. meta::
     :title lang=en: Deleting Data


### PR DESCRIPTION
deleteAll() calls find() with _recursive_ set to _0_, and then delete all the records recursively. If call bindModel or unbindModel() with _reset_ set to _true_, it will have no effect, sometimes it's dangerous.
