### PR TITLE
Create a Japanese PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ES_HOST =
 LANGS = en es fr ja pt ru
 
 # pdflatex does not like ja or ru for some reason.
-PDF_LANGS = en es fr pt
+PDF_LANGS = en es fr ja pt
 
 DEST = website
 

--- a/ja/Makefile
+++ b/ja/Makefile
@@ -101,8 +101,8 @@ latex:
 
 latexpdf:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex/$(LANG)
-	@echo "Running LaTeX files through pdflatex..."
-	make -C $(BUILDDIR)/latex/$(LANG) all-pdf
+	@echo "Running LaTeX files through platex and dvipdfmx..."
+	$(MAKE) -C $(BUILDDIR)/latex/$(LANG) all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex/$(LANG)."
 
 text:

--- a/ja/index.rst
+++ b/ja/index.rst
@@ -16,7 +16,7 @@ CakePHP cookbookは、オープンに開発されている、コミュニティ�
     どこでもCakePHPのレシピをお楽しみ頂けます。PDFとEPUBをご用意しましたので、\
     多くのデバイス上でオフラインでドキュメントを読むことができます。
 
-    - `PDF(英語) <../_downloads/en/CakePHPCookbook.pdf>`_
+    - `PDF <../_downloads/ja/CakePHPCookbook.pdf>`_
     - `EPUB <../_downloads/ja/CakePHPCookbook.epub>`_
     - `オリジナルソース <http://github.com/cakephp/docs>`_
 


### PR DESCRIPTION
## About
- Create a Japanese PDF.
## Requirements
- Sphinx 1.2
  - Makefile target of "all-pdf-ja" is available in Sphinx 1.2.
## Testing
### Mac OS X
- Mac OS X 10.9.1
- MacTeX 2013
- Sphinx 1.2 (Python 2.7.3)
### Debian
- Debian 7.3 (x86_64)
- TexLive 2013
- Sphinx 1.2 (Python 2.7.6)
