### PR TITLE
Remove examples and tutorials from the TOC

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -16,7 +16,6 @@ Contents
    console-and-shells
    development
    deployment
-   tutorials-and-examples
    contributing
    appendices
 

--- a/en/index.rst
+++ b/en/index.rst
@@ -24,12 +24,6 @@ the documentation.
 Getting started
 ===============
 
-Build a blog
-------------
-
-Get started with the :doc:`blog tutorial</tutorials-and-examples/blog/blog>`.
-You'll learn the basics of CakePHP, and build a basic blog in the process.
-
 Conventions
 -----------
 

--- a/en/pdf-contents.rst
+++ b/en/pdf-contents.rst
@@ -15,7 +15,6 @@ Contents
    console-and-shells
    development
    deployment
-   tutorials-and-examples
    appendices
 
 


### PR DESCRIPTION
These tutorials and guides aren't working right now and can't be updated
until the form helper is updated. Removing them sucks but is better than
confused and frustrated users.
