### PR TITLE
[pt] Remove Zero-width space character (U+200B)

### DIFF
--- a/pt/appendices/2-1-migration-guide.rst
+++ b/pt/appendices/2-1-migration-guide.rst
@@ -114,7 +114,7 @@ App
 - :php:meth:`App::build()` agora tem a capacidade de registrar novos pacotes usando
   ``App::REGISTER``. Veja :ref:`app-build-register` para mais informações.
 - As classes que não podem ser encontradas nos caminhos configurados serão pesquisados
-  ​dentro de ``APP``, como um caminho alternativo. Isso torna o carregamento automático
+  dentro de ``APP``, como um caminho alternativo. Isso torna o carregamento automático
   dos diretórios aninhados em ``app/Vendedor`` mais fácil.
 
 Console
@@ -317,7 +317,7 @@ FormHelper
   como 'N' ao invés de apenas 0.
 - O atributo ``for`` para campos datetime agora reflete o primeiro campo gerado. Isso pode
   resultar na mudança do atributo ``for`` de acordo com os campo geradas.
-- O atributo ``type`` para :php:meth:`FormHelper::button()` pode ​​ser removido agora. O padrão
+- O atributo ``type`` para :php:meth:`FormHelper::button()` pode ser removido agora. O padrão
   ainda é 'submit'.
 - :php:meth:`FormHelper::radio()` agora permite que você desabilite todas as opções. Você pode fazer
   isso definindo ``'disabled' => true`` ou ``'disabled' => 'disabled'`` no array ``$attributes``.

--- a/pt/controllers/components.rst
+++ b/pt/controllers/components.rst
@@ -155,7 +155,7 @@ controllers. Então não há necessidade de redeclarar o mesmo componente duas
 vezes.
 
 Ao incluir componentes em um controller você também pode declarar um conjunto de
-parâmetros que serão passados ​​para o construtor do componente. Estes parâmetros
+parâmetros que serão passados para o construtor do componente. Estes parâmetros
 podem ser usados pelo componente.
 
 ::


### PR DESCRIPTION
Remove Zero-width space character (U+200B) from PT documents.
It was a cause of this invisible character fails to PDF conversion.

It is not visible on GitHub, I want you to look at the capture below.

![cap](https://f.cloud.github.com/assets/10488/1860127/c8558f60-77ae-11e3-97f8-d447b654345c.png)

Relation: #1001
