### PR TITLE
Fix Check permissions description.

### DIFF
--- a/en/console-and-shells/acl-shell.rst
+++ b/en/console-and-shells/acl-shell.rst
@@ -60,9 +60,7 @@ switch 'deny' in for 'grant'.
 Check permissions
 =================
 
-Use this command to grant ACL permissions. Once executed, the ARO
-specified (and its children, if any) will have ALLOW access to the
-specified ACO action (and the ACO's children, if any)::
+Use this command to check ACL permissions.
 
     ./Console/cake acl check Group.1 controllers/Posts read
 


### PR DESCRIPTION
Description of "Check permissions" is the same as the grant one.
