### PR TITLE
Use fetch(title) instead

### DIFF
--- a/en/appendices/2-5-migration-guide.rst
+++ b/en/appendices/2-5-migration-guide.rst
@@ -145,6 +145,7 @@ View
 View
 ----
 
+- ``$title_for_layout`` is deprecated. Use ``$this->fetch('title');`` instead.
 - :php:meth:`View::get()` now accepts a second argument to provide a default
   value.
 


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/2636

The others already in the 2.1 migration guide. This one not, although the doc block in View class already states that it is deprecated and will be removed in 3.0.
