### PR TITLE
Fixed an ambiguous explanation

### DIFF
--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -950,6 +950,12 @@ Datetime options
 Form Element-Specific Methods
 =============================
 
+.. note::
+    All the elements are created under a form for the ``User`` model as in the examples above. 
+    For this reason, the HTML code generated will contain attributes that reference to User.
+    Ex: name=data[User][username],
+        id=UserUsername
+
 .. php:method:: label(string $fieldName, string $text, array $options)
 
     Create a label element. ``$fieldName`` is used for generating the
@@ -1019,6 +1025,12 @@ Form Element-Specific Methods
 
     .. code-block:: html
 
+        <input name="data[User][id]" id="UserId" type="hidden" />
+
+    If the form is edited, the value corresponding to 'id' field will automatically be added to the HTML 
+    generated. Example for data[User][id] = 10:
+
+    .. code-block:: html
         <input name="data[User][id]" value="10" id="UserId" type="hidden" />
 
     .. versionchanged:: 2.0
@@ -1037,7 +1049,14 @@ Form Element-Specific Methods
     .. code-block:: html
 
         <textarea name="data[User][notes]" id="UserNotes"></textarea>
-
+        
+    If the form is edited, the value corresponding to 'id' field will automatically be added to the HTML 
+    generated. Example:
+    
+        <textarea name="data[User][notes]" id="UserNotes">
+        This text is to be edited.
+        </textarea>
+    
     .. note::
 
         The ``textarea`` input type allows for the ``$options`` attribute


### PR DESCRIPTION
Under "Form Element-Specific Methods" paragraph, I modified the output for "echo $this->Form->hidden('id');", and for "echo $this->Form->textarea('notes');", and added some explanations.
