### PR TITLE
Expunge Repository from the docs.

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -352,8 +352,7 @@ Controller
 - ``Controller::validate()`` and ``Controller::validationErrors()`` have been
   removed. They were left over methods from the 1.x days where the concerns of
   models + controllers were far more intertwined.
-- ``Controller::loadModel()`` has been replaced with
-  :php:class:`~Cake\\Controller\\Controller::repository()`.
+- ``Controller::loadModel()`` now loads table objects.
 - The ``Controller::$scaffold`` property has been removed. Dynamic scaffolding
   has been removed from CakePHP core, and will be provided as a standalone
   plugin.

--- a/en/appendices/orm-migration.rst
+++ b/en/appendices/orm-migration.rst
@@ -321,7 +321,7 @@ calculated fields is easy to do in your finder methods. By using the query
 builder and expression objects you can achieve the same results that virtual
 fields gave::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
     use Cake\ORM\Query;
@@ -344,7 +344,7 @@ many limitations class definitions have, and provide only one way to define
 associations. Your ``initialize`` method and all other parts of your application
 code, interact with the same API when manipulating associations::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
     use Cake\ORM\Query;
@@ -382,7 +382,7 @@ of validation rules. In CakePHP 3.0, both these problems have been remedied.
 Validation rules are always built with a ``Validator`` object, and it is trivial to
 have multiple sets of rules::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
     use Cake\ORM\Query;

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -443,30 +443,30 @@ Other Useful Methods
     :php:meth:`Cake\\Routing\\RequestActionTrait::requestAction()` for more
     information on this method.
 
-.. php:method:: repository(string $modelClass, string $type)
+.. php:method:: loadModel(string $modelClass, string $type)
 
-    The ``repository`` function comes handy when you need to use a repository
-    that is not the controller's default one::
+    The ``loadModel`` function comes handy when you need to use a model
+    table/collection that is not the controller's default one::
 
-        $this->repository('Articles');
+        $this->loadModel('Articles');
         $recentArticles = $this->Articles->find('all', [
             'limit' => 5,
             'order' => 'Articles.created DESC'
         ]);
 
-    If you are using a repository provider other than the built-in ORM you can
-    link that repository system into CakePHP's controllers by connecting its
+    If you are using a table provider other than the built-in ORM you can
+    link that table system into CakePHP's controllers by connecting its
     factory method::
 
-        $this->repositoryFactory(
+        $this->modelFactory(
             'ElasticIndex',
-            ['ElasticRepository', 'factory']
+            ['ElasticIndexes', 'factory']
         );
 
-    After registering a repository factory, you can use ``repository`` to load
+    After registering a table factory, you can use ``loadModel`` to load
     instances::
 
-        $this->repository('Locations', 'ElasticIndex');
+        $this->loadModel('Locations', 'ElasticIndex');
 
     .. note::
 

--- a/en/orm.rst
+++ b/en/orm.rst
@@ -48,10 +48,10 @@ The conventions in CakePHP allow us to skip some boilerplate code, and allow the
 framework to insert base classes when your application has not created
 a concrete class. If we wanted to customize our ArticlesTable class adding some
 associations or defining some additional methods we would add the following to
-``App/Model/Repository/ArticlesTable.php``::
+``App/Model/Table/ArticlesTable.php``::
 
     <?php
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -20,11 +20,11 @@ Basic Usage
 ===========
 
 To get started, create a Table class. These classes live in
-``App/Model/Repository``. Tables are a type of repository specific to relational
+``App/Model/Table``. Tables are a type model collection specific to relational
 databases, and the main interface to your database in CakePHP's ORM. The most
 basic table class would look like::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -38,7 +38,7 @@ table will be used. If our table class was named ``BlogPosts`` your table should
 be named ``blog_posts``. You can specify the table to using the ``table()``
 method::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -54,7 +54,7 @@ No inflection conventions will be applied when specifying a table. By convention
 the ORM also expects each table to have a primary key with the name of ``id``.
 If you need to modify this you can use the ``primaryKey()`` method::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -143,7 +143,7 @@ object. Methods matching the association type allow you to define the
 associations in your application. For example if we wanted to define a belongsTo
 association in our ArticlesTable::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -708,7 +708,7 @@ Once you've converted request data into entities you can ``save()`` or
 Loading entities
 ================
 
-While table objects provide an abstraction around a 'repository' or table of
+While table objects provide an abstraction around a 'repository' or collection of
 objects, when you query for individual records you get 'entity' objects. While
 this section discusses the different ways you can find and load entities, you
 should read the :doc:`/orm/entities` section for more information on entities.
@@ -1735,7 +1735,7 @@ would allow for re-usable pieces of logic, they would complicate binding events.
 To add a behavior to your table you can call the ``addBehavior`` method.
 Generally the best place to do this is in the ``initialize`` method::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -1748,7 +1748,7 @@ Generally the best place to do this is in the ``initialize`` method::
 As with associations, you can use :term:`plugin syntax` and provide additional
 configuration options::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -1779,7 +1779,7 @@ By default all table instances use the ``default`` database connection. If your
 application uses multiple database connections you will want to configure which
 tables use which connections. This is the ``defaultConnectionName`` method::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
 

--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -177,7 +177,7 @@ basic directory structure. It should look like this::
             /Controller
                 /Component
             /Model
-                /Repository
+                /Table
                 /Entity
                 /Behavior
             /View
@@ -309,8 +309,8 @@ create the table and entity for that controller::
     class Contact extends Entity {
     }
 
-    // /Plugin/ContactManager/Model/Repository/ContactsTable.php:
-    namespace ContactManager\Model\Repository;
+    // /Plugin/ContactManager/Model/Table/ContactsTable.php:
+    namespace ContactManager\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -321,8 +321,8 @@ If you need to reference a model within your plugin when building associations,
 or defining entitiy classes, you need to include the plugin name with the class
 name, separated with a dot. For example::
 
-    // /Plugin/ContactManager/Model/Repository/ContactsTable.php:
-    namespace ContactManager\Model\Repository;
+    // /Plugin/ContactManager/Model/Table/ContactsTable.php:
+    namespace ContactManager\Model\Table;
 
     use Cake\ORM\Table;
 
@@ -335,12 +335,12 @@ name, separated with a dot. For example::
 If you would prefer that the array keys for the association not have the plugin
 prefix on them, use the alternative syntax::
 
-    // /Plugin/ContactManager/Model/Repository/ContactsTable.php:
-    namespace ContactManager\Model\Repository;
+    // /Plugin/ContactManager/Model/Table/ContactsTable.php:
+    namespace ContactManager\Model\Table;
 
     use Cake\ORM\Table;
 
-    class ContactsTable extends Repository {
+    class ContactsTable extends Table {
         public function initialize(array $config) {
             $this->hasMany('AltName', [
                 'className' => 'ContactManager.AltName',

--- a/fr/appendices/3-0-migration-guide.rst
+++ b/fr/appendices/3-0-migration-guide.rst
@@ -390,8 +390,6 @@ Controller
   retirées. Il y avait d'autres méthodes laissées depuis les jours de 1.x days,
   où les préoccupations des models + controllers étaient bien plus étroitement
   liées.
-- ``Controller::loadModel()`` a été remplacée par
-  :php:class:`~Cake\\Controller\\Controller::repository()`.
 - La propriété ``Controller::$scaffold`` a été retirée. Le scaffolding dynamique
   a été retiré du coeur de CakePHP, et sera fourni en tant que plugin autonome.
 

--- a/fr/appendices/orm-migration.rst
+++ b/fr/appendices/orm-migration.rst
@@ -353,7 +353,7 @@ l'ajout des champs calculés est facile à faire dans les méthodes finder. En
 utilisant le query builder et les objets expression que vous pouvez atteindre
 les mêmes résultats que les champs virtuels donnent::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
     use Cake\ORM\Query;
@@ -378,7 +378,7 @@ associations. Votre méthode ``initialize`` et toutes les autres parties de
 votre code d'application, intéragit avec la même API lors de la
 manipulation des associations::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
     use Cake\ORM\Query;
@@ -420,7 +420,7 @@ deux de ces problèmes. Les règles de validation sont toujours construites
 avec un objet ``Validator``, et il est trivial d'avoir plusieurs ensembles de
 règles::
 
-    namespace App\Model\Repository;
+    namespace App\Model\Table;
 
     use Cake\ORM\Table;
     use Cake\ORM\Query;


### PR DESCRIPTION
As per the discussion in cakephp/cakephp#2669 this removes the term 'Repository' from around the ORM docs.
