### PR TITLE
The countBy example was using the groupBy method

### DIFF
--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -244,7 +244,7 @@ If you only wish to know the number of occurrences per group, you can do so by
 using the ``countBy`` method, it takes the same arguments as ``groupBy`` so it
 should be already familiar to you::
 
-    $classResults = $students->groupBy(function($student) {
+    $classResults = $students->countBy(function($student) {
         retrun $student->grade > 6 ? 'approved' : 'reproved';
     });
 


### PR DESCRIPTION
Hi,

In http://book.cakephp.org/3.0/en/core-libraries/collections.html#grouping-and-counting, the countBy example was using groupBy method and not the countBy.
