### PR TITLE
In the groupBy example was missing a comma

### DIFF
--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -223,7 +223,7 @@ share the same value for a property::
     [
       10 => [
         ['name' => 'Andrew', 'grade' => 10],
-        ['name' => 'Stacy' 'grade' => 10]
+        ['name' => 'Stacy', 'grade' => 10]
       ],
       9 => [
         ['name' => 'Mark', 'grade' => 9],


### PR DESCRIPTION
The array in the groupBy example was missing a comma, causing a sintax error
