### PR TITLE
Fixed an ambiguous explanation

### DIFF
--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -953,7 +953,7 @@ Form Element-Specific Methods
     All elements are created under a form for the ``User`` model as in the examples above. 
     For this reason, the HTML code generated will contain attributes that reference to the User model.
     Ex: name=data[User][username], id=UserUsername
-::
+    
 .. php:method:: label(string $fieldName, string $text, array $options)
 
     Create a label element. ``$fieldName`` is used for generating the


### PR DESCRIPTION
Under "Form Element-Specific Methods" paragraph, I modified the output for "echo $this->Form->hidden('id');", and for "echo $this->Form->textarea('notes');", and added some explanations.
