### PR TITLE
Group-Only ACL configuration is missing additional instructions

### DIFF
--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -339,7 +339,7 @@ Modify the ``actsAs`` for the model ``User`` and disable the requester directive
 
     public $actsAs = array('Acl' => array('type' => 'requester', 'enabled' => false));
 
-This method will tell ACL to skip checking ``User`` Aro's and to
+This method along with configuration change will tell ACL to skip checking ``User`` Aro's and to
 check only ``Group`` Aro's.
 
 Every user has to have assigned ``group_id`` for this to work.


### PR DESCRIPTION
Hi there,
I was implementing the Group-Only based ACL, and I found the information lacking as it was still creating User and checking permission against it. So I have added the instruction to the documentation.
Hope this will be helpful for some newbie like me.
