### PR TITLE
Update authentication.rst

### DIFF
--- a/ja/core-libraries/components/authentication.rst
+++ b/ja/core-libraries/components/authentication.rst
@@ -673,7 +673,7 @@ Blowfish password hasher は、任意の認証クラスで使用することが�
 抽象メソッドの ``hash()`` と ``check()`` を実装する必要があります。
 ``app/Controller/Component/Auth/CustomPasswordHasher.php`` に次のように記述します::
 
-    App::uses('CustomPasswordHasher', 'Controller/Component/Auth');
+    App::uses('AbstractPasswordHasher', 'Controller/Component/Auth');
 
     class CustomPasswordHasher extends AbstractPasswordHasher {
         public function hash($password) {


### PR DESCRIPTION
Modified CustomPasswordHasher Sample code
- App::uses $className
  - Sample code for En and Ja are different
    - [En](https://github.com/cakephp/docs/blob/master/en/core-libraries/components/authentication.rst#creating-custom-password-hasher-classes)
    - [Ja](https://github.com/cakephp/docs/blob/master/ja/core-libraries/components/authentication.rst#%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%A0%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5%E5%8C%96%E3%82%AF%E3%83%A9%E3%82%B9%E3%81%AE%E4%BD%9C%E6%88%90)  => Error occurs Ja...
