### PR TITLE
Minor correction. Documentation for routing incorrect on use of connectNamed()

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -180,8 +180,8 @@ When generating URLs, routes are used too. Using
 a url will output /cooks/some_action/5 if the above route is the
 first match found.
 
-By default all named passed and arguments are extracted from URLs matching 
-greedy templates. However you can configure how, and which named arguments are
+By default all named passed and arguments are extracted from URLs matching
+greedy templates. However, you can configure how and which named arguments are
 parsed using :php:meth:`Router::connectNamed()` if you need to.
 
 .. _route-elements:


### PR DESCRIPTION
Documentation for routing incorrectly states you need to use connectNamed() to allow named arguments to be parsed. You dont. Routes parse them by default in 2.5 - so long as template is greedy. Changed docs accordingly
