### PR TITLE
Table names to match wording later in document

### DIFF
--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -24,6 +24,7 @@ made of any number of tokens. Tokens are composed of two groups. Expressions,
 are used to traverse the array data, while matchers are used to qualify
 elements. You apply matchers to expression elements.
 
+#### Expression Types
 +--------------------------------+--------------------------------------------+
 | Expression                     | Definition                                 |
 +================================+============================================+
@@ -42,6 +43,7 @@ elements, you can use attribute matching with certain methods. They are ``extrac
 ``combine()``, ``format()``, ``check()``, ``map()``, ``reduce()``,
 ``apply()``, ``sort()`` and ``nest()``.
 
+#### Attribute Matching Types
 +--------------------------------+--------------------------------------------+
 | Matcher                        | Definition                                 |
 +================================+============================================+


### PR DESCRIPTION
This has always been unclear to me when the document refers and links to "This method **only** supports the expression types of :ref:`hash-path-syntax`::". I propose naming the tables something to match the later verbiage to make this more clear as to which expressions are supported by the method.
