### PR TITLE
Missing asterix for singularize

### DIFF
--- a/en/core-utility-libraries/inflector.rst
+++ b/en/core-utility-libraries/inflector.rst
@@ -15,8 +15,8 @@ normally accessed statically. Example:
 
 .. php:staticmethod:: singularize($plural)
 
-    **Input:** Apples, Oranges, People, Men
-    **Output:** Apple, Orange, Person, Man
+    * **Input:** Apples, Oranges, People, Men
+    * **Output:** Apple, Orange, Person, Man
 
 .. php:staticmethod:: camelize($underscored)
 


### PR DESCRIPTION
There's missing an extra asterix for the singularize, meaning it's not written as a list but in one line
