### PR TITLE
Correction d'une petite faute

### DIFF
--- a/fr/models/saving-your-data.rst
+++ b/fr/models/saving-your-data.rst
@@ -876,7 +876,7 @@ légèrement différemment. Le nom du Tag est défini en utilisant la convention
     $this->Form->input('Tag');
 
 En utilisant le code précédent, un liste déroulante est créée, permettant aux
-multiples choix d'être automatiquement sauvegarder au Recipe existant en étant
+multiples choix d'être automatiquement sauvegardés au Recipe existant en étant
 ajouté à la base de données.
 
 Self HABTM


### PR DESCRIPTION
On passe de :
En utilisant le code précédent, un liste déroulante est créée, permettant aux multiples choix d’être automatiquement sauvegarder au Recipe existant en étant ajouté à la base de données.

A :
En utilisant le code précédent, un liste déroulante est créée, permettant aux multiples choix d’être automatiquement sauvegard_és_ au Recipe existant en étant ajouté à la base de données.
