### PR TITLE
Update hash.rst to have entry for apply()

### DIFF
--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -623,6 +623,10 @@ Attribute Matching Types
     results with $function. You can use both expression and matching elements
     with this method.
 
+.. php:staticmethod:: apply(array $data, $path, $function)
+
+    Apply a callback to a set of extracted values using $function. The function will get the extracted values as the first argument.
+
 .. php:staticmethod:: sort(array $data, $path, $dir, $type = 'regular')
 
     :rtype: array


### PR DESCRIPTION
apply() is listed at the top of the doc, but there is no entry for it below.
