### PR TITLE
Update retrieving-your-data.rst

### DIFF
--- a/en/models/retrieving-your-data.rst
+++ b/en/models/retrieving-your-data.rst
@@ -40,6 +40,9 @@ It's also possible to add and use other parameters, as is made use
 of by some find types, behaviors and of course possibly with your
 own model methods.
 
+.. note::
+
+If ``'find'`` cannot find any value it returns an empty array.
 
 .. _model-find-first:
 


### PR DESCRIPTION
Just a simple note. If no value is found it is not specified what 'find' will return hence the reader wouldn't know what to spect in that case.
I propose to add a note about it in the general find explanation.
As a general review I would propose to mention returned values in where ever function where is not mentioned. It would help a lot and it is just adding a single line in most cases
