### PR TITLE
Path name mistakes in doc

### DIFF
--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -79,7 +79,7 @@ directories in ``app/webroot`` with paths matching those used by CakePHP.
 -  ``app/Plugin/DebugKit/webroot/js/my_file.js`` becomes
    ``app/webroot/debug_kit/js/my_file.js``
 -  ``app/View/Themed/Navy/webroot/css/navy.css`` becomes
-   ``app/webroot/theme/Navy/css/navy.css``
+   ``app/webroot/themed/Navy/css/navy.css``
 
 
 .. meta::


### PR DESCRIPTION
app/View/Themed/Navy/webroot/css/navy.css becomes app/webroot/themed/Navy/css/navy.css
