### PR TITLE
Improved 'Hashing passwords' example.

### DIFF
--- a/en/core-libraries/components/authentication.rst
+++ b/en/core-libraries/components/authentication.rst
@@ -373,7 +373,7 @@ callback of your model using appropriate password hasher class::
 
     class User extends AppModel {
         public function beforeSave($options = array()) {
-            if (!$this->id) {
+            if (!empty($this->data['User']['password'])) {
                 $passwordHasher = new SimplePasswordHasher();
                 $this->data['User']['password'] = $passwordHasher->hash(
                     $this->data['User']['password']


### PR DESCRIPTION
The previous example checked if an id was set in the model, and therefore may save passwords in plaintext if an id was set and a password field was submitted with form data. My change simply checks if there's a password field from the form data and hashes it.
