### PR TITLE
Install phpunit 3.7.x, PHPUnit 4 doesn't work

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -18,10 +18,12 @@ following::
 
     pear upgrade PEAR
     pear config-set auto_discover 1
-    pear install pear.phpunit.de/PHPUnit
+    pear install pear.phpunit.de/PHPUnit-3.7.32
 
 .. note::
 
+    PHPUnit 4 is not compatible with CakePHP's Unit Testing.
+    
     Depending on your system's configuration, you may need to run the previous
     commands with ``sudo``
 


### PR DESCRIPTION
PHPUnit 4 removes files that Cake uses. You must install 3.7 for everything to work.
