### PR TITLE
Update part-two.rst

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -455,6 +455,15 @@ like::
             throw new NotFoundException(__('Invalid post'));
         }
 
+        /* 
+            CakeRequest::is() has only been able to take an array as of CakePHP 2.4.0, 
+            earlier versions are expecting a string.
+            so for user using CakePHP < 2.4, 
+            please use the following 
+                $this->request->is('post') || $this->request->is('put')
+            instead of 
+                $this->request->is(array('post', 'put'))
+        */
         if ($this->request->is(array('post', 'put'))) {
             $this->Post->id = $id;
             if ($this->Post->save($this->request->data)) {


### PR DESCRIPTION
Because CakeRequest::is() has only been able to take an array as of CakePHP 2.4.0, earlier versions are expecting a string. So the example in edit() post is better added a comment to explain.
This can solve many new comers' problem.
And developer sometimes might use prior version to test due to production server limitation in real world practically.
