### PR TITLE
Updated isOwnedBy function to check if not false

### DIFF
--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -388,7 +388,7 @@ logic as possible into models. Let's then implement the function::
     // app/Model/Post.php
 
     public function isOwnedBy($post, $user) {
-        return $this->field('id', array('id' => $post, 'user_id' => $user)) === $post;
+        return $this->field('id', array('id' => $post, 'user_id' => $user)) !== false;
     }
 
 


### PR DESCRIPTION
Previous code:

``` php
return $this->field('id', array('id' => $post, 'user_id' => $user)) === $post;
```

Does not work because $this->field() returns a string value when successful and otherwise returns false. The $post variable is of type int.

If $this->field() returns anything other than bool(false) it must mean it found the post_id, but imho matching it against the searched parameter would be useless and parsing String > int or int > String is not that awesome.. 
Changing === to == would cause posts with id 0 to fail (as 0 == false) therefore I propose the this solution.
