### PR TITLE
Note about typecasting.

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -235,7 +235,6 @@ describe the commented block of code.
 Comments can include the following `phpDocumentor <http://phpdoc.org>`_
 tags:
 
-*  `@access <http://manual.phpdoc.org/HTMLframesConverter/phpdoc.de/phpDocumentor/tutorial_tags.access.pkg.html>`_
 *  `@author <http://manual.phpdoc.org/HTMLframesConverter/phpdoc.de/phpDocumentor/tutorial_tags.author.pkg.html>`_
 *  `@copyright <http://manual.phpdoc.org/HTMLframesConverter/phpdoc.de/phpDocumentor/tutorial_tags.copyright.pkg.html>`_
 *  `@deprecated <http://manual.phpdoc.org/HTMLframesConverter/phpdoc.de/phpDocumentor/tutorial_tags.deprecated.pkg.html>`_


### PR DESCRIPTION
As typehinting is not entirely free, we only typehint public methods.
It is also adviced to only typehint type array and object.
This adds a small note in the conventions section.
