### PR TITLE
remove versionchanged and versionadded notes from 2.x

### DIFF
--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -1,8 +1,6 @@
 Completion Shell
 ################
 
-.. versionadded:: 2.5
-
 Working with the console gives the developer a lot of possibilities but having
 to completely know and write those commands can be tedious. Especially when
 developing new shells where the commands differ per minute iteration. The

--- a/en/controllers/pages-controller.rst
+++ b/en/controllers/pages-controller.rst
@@ -12,11 +12,6 @@ When you "bake" an app using CakePHP's console utility the Pages Controller is
 created in your ``app/Controller/`` folder. You can also copy the file from
 ``lib/Cake/Console/Templates/skel/Controller/PagesController.php``.
 
-.. versionchanged:: 2.1
-    With CakePHP 2.0 the Pages Controller was part of ``lib/Cake``. Since 2.1
-    the Pages Controller is no longer part of the core but ships in the app
-    folder.
-
 .. warning::
 
     Do not directly modify ANY file under the ``lib/Cake`` folder to avoid

--- a/en/core-libraries/components/request-handling.rst
+++ b/en/core-libraries/components/request-handling.rst
@@ -259,8 +259,6 @@ application.
 Taking Advantage of HTTP Cache Validation
 =========================================
 
-.. versionadded:: 2.1
-
 The HTTP cache validation model is one of the processes used for cache
 gateways, also known as reverse proxies, to determine if they can serve a
 stored copy of a response to the client. Under this model, you mostly save
@@ -286,8 +284,6 @@ setting to false::
 
 Using custom ViewClasses
 ========================
-
-.. versionadded:: 2.3
 
 When using JsonView/XmlView you might want to override the default serialization
 with a custom View class, or add View classes for other types.

--- a/en/core-libraries/components/security-component.rst
+++ b/en/core-libraries/components/security-component.rst
@@ -217,8 +217,6 @@ You may "unlock" these actions by listing them in ``$this->Security->unlockedAct
 ``beforeFilter``. The ``unlockedActions`` property will **not** effect other
 features of ``SecurityComponent``.
 
-.. versionadded:: 2.3
-
 .. meta::
     :title lang=en: Security
     :keywords lang=en: configurable parameters,security component,configuration parameters,invalid request,protection features,tighter security,holing,php class,meth,404 error,period of inactivity,csrf,array,submission,security class,disable security,unlockActions

--- a/en/core-libraries/helpers/cache.rst
+++ b/en/core-libraries/helpers/cache.rst
@@ -39,9 +39,8 @@ You will also need to add the CacheDispatcher to your dispatcher filters in your
         'CacheDispatcher'
     ));
 
-.. versionadded:: 2.3
-  If you have a setup with multiple domains or languages you can use
-  `Configure::write('Cache.viewPrefix', 'YOURPREFIX');` to store the view cache files prefixed.
+If you have a setup with multiple domains or languages you can use
+`Configure::write('Cache.viewPrefix', 'YOURPREFIX');` to store the view cache files prefixed.
 
 Additional Configuration Options
 --------------------------------

--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -200,9 +200,6 @@ Context factory functions are where you can add logic for checking the form
 options for the correct type of entity. If matching input data is found you can
 return an object. If there is no match return null.
 
-    .. versionchanged:: 2.5
-        The ``$secureAttributes`` parameter was added in 2.5.
-
 .. _automagic-form-elements:
 
 Creating Form Inputs

--- a/en/core-libraries/helpers/number.rst
+++ b/en/core-libraries/helpers/number.rst
@@ -9,13 +9,6 @@ to format currency, percentages, data sizes, format numbers to
 specific precisions and also to give you more flexibility with
 formatting numbers.
 
-.. versionchanged:: 2.1
-   ``NumberHelper`` have been refactored into :php:class:`CakeNumber` class to
-   allow easier use outside of the ``View`` layer.
-   Within a view, these methods are accessible via the ``NumberHelper``
-   class and you can call it as you would call a normal helper method:
-   ``$this->Number->method($args);``.
-
 .. include:: ../../core-utility-libraries/number.rst
     :start-after: start-cakenumber
     :end-before: end-cakenumber

--- a/en/core-libraries/helpers/paginator.rst
+++ b/en/core-libraries/helpers/paginator.rst
@@ -114,10 +114,6 @@ Accepted keys for ``$options``:
 * ``direction`` The default direction to use when this link isn't active.
 * ``lock`` Lock direction. Will only use the default direction then, defaults to false.
 
-  .. versionadded:: 2.5
-    You can now set the lock option to true in order to lock the sorting direction into the
-    specified direction.
-
 Assuming you are paginating some posts, and are on page one::
 
     echo $this->Paginator->sort('user_id');

--- a/en/core-libraries/helpers/text.rst
+++ b/en/core-libraries/helpers/text.rst
@@ -9,13 +9,6 @@ creating excerpts of text around chosen words or phrases,
 highlighting key words in blocks of text, and to gracefully
 truncating long stretches of text.
 
-.. versionchanged:: 2.1
-   Several of ``TextHelper`` methods have been moved into :php:class:`String`
-   class to allow easier use outside of the ``View`` layer.
-   Within a view, these methods are accessible via the `TextHelper`
-   class and you can call it as you would call a normal helper method:
-   ``$this->Text->method($args);``.
-
 .. php:method:: autoLinkEmails(string $text, array $options=array())
 
     :param string $text: The text to convert.
@@ -34,9 +27,8 @@ truncating long stretches of text.
         For more information regarding our world-famous pastries and desserts,
         contact <a href="mailto:info@example.com">info@example.com</a>
 
-    .. versionchanged:: 2.1
-        In 2.1 this method automatically escapes its input. Use the ``escape``
-        option to disable this if necessary.
+    This method automatically escapes its input. Use the ``escape``
+    option to disable this if necessary.
 
 .. php:method:: autoLinkUrls(string $text, array $htmlOptions=array())
 
@@ -47,9 +39,8 @@ truncating long stretches of text.
     strings that start with https, http, ftp, or nntp and links them
     appropriately.
 
-    .. versionchanged:: 2.1
-        In 2.1 this method automatically escapes its input. Use the ``escape``
-        option to disable this if necessary.
+    This method automatically escapes its input. Use the ``escape``
+    option to disable this if necessary.
 
 .. php:method:: autoLink(string $text, array $htmlOptions=array())
 
@@ -60,9 +51,8 @@ truncating long stretches of text.
     ``autoLinkEmails()`` on the supplied ``$text``. All URLs and emails
     are linked appropriately given the supplied ``$htmlOptions``.
 
-    .. versionchanged:: 2.1
-        In 2.1 this method automatically escapes its input. Use the ``escape``
-        option to disable this if necessary.
+    This method automatically escapes its input. Use the ``escape``
+    option to disable this if necessary.
 
 .. php:method:: autoParagraph(string $text)
 
@@ -82,8 +72,6 @@ truncating long stretches of text.
         <p>For more information<br />
         regarding our world-famous pastries and desserts.<p>
         <p>contact info@example.com</p>
-
-    .. versionadded:: 2.4
 
 .. include:: ../../core-utility-libraries/string.rst
     :start-after: start-string

--- a/en/core-libraries/helpers/time.rst
+++ b/en/core-libraries/helpers/time.rst
@@ -10,13 +10,6 @@ Time Helper has two main tasks that it can perform:
 #. It can format time strings.
 #. It can test time (but cannot bend time, sorry).
 
-.. versionchanged:: 2.1
-   ``TimeHelper`` has been refactored into the :php:class:`CakeTime` class to allow
-   easier use outside of the ``View`` layer.
-   Within a view, these methods are accessible via the `TimeHelper`
-   class and you can call it as you would call a normal helper method:
-   ``$this->Time->method($args);``.
-
 Using the Helper
 ================
 

--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -101,9 +101,7 @@ CakePHP requires that all logging adapters implement
 
 .. _file-log:
 
-.. versionadded:: 2.4
-
-As of 2.4 ``FileLog`` engine takes a few new options:
+``FileLog`` engine takes the following options:
 
 * ``size`` Used to implement basic log file rotation. If log file size
   reaches specified size the existing file is renamed by appending timestamp
@@ -116,11 +114,7 @@ As of 2.4 ``FileLog`` engine takes a few new options:
 
 .. warning::
 
-    Prior to 2.4 you had to include the suffix ``Log`` in your configuration
-    (``LoggingPack.DatabaseLog``). This is now not necessary anymore.
-    If you have been using a Log engine like ```DatabaseLogger`` that does not follow
-    the convention to use a suffix ``Log`` for your class name you have to adjust your
-    class name to ``DatabaseLog``. You should also avoid class names like ``SomeLogLog``
+    Engines have the suffix ``Log``. You should avoid class names like ``SomeLogLog``
     which include the suffix twice at the end.
 
 .. note::
@@ -128,7 +122,7 @@ As of 2.4 ``FileLog`` engine takes a few new options:
     You should configure loggers during bootstrapping. ``app/Config/app.php`` is the
     conventional place to configure log adapters.
 
-    Also new in 2.4: In debug mode missing directories will now be automatically created to avoid unnecessary
+    In debug mode missing directories will be automatically created to avoid unnecessary
     errors thrown when using the FileEngine.
 
 Error and Exception Logging
@@ -182,8 +176,6 @@ custom paths to be used::
 
 Logging to Syslog
 =================
-
-.. versionadded:: 2.4
 
 In production environments it is highly recommended that you setup your system to
 use syslog instead of the files logger. This will perform much better as any

--- a/en/core-utility-libraries/email.rst
+++ b/en/core-utility-libraries/email.rst
@@ -383,8 +383,6 @@ necessary when dealing with some Japanese ISP's::
     // to non-conformant addresses.
     $email->emailPattern($newPattern);
 
-.. versionadded:: 2.4
-
 
 Sending Messages Quickly
 ========================
@@ -421,9 +419,6 @@ Check the list of :ref:`configurations <email-configurations>` to see all accept
 
 Sending Emails from CLI
 ========================
-
-.. versionchanged:: 2.2
-    The ``domain()`` method was added in 2.2
 
 When sending emails within a CLI script (Shells, Tasks, ...) you should manually
 set the domain name for CakeEmail to use. It will serve as the host name for the

--- a/en/core-utility-libraries/file-folder.rst
+++ b/en/core-utility-libraries/file-folder.rst
@@ -551,8 +551,6 @@ File API
 
     Replaces text in a file. Returns false on failure and true on success.
 
-    .. versionadded::
-        2.5 ``File::replaceText()``
 
 .. todo::
 

--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -3,8 +3,6 @@ Hash
 
 .. php:class:: Hash
 
-.. versionadded:: 2.2
-
 Array management, if done right, can be a very powerful and useful
 tool for building smarter, more optimized code. CakePHP offers a
 very useful set of static utilities in the Hash class that allow you
@@ -41,8 +39,8 @@ Expression Types
 +--------------------------------+--------------------------------------------+
 
 All expression elements are supported by all methods. In addition to expression
-elements, you can use attribute matching with certain methods. They are ``extract()``, 
-``combine()``, ``format()``, ``check()``, ``map()``, ``reduce()``, 
+elements, you can use attribute matching with certain methods. They are ``extract()``,
+``combine()``, ``format()``, ``check()``, ``map()``, ``reduce()``,
 ``apply()``, ``sort()``, ``insert()``, ``remove()`` and ``nest()``.
 
 Attribute Matching Types
@@ -70,9 +68,6 @@ Attribute Matching Types
 | ``[text=/.../]``               | Match elements that have values matching   |
 |                                | the regular expression inside ``...``.     |
 +--------------------------------+--------------------------------------------+
-
-.. versionchanged:: 2.5
-    Matcher support was added to ``insert()`` and ``remove()``.
 
 .. php:staticmethod:: get(array $data, $path)
 
@@ -127,9 +122,6 @@ Attribute Matching Types
         $users = $this->User->find('all');
         $users = Hash::insert($users, '{n}.User.new', 'value');
 
-    .. versionchanged:: 2.5
-        As of 2.5.0 attribute matching expressions work with insert().
-
 
 .. php:staticmethod:: remove(array $data, $path = null)
 
@@ -155,8 +147,6 @@ Attribute Matching Types
 
     Using ``{n}`` and ``{s}`` will allow you to remove multiple values at once.
 
-    .. versionchanged:: 2.5
-        As of 2.5.0 attribute matching expressions work with remove()
 
 .. php:staticmethod:: combine(array $data, $keyPath = null, $valuePath = null, $groupPath = null)
 

--- a/en/core-utility-libraries/number.rst
+++ b/en/core-utility-libraries/number.rst
@@ -20,9 +20,6 @@ use the ``CakeNumber`` class::
         }
     }
 
-.. versionadded:: 2.1
-    ``CakeNumber`` has been factored out from :php:class:`NumberHelper`.
-
 .. start-cakenumber
 
 All of these functions return the formatted number; They do not
@@ -114,17 +111,12 @@ automatically echo the output into the view.
         App::uses('CakeNumber', 'Utility');
         echo CakeNumber::currency('1234.56', 'FOO');
 
-    .. versionchanged:: 2.4
-        The ``fractionExponent`` option was added.
-
 .. php:method:: defaultCurrency(string $currency)
 
     :param string $currency: Set a known currency for :php:meth:`CakeNumber::currency()`.
 
     Setter/getter for default currency. This removes the need always passing the
     currency to :php:meth:`CakeNumber::currency()` and change all currency outputs by setting other default.
-
-    .. versionadded:: 2.3 This method was added in 2.3
 
 .. php:method:: addFormat(string $formatName, array $options)
 
@@ -217,18 +209,12 @@ automatically echo the output into the view.
             'multiply' => true
         ));
 
-    .. versionadded:: 2.4
-        The ``$options`` argument with the ``multiply`` option was added.
-
 .. php:method:: fromReadableSize(string $size, $default)
 
     :param string $size: The formatted human readable value.
 
     This method unformats a number from a human readable byte size
     to an integer number of bytes.
-
-    .. versionadded:: 2.3
-        This method was added in 2.3
 
 .. php:method:: toReadableSize(string $dataSize)
 
@@ -353,9 +339,6 @@ automatically echo the output into the view.
             'thousands' => ','
         ));
         // output '+123,456.79'
-
-    .. versionadded:: 2.3
-        This method was added in 2.3
 
 .. end-cakenumber
 

--- a/en/core-utility-libraries/security.rst
+++ b/en/core-utility-libraries/security.rst
@@ -33,9 +33,6 @@ Security API
     Instead you should use the one way hashing methods provided by
     :php:meth:`~Security::hash()`
 
-    .. versionadded:: 2.2
-        ``Security::rijndael()`` was added in 2.2.
-
 .. php:staticmethod:: encrypt($text, $key, $hmacSalt = null)
 
     :param string $plain: The value to encrypt.
@@ -57,8 +54,6 @@ Security API
 
     Encrypted values can be decrypted using :php:meth:`Security::decrypt()`.
 
-    .. versionadded:: 2.5
-
 .. php:staticmethod:: decrypt($cipher, $key, $hmacSalt = null)
 
     :param string $cipher: The ciphertext to decrypt.
@@ -78,8 +73,6 @@ Security API
 
     If the value cannot be decrypted due to changes in the key or HMAC salt
     ``false`` will be returned.
-
-    .. versionadded:: 2.5
 
 .. php:staticmethod:: generateAuthKey( )
 
@@ -122,9 +115,6 @@ Security API
     provided as the ``$salt`` parameter. This allows bcrypt to reuse the same
     cost and salt values, allowing the generated hash to end up with the same
     resulting hash given the same input value.
-
-    .. versionchanged:: 2.3
-        Support for bcrypt was added in 2.3
 
 
 .. php:staticmethod:: inactiveMins( )

--- a/en/development/debugging.rst
+++ b/en/development/debugging.rst
@@ -28,10 +28,6 @@ default.
 Output from this function is only shown if the core debug variable
 has been set to a value greater than 0.
 
-.. versionchanged:: 2.1
-    The output of ``debug()`` more resembles ``var_dump()``, and uses
-    :php:class:`Debugger` internally.
-
 Debugger Class
 ==============
 
@@ -91,13 +87,6 @@ set to ``true``.
         Car::decelerate()
         Car::stop()
 
-    .. versionchanged:: 2.1
-        In 2.1 forward the output was updated for readability. See
-        :php:func:`Debugger::exportVar()`
-
-    .. versionchanged:: 2.5.0
-        The ``depth`` parameter was added.
-
 .. php:staticmethod:: Debugger::log($var, $level = 7, $depth = 3)
 
     Creates a detailed stack trace log at the time of invocation. The
@@ -105,9 +94,6 @@ set to ``true``.
     Debugger::dump(), but to the debug.log instead of the output
     buffer. Note your app/tmp directory (and its contents) must be
     writable by the web server for log() to work correctly.
-
-    .. versionchanged:: 2.5.0
-        The ``depth`` parameter was added.
 
 .. php:staticmethod:: Debugger::trace($options)
 
@@ -163,9 +149,6 @@ set to ``true``.
     variable conversions, and can be used in your own Debuggers as
     well.
 
-    .. versionchanged:: 2.1
-        This function generates different output in 2.1 forward.
-
 .. php:staticmethod:: Debugger::invoke($debugger)
 
     Replace the CakePHP Debugger with a new instance.
@@ -174,7 +157,6 @@ set to ``true``.
 
     Get the type of a variable. Objects will return their class name
 
-    .. versionadded:: 2.1
 
 Using Logging to Debug
 ======================

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -114,9 +114,6 @@ parameters that are passed to the dispatch filter. By default the base class
 will assign these settings to the ``$settings`` property after merging them with
 the defaults in the class.
 
-.. versionchanged:: 2.5
-    You can now provide constructor settings to dispatch filters in 2.5.
-
 Filter Classes
 ==============
 

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -181,8 +181,6 @@ need them, using :php:meth:`RequestHandler::addInputType()`
 Modifying the default REST Routes
 =================================
 
-.. versionadded:: 2.1
-
 If the default REST routes don't work for your application, you can modify them
 using :php:meth:`Router::resourceMap()`. This method allows you to set the
 default routes that get set with :php:meth:`Router::mapResources()`. When using
@@ -209,8 +207,6 @@ If the default routes created by :php:meth:`Router::mapResources()` don't work
 for you, use the :php:meth:`Router::connect()` method to define a custom set of
 REST routes. The ``connect()`` method allows you to define a number of different
 options for a given URL. See the section on :ref:`route-conditions` for more information.
-
-.. versionadded:: 2.5
 
 You can provide ``connectOptions`` key in the ``$options`` array for
 :php:meth:`Router::mapResources()` to provide custom setting used by

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -30,7 +30,7 @@ is also supported. To install PHPUnit run the following::
 .. note::
 
     PHPUnit 4 is not compatible with CakePHP's Unit Testing.
-    
+
     Depending on your system's configuration, you may need to run the previous
     commands with ``sudo``
 
@@ -587,8 +587,7 @@ fixture name::
 In the above example, both fixtures would be loaded from
 ``App/Test/Fixture/blog/``.
 
-.. versionchanged:: 2.5
-    As of 2.5.0 you can load fixtures in subdirectories.
+You can also load fixtures from subdirectories.
 
 Testing Models
 ==============
@@ -715,7 +714,7 @@ Say you have a typical Articles controller, and its corresponding
 model. The controller code looks like::
 
     App::uses('AppController', 'Controller');
-    
+
     class ArticlesController extends AppController {
         public $helpers = array('Form', 'Html');
 
@@ -801,7 +800,7 @@ normal. You should always return after calling ``redirect`` to prevent unwanted
 code from executing::
 
     App::uses('AppController', 'Controller');
-    
+
     class ArticlesController extends AppController {
         public function add() {
             if ($this->request->is('post')) {

--- a/en/views.rst
+++ b/en/views.rst
@@ -59,8 +59,6 @@ chapter:
 Extending Views
 ---------------
 
-.. versionadded:: 2.1
-
 View extending allows you to wrap one view in another. Combining this with
 :ref:`view blocks <view-blocks>` gives you a powerful way to keep your views
 :term:`DRY`. For example, your application has a sidebar that needs to change depending
@@ -139,8 +137,6 @@ as the ``content`` block.
 Using View Blocks
 =================
 
-.. versionadded:: 2.1
-
 View blocks replace ``$scripts_for_layout`` and provide a flexible API that
 allows you to define slots or blocks in your views/layouts that will be defined
 elsewhere. For example, blocks are ideal for implementing things such as
@@ -202,9 +198,6 @@ In the above example, the ``navbar`` block will only contain the content added
 in the first section. Since the block was defined in the child view, the
 default content with the ``<p>`` tag will be discarded.
 
-.. versionadded: 2.3
-    ``startIfEmpty()`` and ``prepend()`` were added in 2.3
-
 .. note::
 
     You should avoid using ``content`` as a block name. This is used by CakePHP
@@ -213,8 +206,6 @@ default content with the ``<p>`` tag will be discarded.
 
 Displaying Blocks
 -----------------
-
-.. versionadded:: 2.1
 
 You can display blocks using the ``fetch()`` method. ``fetch()`` will safely
 output a block, returning '' if a block does not exist::
@@ -246,13 +237,9 @@ states. You can provide a default value using the second argument:
         <?= $this->fetch('cart', 'Your cart is empty') ?>
     </div>
 
-.. versionchanged:: 2.3
-    The ``$default`` argument was added in 2.3.
 
 Using Blocks for Script and CSS Files
 -------------------------------------
-
-.. versionadded:: 2.1
 
 Blocks replace the deprecated ``$scripts_for_layout`` layout variable. Instead
 you should use blocks. The :php:class:`HtmlHelper` ties into view blocks, and its
@@ -415,8 +402,6 @@ and easy way to serve up content that isn't text/html.
 
 Using Layouts from Plugins
 --------------------------
-
-.. versionadded:: 2.1
 
 If you want to use a layout that exists in a plugin, you can use
 :term:`plugin syntax`. For example, to use the contact layout from the
@@ -600,10 +585,6 @@ if you are in the ``ContactsController`` of the Contacts plugin, the following::
 
 are equivalent and will result in the same element being rendered.
 
-.. versionchanged:: 2.1
-    The ``$options[plugin]`` option was deprecated and support for
-    ``Plugin.element`` was added.
-
 
 Creating Your Own View Classes
 ==============================
@@ -662,9 +643,6 @@ To call any view method use ``$this->method()``
     As of 2.5, you can provide a default value in case the variable is not
     already set.
 
-    .. versionchanged:: 2.5
-        The ``$default`` argument was added in 2.5.
-
 .. php:method:: getVar(string $var)
 
     Gets the value of the viewVar with the name ``$var``.
@@ -717,56 +695,40 @@ To call any view method use ``$this->method()``
     Start a capturing block for a view block. See the section on
     :ref:`view-blocks` for examples.
 
-    .. versionadded:: 2.1
-
 .. php:method:: end
 
     End the top most open capturing block. See the section on
     :ref:`view-blocks` for examples.
-
-    .. versionadded:: 2.1
 
 .. php:method:: append($name, $content)
 
     Append into the block with ``$name``. See the section on
     :ref:`view-blocks` for examples.
 
-    .. versionadded:: 2.1
-
 .. php:method:: prepend($name, $content)
 
     Prepend to the block with ``$name``. See the section on
     :ref:`view-blocks` for examples.
-
-    .. versionadded:: 2.3
 
 .. php:method:: startIfEmpty($name)
 
     Start a block if it is empty. All content in the block
     will be captured and discarded if the block is already defined.
 
-    .. versionadded:: 2.3
-
 .. php:method:: assign($name, $content)
 
     Assign the value of a block. This will overwrite any existing content. See
     the section on :ref:`view-blocks` for examples.
-
-    .. versionadded:: 2.1
 
 .. php:method:: fetch($name, $default = '')
 
     Fetch the value of a block. If a block is empty or undefined, '' will be returned.
     See the section on :ref:`view-blocks` for examples.
 
-    .. versionadded:: 2.1
-
 .. php:method:: extend($name)
 
     Extend the current view/element/layout with the named one. See the section
     on :ref:`extending-views` for examples.
-
-    .. versionadded:: 2.1
 
 .. php:attr:: layout
 
@@ -796,8 +758,6 @@ To call any view method use ``$this->method()``
 
     An instance of :php:class:`ViewBlock`. Used to provide view block
     functionality in view rendering.
-
-    .. versionadded:: 2.1
 
 More About Views
 ================

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -26,10 +26,6 @@ Before you can use the data view classes, you'll need to do a bit of setup:
    types. You can also set the component up with the ``viewClassMap`` setting,
    to map types to your custom classes and/or map other data types.
 
-.. versionadded:: 2.3
-    :php:meth:`RequestHandlerComponent::viewClassMap()` method has been added to map types to viewClasses.
-    The viewClassMap setting will not work on earlier versions.
-
 After adding ``Router::parseExtensions('json');`` to your routes file, CakePHP
 will automatically switch view classes when a request is done with the ``.json``
 extension, or the Accept header is ``application/json``.
@@ -111,9 +107,6 @@ well.
     view variables with a ``<response>`` node. You can set a custom name for
     this node using the ``_rootNode`` view variable.
 
-    .. versionadded:: 2.3
-        The ``_rootNode`` feature was added.
-
 .. php:class:: JsonView
 
     A view class for generating Json view data. See above for how you can use
@@ -126,8 +119,6 @@ well.
 
 JSONP Response
 ==============
-
-.. versionadded:: 2.4
 
 When using JsonView you can use the special view variable ``_jsonp`` to enable
 returning a JSONP response. Setting it to ``true`` makes the view class check if query


### PR DESCRIPTION
Follow up on https://github.com/cakephp/docs/pull/1280 for 3.x
