### PR TITLE
Consistent usage of cake console across docs

### DIFF
--- a/en/console-and-shells/code-generation-with-bake.rst
+++ b/en/console-and-shells/code-generation-with-bake.rst
@@ -9,7 +9,7 @@ functional application in just a few minutes. In fact, Bake is a natural step to
 take once an application has been scaffolded.
 
 Depending on how your computer is configured, you may have to set
-execute rights on the cake bash script to call it using ``./Console/cake
+execute rights on the cake bash script to call it using ``Console/cake 
 bake``. The cake console is run using the PHP CLI (command line
 interface). If you have problems running the script, ensure that
 you have the PHP CLI installed and that it has the proper modules

--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -21,7 +21,7 @@ For the first step commands outputs the available Shell Commands, including
 plugin name when applicable. (All returned possibilities, for this and the other
 sub commands, are separated by a space.) For example::
 
-    ./Console/cake Completion commands
+    Console/cake  Completion commands
 
 Returns::
 
@@ -37,7 +37,7 @@ Once the preferred command has been chosen subCommands comes in as the second
 step and outputs the possible sub command for the given shell command. For
 example::
 
-    ./Console/cake Completion subcommands bake
+    Console/cake  Completion subcommands bake
 
 Returns::
 
@@ -50,7 +50,7 @@ As the third and final options outputs options for the given (sub) command as
 set in getOptionParser. (Including the default options inherited from Shell.)
 For example::
 
-    ./Console/cake Completion options bake
+    Console/cake  Completion options bake
 
 Returns::
 

--- a/en/console-and-shells/i18n-shell.rst
+++ b/en/console-and-shells/i18n-shell.rst
@@ -18,7 +18,7 @@ command. This command will scan your entire application for ``__()`` style
 function calls, and extract the message string. Each unique string in your
 application will be combined into a single POT file::
 
-    ./Console/cake i18n extract
+    Console/cake  i18n extract
 
 The above will run the extraction shell. The result of this command will be the
 file ``app/Locale/default.pot``. You use the pot file as a template for creating
@@ -30,7 +30,7 @@ Generating POT Files for Plugins
 
 You can generate a POT file for a specific plugin using::
 
-    ./Console/cake i18n extract --plugin <Plugin>
+    Console/cake  i18n extract --plugin <Plugin>
 
 This will generate the required POT files used in the plugins.
 
@@ -40,7 +40,7 @@ Excluding Folders
 You can pass a comma separated list of folders that you wish to be excluded.
 Any path containing a path segment with the provided values will be ignored::
 
-    ./Console/cake i18n extract --exclude Test,Vendor
+    Console/cake  i18n extract --exclude Test,Vendor
 
 Skipping Overwrite Warnings for Existing POT Files
 --------------------------------------------------
@@ -48,7 +48,7 @@ Skipping Overwrite Warnings for Existing POT Files
 By adding --overwrite, the shell script will no longer warn you if a POT file
 already exists and will overwrite by default::
 
-    ./Console/cake i18n extract --overwrite
+    Console/cake  i18n extract --overwrite
 
 Extracting Messages from the CakePHP Core Libraries
 ---------------------------------------------------
@@ -57,11 +57,11 @@ By default, the extract shell script will ask you if you like to extract
 the messages used in the CakePHP core libraries. Set --extract-core to yes or
 no to set the default behavior::
 
-    ./Console/cake i18n extract --extract-core yes
+    Console/cake  i18n extract --extract-core yes
 
     or
 
-    ./Console/cake i18n extract --extract-core no
+    Console/cake  i18n extract --extract-core no
 
 
 Create the Tables used by TranslateBehavior
@@ -70,7 +70,7 @@ Create the Tables used by TranslateBehavior
 The i18n shell can also be used to initialize the default tables used by the
 :php:class:`TranslateBehavior`::
 
-    ./Console/cake i18n initdb
+    Console/cake  i18n initdb
 
 This will create the ``i18n`` table used by translate behavior.
 

--- a/en/console-and-shells/upgrade-shell.rst
+++ b/en/console-and-shells/upgrade-shell.rst
@@ -8,21 +8,21 @@ from 1.3 to 2.0.
 
 To run all upgrade steps::
 
-    ./Console/cake upgrade all
+    Console/cake  upgrade all
 
 If you would like to see what the shell will do without modifying files perform
 a dry run first with --dry-run::
 
-    ./Console/cake upgrade all --dry-run
+    Console/cake  upgrade all --dry-run
 
 To upgrade your plugin run the command::
 
-    ./Console/cake upgrade all --plugin YourPluginName
+    Console/cake  upgrade all --plugin YourPluginName
 
 You are able to run each upgrade step individually. To see all the steps
 available run the command::
 
-    ./Console/cake upgrade --help
+    Console/cake  upgrade --help
 
 Or visit the `API docs <http://api.cakephp.org/2.4/class-UpgradeShell.html>`_ for more info.
 
@@ -70,7 +70,7 @@ Your folder structure should look like this now::
 Now we can run the upgrade shell by ``cd``'ing into your ``app`` folder and
 running the command::
 
-    ./Console/cake upgrade all
+    Console/cake  upgrade all
 
 This will do **most** of the work to upgrade your app to 2.x. Check things over
 in your upgraded ``app`` folder. If everything looks good then congratulate

--- a/en/installation.rst
+++ b/en/installation.rst
@@ -115,7 +115,7 @@ In this example, we will be using CakePHP's console to run PHP's built-in
 web server which will make your application available at
 ``http://host:port``.  From the ``App/Console`` directory, execute::
     
-    $ ./cake server
+    Console/cake server
 
 By default, without any arguments provided, this will serve your application
 at ``http://localhost:8765/``.
@@ -124,7 +124,7 @@ If you have something conflicting with ``localhost`` or ``port 8765``, you can
 tell the CakePHP console to run the web server on a specific host and/or port
 utilizing the following arguments::
 
-    $ ./cake server -H 192.168.13.37 -p 5673
+    Console/cake server -H 192.168.13.37 -p 5673
 
 This will serve your application at ``http://192.168.13.37:5673/``. 
 

--- a/en/tutorials-and-examples/simple-acl-controlled-application/part-two.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/part-two.rst
@@ -25,12 +25,12 @@ file as shown below::
 Finally execute the following command in the CakePHP console::
 
 
-    ./Console/cake AclExtras.AclExtras aco_sync
+    Console/cake  AclExtras.AclExtras aco_sync
 
 You can get a complete guide for all available commands like this::
 
-    ./Console/cake AclExtras.AclExtras -h
-    ./Console/cake AclExtras.AclExtras aco_sync -h
+    Console/cake  AclExtras.AclExtras -h
+    Console/cake  AclExtras.AclExtras aco_sync -h
 
 Once populated your `acos` table proceed to create your application permissions.
 
@@ -42,7 +42,7 @@ be providing one. To allow ARO's access to ACO's from the shell interface use
 the AclShell. For more information on how to use it consult the AclShell help
 which can be accessed by running::
 
-    ./Console/cake acl --help
+    Console/cake  acl --help
 
 Note: \* needs to be quoted ('\*')
 

--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -228,7 +228,7 @@ table error ("Error: Database table acos for model Aco was not
 found."). To remove these errors we need to run a schema file. In a
 shell run the following::
 
-    ./Console/cake schema create DbAcl
+    Console/cake  schema create DbAcl
 
 This schema will prompt you to drop and create the tables. Say yes
 to dropping and creating the tables.
@@ -373,7 +373,7 @@ few ways to manually create ACO's though. You can create ACO
 objects from the Acl shell or You can use the ``AclComponent``.
 Creating Acos from the shell looks like::
 
-    ./Console/cake acl create aco root controllers
+    Console/cake  acl create aco root controllers
 
 While using the AclComponent would look like::
 


### PR DESCRIPTION
The usage of `./` vs. not was pretty much even throughout the docs.
