### PR TITLE
Corrected BaseLog path from Log to Log/Engine.

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -50,7 +50,7 @@ When configuring a log stream the ``engine`` parameter is used to
 locate and load the log handler. All of the other configuration
 properties are passed to the log stream's constructor as an array.::
 
-    App::uses('BaseLog', 'Log');
+    App::uses('BaseLog', 'Log/Engine');
 
     class DatabaseLog extends BaseLog {
         public function __construct($options = array()) {


### PR DESCRIPTION
Documentation for creating custom log streams has incorrect package path to BaseLog.
