### PR TITLE
Composer installation instructions updated for 2.5

### DIFF
--- a/en/installation/advanced-installation.rst
+++ b/en/installation/advanced-installation.rst
@@ -76,7 +76,7 @@ changing ``CAKE_CORE_INCLUDE_PATH`` to be a relative path::
 
     define(
         'CAKE_CORE_INCLUDE_PATH',
-        ROOT . '/Vendor/pear-pear.cakephp.org/CakePHP'
+        ROOT . '/Vendor/cakephp/cakephp/lib'
     );
 
 .. note::


### PR DESCRIPTION
Cake is installed to a different directly, contrary to the previous documentation.
