### PR TITLE
Correction de l'affichage d'un blocd de doc

### DIFF
--- a/fr/core-libraries/helpers/form.rst
+++ b/fr/core-libraries/helpers/form.rst
@@ -384,6 +384,7 @@ ce champ. En interne ``input()`` délègue aux autre méthode du FormHelper.
 
        echo $this->Form->end('Add');
 
+
     Un exemple plus complet montrant quelques options pour le champ de date ::
 
         echo $this->Form->input('birth_dt', array(


### PR DESCRIPTION
Entre :

"Par exemple, supposons que votre model User contient les champs username (varchar), password (varchar), approved (datetime) et quote (text). Vous pouvez utiliser la méthode input() de l’Helper Formulaire (Formhelper) pour créer une entrée appropriée pour tous les champs du formulaire.:"

et :

http://book.cakephp.org/2.0/fr/core-libraries/helpers/form.html#FormHelper::inputs

tout le bloc était pris comme du code. 
S'en suivait une lecture difficile.
