### PR TITLE
Correction d'une erreur de syntaxe

### DIFF
--- a/fr/core-libraries/helpers/form.rst
+++ b/fr/core-libraries/helpers/form.rst
@@ -592,7 +592,7 @@ comme les attributs html. Ce qui suit va couvrir les options spécifiques de
   afficher dans le label qui accompagne le input::
   
       echo $this->Form->input('User.name', array(
-          'label' => 'Alias de l'user'
+          'label' => "Alias de l'user"
       ));
 
   Affichera:


### PR DESCRIPTION
J'ai fait le choix de mettre des doubles quotes plutôt que d'échapper l'apostrophe, c'est comme ça que je fais systématiquement lorsque la chaîne devrait être échappée.
