### PR TITLE
Clarifying behavior of 'unique' option in HABTM

### DIFF
--- a/en/models/associations-linking-models-together.rst
+++ b/en/models/associations-linking-models-together.rst
@@ -685,8 +685,8 @@ Possible keys for HABTM association arrays include:
       and leave any existing relationship records in place, possibly
       resulting in duplicate relationship records.
     - When set to ``keepExisting``, the behavior is similar to `true`,
-      but with an additional check so that if a any of the records
-      to be added duplicates and existing relationship record, the
+      but with an additional check so that if any of the records
+      to be added are duplicates of an existing relationship record, the
       existing relationship record is not deleted, and the duplicate
       is ignored.  This can be useful if, for example, the join table
       has additional data in it that needs to be retained.


### PR DESCRIPTION
The docs here were unclear and - in the case of `false` - not even sensical, probably due to some errant edit history.  I've edited the copy to reflect the behavior as I understand it after reading the code and doing some tests to confirm.
