### PR TITLE
Update password field length in db.

### DIFF
--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -15,7 +15,7 @@ First, let's create a new table in our blog database to hold our users' data::
     CREATE TABLE users (
         id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
         username VARCHAR(50),
-        password VARCHAR(50),
+        password VARCHAR(255),
         role VARCHAR(20),
         created DATETIME DEFAULT NULL,
         modified DATETIME DEFAULT NULL


### PR DESCRIPTION
Blowfish hashes generated by password_hash() are 60 chars long, moreover
PHP manual recommends using length 255 to be future proof.
