### PR TITLE
don't forget to call clear() instead of create()

### DIFF
--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -148,7 +148,7 @@ Otherwise a new record is created::
 
 .. tip::
 
-    When calling save in a loop, don't forget to call ``create()``.
+    When calling save in a loop, don't forget to call ``clear()``.
 
 
 If you want to update a value, rather than create a new one, make sure


### PR DESCRIPTION
we had a problem in one of our apps:

let's assume the following code:

foreach ($posts as $post) {
  $this->Post->create();
  $this->Post->id = $post['Post']['id'];
  $this->Post->save(['column3' => 'foo', 'column4' => 'bar']);
}

When calling create() instead of clear(), cakePHP saves default values to columns, which are not part of the save()-call. (e.g. 'column1' defaults to boolean false, but can have changed to "true" due to another save-operation). 

When calling clear(), cakePHP saves only the mentioned columns.
