### PR TITLE
Fix capitalization of header for is('ajax')

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -221,7 +221,7 @@ There are several built-in detectors that you can use:
 * ``is('head')`` Check to see whether the current request is HEAD.
 * ``is('options')`` Check to see whether the current request is OPTIONS.
 * ``is('ajax')`` Check to see whether the current request came with
-  X-Requested-with = XmlHttpRequest.
+  X-Requested-With = XMLHttpRequest.
 * ``is('ssl')`` Check to see whether the request is via SSL
 * ``is('flash')`` Check to see whether the request has a User-Agent of Flash
 * ``is('mobile')`` Check to see whether the request came from a common list


### PR DESCRIPTION
The code makes a case-sensitive compare to  'XMLHttpRequest', so anyone manually setting it to XmlHttpRequest per this doc would run into issues of it not showing up as is('ajax').  I also capitalized With in the header name, since that's what jQuery sends, and case doesn't matter there (since it's pulled from the $_SERVER array which is all-caps)
