### PR TITLE
Update advanced-installation.rst

### DIFF
--- a/en/installation/advanced-installation.rst
+++ b/en/installation/advanced-installation.rst
@@ -58,7 +58,7 @@ Once Composer has finished running you should have a directory structure that lo
             bin/
             autoload.php
             composer/
-            pear-pear.cakephp.org/
+            cakephp/
 
 You are now ready to generate the rest of your application skeleton::
 


### PR DESCRIPTION
fixes installation path.

"pear-pear.cakephp.org/" is install by pear repo.
