### PR TITLE
stackTrace()

### DIFF
--- a/en/appendices/2-6-migration-guide.rst
+++ b/en/appendices/2-6-migration-guide.rst
@@ -8,7 +8,7 @@ Basics.php
 ==========
 
 - ``stackTrace()`` has been added as a convenience wrapper function for ```Debugger::trace()``.
-  It directly echos just as ``debug()`` does.
+  It directly echos just as ``debug()`` does. But only if debug level is on.
 
 Console
 =======

--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -129,6 +129,10 @@ such as debugging and translating content.
     which it was called.
     Also see :doc:`/development/debugging`
 
+.. php:function:: stackTrace(array $options = array())
+
+    If the application's DEBUG level is non-zero, the stack trace is printed out.
+
 .. php:function:: env(string $key)
 
     Gets an environment variable from available sources. Used as a


### PR DESCRIPTION
Docs for https://github.com/cakephp/cakephp/pull/3919
The 3.0 migration docs probably doesn't need to mention it again.
