### PR TITLE
Update the 'idField' and 'valueField' options

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -813,10 +813,10 @@ a table::
     }
 
 When calling ``list`` you can configure the fields used for the key and value with
-the ``fields`` option::
+the ``idField`` and ``valueField`` options respectively::
 
     $query = $articles->find('list', [
-        'fields' => ['slug', 'title']
+        'idField' => 'slug', 'valueField' => 'title']
     ]);
     $data = $query->toArray();
 
@@ -830,7 +830,7 @@ Results can be grouped into nested sets. This is useful when you want
 bucketed sets, or want to build ``<optgroup>`` elements with FormHelper::
 
     $query = $articles->find('list', [
-        'fields' => ['author_id', 'slug', 'title'],
+        'idField' => 'slug', 'valueField' => 'title'],
         'groupField' => ['author_id']
     ]);
     $data = $query->toArray();


### PR DESCRIPTION
The 'fields' option is no longer used, there are now options 'idField' and 'valueField' which was not accurate in the documentation.
