### PR TITLE
correct /src/Plugin/ to /plugins/

### DIFF
--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -310,7 +310,7 @@ For example::
         }
     }
     
-This would render ``/plugins/Users/Template/UserDetails/custom_file.ctp``
+This would render ``/plugins/Users/src/Template/UserDetails/custom_file.ctp``
 
 Flow Control
 ------------


### PR DESCRIPTION
small folder structure correction for plugins
If you internally decide to use either src/ or /src/, let me know I'll be happy to give a hand
