### PR TITLE
Update global-constants-and-functions.rst

### DIFF
--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -181,7 +181,7 @@ Most of the following constants refer to paths in your application.
 
 .. php:const:: APP
 
-   Path to the application's directory.
+   Absolute path to the applications directory, including a trailing slash.
 
 .. php:const:: APP_DIR
 


### PR DESCRIPTION
Improved the wording and included that it will include the trailing slash for you. So if you are doing APP . WEBROOT_DIR you don't accidentally include an extra DS.
