### PR TITLE
Update views.rst

### DIFF
--- a/en/views.rst
+++ b/en/views.rst
@@ -72,13 +72,13 @@ that change:
 .. code-block:: php
 
     // /src/Template/Common/view.ctp
-    <h1><?= $this->fetch('title') ?></h1>
-    <?= $this->fetch('content') ?>
+    <h1><?php echo $this->fetch('title') ?></h1>
+    <?php echo $this->fetch('content') ?>
 
     <div class="actions">
         <h3>Related actions</h3>
         <ul>
-        <?= $this->fetch('sidebar') ?>
+        <?php echo $this->fetch('sidebar') ?>
         </ul>
     </div>
 
@@ -109,7 +109,7 @@ uncaptured content from the extending view. Assuming our view file has a
 
     // The remaining content will be available as the 'content' block
     // in the parent view.
-    <?= h($post['Post']['body']) ?>
+    <?php echo h($post['Post']['body']) ?>
 
 The post view above shows how you can extend a view, and populate a set of
 blocks. Any content not already in a defined block will be captured and put
@@ -191,7 +191,7 @@ Displaying Blocks
 You can display blocks using the ``fetch()`` method. ``fetch()`` will output
 a block, returning '' if a block does not exist::
 
-    <?= $this->fetch('sidebar') ?>
+    <?php echo $this->fetch('sidebar') ?>
 
 You can also use fetch to conditionally show content that should surround a
 block should it exist. This is helpful in layouts, or extended views where you
@@ -203,7 +203,7 @@ want to conditionally show headings or other markup:
     <?php if ($this->fetch('menu')): ?>
     <div class="menu">
         <h3>Menu options</h3>
-        <?= $this->fetch('menu') ?>
+        <?php echo $this->fetch('menu') ?>
     </div>
     <?php endif; ?>
 
@@ -215,7 +215,7 @@ states. You can provide a default value using the second argument:
 
     <div class="shopping-cart">
         <h3>Your Cart</h3>
-        <?= $this->fetch('cart', 'Your cart is empty') ?>
+        <?php echo $this->fetch('cart', 'Your cart is empty') ?>
     </div>
 
 
@@ -239,9 +239,9 @@ when used with the ``block = true`` option:
     <!DOCTYPE html>
     <html lang="en">
         <head>
-        <title><?= $this->fetch('title') ?></title>
-        <?= $this->fetch('script') ?>
-        <?= $this->fetch('css') ?>
+        <title><?php echo $this->fetch('title') ?></title>
+        <?php echo $this->fetch('script') ?>
+        <?php echo $this->fetch('css') ?>
         </head>
         // rest of the layout follows
 
@@ -252,7 +252,7 @@ block the scripts and CSS go to::
     $this->Html->script('carousel', ['block' => 'scriptBottom']);
 
     // in your layout
-    <?= $this->fetch('scriptBottom') ?>
+    <?php echo $this->fetch('scriptBottom') ?>
 
 .. _view-layouts:
 
@@ -297,7 +297,7 @@ might look like:
    </div>
 
    <!-- Here's where I want my views to be displayed -->
-   <?= $this->fetch('content') ?>
+   <?php echo $this->fetch('content') ?>
 
    <!-- Add a footer to each displayed page -->
    <div id="footer">...</div>
@@ -487,7 +487,7 @@ like the following:
     <?php foreach ($posts as $post): ?>
     <ol>
     <?php foreach ($posts as $post): ?>
-          <li><?= $post['Post']['title'] ?></li>
+          <li><?php echo $post['Post']['title'] ?></li>
     <?php endforeach; ?>
     </ol>
 


### PR DESCRIPTION
Dropped short tag echo notation.
1. It's used inconsistently
2. It adds a dependency on the server's php.ini to have `short_tags` set to on. Just echoing everything makes sure it works on every server, regardless of it's configuration.
