### PR TITLE
Removed not needed 'foreach' in 'Elements' section

### DIFF
--- a/en/views.rst
+++ b/en/views.rst
@@ -484,7 +484,6 @@ like the following:
 
     <h2>Latest Posts</h2>
     <?php $posts = $this->requestAction('posts/index?sort=created&direction=asc&limit=5'); ?>
-    <?php foreach ($posts as $post): ?>
     <ol>
     <?php foreach ($posts as $post): ?>
           <li><?= $post['Post']['title'] ?></li>


### PR DESCRIPTION
Removed not needed 'foreach' in 'Elements' section's code block
