### PR TITLE
add CacheHelper's removal to migration guide

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -912,7 +912,7 @@ JsHelper
 CacheHelper
 --------
 
-- ``CacheHelper`` has been removed and is going to be provided into a standalone plugin.
+- ``CacheHelper`` has been removed and is going to be provided as a standalone plugin.
 
 I18n
 ====


### PR DESCRIPTION
related to cakephp/cakephp@6441e41
