### PR TITLE
Update cakephp-structure.rst

### DIFF
--- a/en/getting-started/cakephp-structure.rst
+++ b/en/getting-started/cakephp-structure.rst
@@ -94,9 +94,7 @@ View Extensions ("Helpers")
 
 A Helper is a class that aids in view logic. Much like a component
 used among controllers, helpers allow presentational logic to be
-accessed and shared between views. One of the core helpers,
-JsHelper, makes AJAX requests within views much easier and comes with 
-support for jQuery (default), Prototype and Mootools.
+accessed and shared between views.
 
 Most applications have pieces of view code that are used
 repeatedly. CakePHP facilitates view code reuse with layouts and


### PR DESCRIPTION
JsHelper has (unfortunately IMHO) been removed from the 3.0 core, so this info is now outdated.
