### PR TITLE
Remove JsHelper reference

### DIFF
--- a/en/views.rst
+++ b/en/views.rst
@@ -615,7 +615,7 @@ To call any view method use ``$this->method()``
 
     Generates a unique non-random DOM ID for an object, based on the
     object type and URL. This method is often used by helpers that need
-    to generate unique DOM ID's for elements such as the :php:class:`JsHelper`::
+    to generate unique DOM ID's for elements::
 
         $uuid = $this->uuid(
           'form',


### PR DESCRIPTION
Removed another JsHelper reference, since JsHelper was removed from the 3.0 core.
