### PR TITLE
Prevent user from overwritting required code

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -373,7 +373,10 @@ back at our Articles model and make a few adjustments::
     use Cake\Validation\Validator;
 
     class ArticlesTable extends Table {
-
+        public function initialize(array $config) {
+            $this->addBehavior('Timestamp');
+        }
+        
         public function validationDefault(Validator $validator) {
             $validator
                 ->notEmpty('title')


### PR DESCRIPTION
As users advance in tutorial, they're told to change the previously created ArticlesTable.php file and if it does not contains initialize() with Timestamp behaviour, it'll cause the views containing <?= $article->created->format(DATE_RFC850) ?> (index.ctp and view.ctp) to fail as users creates new articles that will have 'created' as null. Better to maintain the function there as readers could copy and paste like I just did and broke the blog index and view.
