### PR TITLE
Updating docs - HABTM keepExisting key set on bake

### DIFF
--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -915,8 +915,9 @@ named differently and its behavior is more predictable.
     keys, you can prevent losing the extra field values by setting
     ``'unique'`` array key to ``'keepExisting'``. You could think of
     this similar to 'unique' => true, but without losing data from
-    the extra fields during save operation. See: :ref:`HABTM
-    association arrays <ref-habtm-arrays>`.
+    the extra fields during save operation. Additionally, if you used
+    bake in order to create the models, this is set automatically. 
+    See: :ref:`HABTM association arrays <ref-habtm-arrays>`.
 
 However, in most cases it's easier to make a model for the join table
 and setup hasMany, belongsTo associations as shown in example above


### PR DESCRIPTION
During bake, `'unique'` array key is set to `'keepExisting'` automatically. This overwrites the prescribed default.
