### PR TITLE
Note about how to properly set up composer namespaces for plugins.

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -466,15 +466,16 @@ applications:
 Publish Your Plugin
 ===================
 
-You can add your plugin on `plugins.cakephp.org <http://plugins.cakephp.org>`_.
-But more importantly, create a composer.json file and publish your plugin at `packagist.org <https://packagist.org/>`_.
+You can add your plugin to `plugins.cakephp.org <http://plugins.cakephp.org>`_.
+
+Also, you might want to create a composer.json file and publish your plugin at `packagist.org <https://packagist.org/>`_.
 This way it can easily be used through composer.
 
-Chose a semantically meaningful name for the package name. This should ideally be prefixed with the dependency, in this case "cakephp" as the framework.
+Choose a semantically meaningful name for the package name. This should ideally be prefixed with the dependency, in this case "cakephp" as the framework.
 The vendor name will usually be your GitHub username.
 Do **not** use the CakePHP namespace (cakephp) as this is reserved to CakePHP owned plugins.
 The convention is to use lowercase letters and dashes as separator.
 
 So if you created a plugin "Logging" with your GitHub account "FooBar", a good name
 would be `foo-bar/cakephp-logging`.
-And the CakePHP owned "Localized" plugin can be found under `cakephp/localized` respectivly.
+And the CakePHP owned "Localized" plugin can be found under `cakephp/localized` respectively.


### PR DESCRIPTION
Currently there are pretty wild plugin names out there - and some even violate the CakePHP namespace.
This should clear things up and provide clear conventions around it

FooBar username
Logging plugin

=> foo-bar/cakephp-logging

Just as done by
- https://github.com/josegonzalez/cakephp-csvview ("josegonzalez/cakephp-csvview")
- https://github.com/dereuromark/cakephp-tools ("dereuromark/cakephp-tools")
- https://github.com/cakephp/localized (CakePHP owned - "cakephp/localized")

**And violated by**
- https://github.com/jadb/cakephp-monolog - [ticket pending](https://github.com/jadb/cakephp-monolog/issues/11)
