### PR TITLE
Add file name for easy understanding

### DIFF
--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -23,6 +23,7 @@ However, if you want to have custom logic in your entities you will need to
 create classes. By convention entity classes live in ``src/Model/Entity/``. If
 our application had an ``articles`` table we could create the following entity::
 
+    // src/Model/Entity/Article.php
     namespace App\Model\Entity;
 
     use Cake\ORM\Entity;


### PR DESCRIPTION
First I was thinking if we do 
src/Model/Table/ArticlesTable.php
src/Controller/ArticlesController.php

In entities we do the same and...
src/Model/Entity/ArticlesEntity.php
But this is wrong.

It should be Article.php and this is not written in "Creating entity classes", so I included the file name to be easy to understand. I followed the pattern found in line 295.
