### PR TITLE
Update helpers.rst

### DIFF
--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -117,8 +117,8 @@ configuration options that cannot be included as part of a class declaration,
 you can set those in your controller's beforeRender callback::
 
     class PostsController extends AppController {
-        public function beforeRender() {
-            parent::beforeRender();
+        public function beforeRender(Event $event) {
+            parent::beforeRender($event);
             $this->helpers['CustomStuff'] = $this->_getCustomStuffConfig();
         }
     }


### PR DESCRIPTION
Just added $event for the beforeRender method for newbies and consistency throughout the docs. Otherwise, it throws errors and some people may not know why if the docs are shown without it.
