### PR TITLE
Fixed statement about logging unknown scopes

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -256,9 +256,9 @@ you do other less critical logs.
 
 CakePHP exposes this concept as logging scopes. When log messages are written
 you can include a scope name. If there is a configured logger for that scope,
-the log messages will be directed to those loggers. If a log message is written
-to an unknown scope, loggers that handle that level of message will log the
-message. For example::
+the log messages will be directed to those loggers.
+If a log message is written to an unknown scope, no logger will log the message,
+even if it handles that level of message. For example::
 
     // Configure tmp/logs/shop.log to receive the two configured types (log levels), but only
     // those with `orders` and `payments` as scope
@@ -279,7 +279,7 @@ message. For example::
 
     CakeLog::warning('This gets written only to shops stream', 'orders');
     CakeLog::warning('This gets written to both shops and payments streams', 'payments');
-    CakeLog::warning('This gets written to both shops and payments streams', 'unknown');
+    CakeLog::warning('This gets written to neither of both streams', 'unknown');
 
 In order for scopes to work, you **must** do a few things:
 


### PR DESCRIPTION
I just setup a simple test enviornment and could confirm this.
But please soneone with some more insight should verify this.

My config:

``` php
// Default debug logger
CakeLog::config('debug', array(
    'engine' => 'File',
    'types' => array('notice', 'info', 'debug'),
    'file' => 'debug',
));
// Default error logger
CakeLog::config('error', array(
    'engine' => 'File',
    'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
    'file' => 'error',
));

// Custom logger for a single scope
CakeLog::config('scoped', array(
        'engine' => 'File',
        'scopes' => array('known-scope'),
        'types' => array('warning', 'error'),
        'file' => 'scoped'
    )
);
```

My warnings

``` php
CakeLog::warning('this is a normal warning');
CakeLog::warning('this is a known scoped warning', 'known-scope');
CakeLog::warning('this is an unknown scoped warning', 'foo');
```

error.log

```
2014-08-07 01:06:31 Warning: this is a normal warning
2014-08-07 01:06:31 Warning: this is a known scoped warning
2014-08-07 01:06:31 Warning: this is an unknown scoped warning
```

scoped.log

```
2014-08-07 01:06:31 Warning: this is a known scoped warning
```
