### PR TITLE
Remove duplicate paragraph in authentication.rst

### DIFF
--- a/fr/core-libraries/components/authentication.rst
+++ b/fr/core-libraries/components/authentication.rst
@@ -548,27 +548,6 @@ vous connecter.
     ``env('SCRIPT_NAME)``. Vous devez utiliser une chaîne statique si vous
     voulez un hachage permanent dans des environnements multiples.
 
-Creating custom password hasher classes
----------------------------------------
-Custom password hasher classes need to extend the ``AbstractPasswordHasher``
-class and need to implement the abstract methods ``hash()`` and ``check()``.
-In ``src/Auth/CustomPasswordHasher.php`` you could put
-the following::
-
-    namespace App\Auth;
-
-    use Cake\Auth\AbstractPasswordHasher;
-
-    class CustomPasswordHasher extends AbstractPasswordHasher {
-        public function hash($password) {
-            // stuff here
-        }
-
-        public function check($password, $hashedPassword) {
-            // stuff here
-        }
-    }
-
 Connecter les utilisateurs manuellement
 ---------------------------------------
 


### PR DESCRIPTION
https://github.com/cakephp/docs/blob/3.0/fr/core-libraries/components/authentication.rst#cr%C3%A9er-des-classes-de-hash-de-mot-de-passe-personnalis%C3%A9
