### PR TITLE
table-objects, fix deleteAll example

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -2149,7 +2149,8 @@ delete for those not in the list::
 
     $present = (new Collection($entity->comments))->extract('id');
     TableRegistry::get('Comments')->deleteAll([
-        'conditions' => 'article_id' => $article->id, 'id NOT IN' => $present
+        'article_id' => $article->id,
+        'id NOT IN' => $present
     ]);
 
 As you can see, this also helps creating solutions where an association needs to


### PR DESCRIPTION
fixing wrong options array for deleteAll()
