### PR TITLE
3.0 doc correct model link on index page

### DIFF
--- a/en/index.rst
+++ b/en/index.rst
@@ -43,7 +43,7 @@ a CakePHP application:
 * :doc:`Views </views>` are the presentation layer in your application. They
   give you powerful tools to create HTML, JSON and the other outputs your
   application needs.
-* :doc:`Models </models>` are the key ingredient in any application. They handle
+* :doc:`Models </orm>` are the key ingredient in any application. They handle
   validation, and domain logic within your application.
 
 Getting Help


### PR DESCRIPTION
Following #1595, I figured out that `model.rst` has been replaced by `orm.rst`.
I did correct the link once again and built the doc locally to make sure it's ok this time.
aplologies
