### PR TITLE
3.0 correct link to ProGit book

### DIFF
--- a/en/contributing/code.rst
+++ b/en/contributing/code.rst
@@ -23,7 +23,7 @@ Set up your user information with your name/handle and working email address::
 .. note::
 
     If you are new to Git, we highly recommend you to read the excellent and free
-    `ProGit <http://progit.org>`_ book.
+    `ProGit <git-scm.com/book/>`_ book.
 
 Get a clone of the CakePHP source code from GitHub:
 


### PR DESCRIPTION
- correct the link to `Progit` as it doesn't seems to be http://progit.org anymore.
- also correct the git clone command line as specified here : https://help.github.com/articles/fork-a-repo

if this is good to merge, let me know as I already prepare similar change for master branch.
