### PR TITLE
master - update `Progit` website link

### DIFF
--- a/en/contributing/code.rst
+++ b/en/contributing/code.rst
@@ -23,7 +23,7 @@ Set up your user information with your name/handle and working email address::
 .. note::
 
     If you are new to Git, we highly recommend you to read the excellent and free
-    `ProGit <http://progit.org>`_ book.
+    `ProGit <http://git-scm.com/book/>`_ book.
 
 Get a clone of the CakePHP source code from GitHub:
 


### PR DESCRIPTION
correct link to "Progit" website

backport of  #1614
