### PR TITLE
Removes the CLA from the Contributors/Code guide

### DIFF
--- a/en/contributing/code.rst
+++ b/en/contributing/code.rst
@@ -129,8 +129,8 @@ branch, as you cannot edit it once the pull request is created.
 
     Remember that all code you contribute to CakePHP will be licensed under the
     MIT License, and the `Cake Software Foundation <http://cakefoundation.org/pages/about>`_
-    will become the owner of any contributed code and all contributed code is
-    subject to the `Contributors license agreement <http://cakefoundation.org/pages/cla>`_.
+    will become the owner of any contributed code. Contributors should follow the 
+    `CakePHP Community Guidelines <http://community.cakephp.org/guidelines>`_.
 
 All bug fixes merged into a maintenance branch will also be merged into upcoming
 releases periodically by the core team.


### PR DESCRIPTION
Replaces with the Community Guidelines
References: #880
