### PR TITLE
3.0 Update components.rst

### DIFF
--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -263,12 +263,12 @@ Component API
 Callbacks
 ---------
 
-.. php:method:: initialize(Event $event, Controller $controller)
+.. php:method:: initialize(Event $event)
 
     Is called before the controller's
     beforeFilter method.
 
-.. php:method:: startup(Event $event, Controller $controller)
+.. php:method:: startup(Event $event)
 
     Is called after the controller's beforeFilter
     method but before the controller executes the current action


### PR DESCRIPTION
Including a param for Controller throws a warning that no second argument is passed. I assume you are now supposed to `$event->getSubject()` instead of being passed a controller, or use `getController()` from the constructors collection.
