### PR TITLE
3.0 remove exception.rst

### DIFF
--- a/en/development.rst
+++ b/en/development.rst
@@ -11,7 +11,6 @@ debugging, and testing will be covered.
     development/configuration
     development/routing
     development/sessions
-    development/exceptions
     development/errors
     development/debugging
     development/testing

--- a/en/development/exceptions.rst
+++ b/en/development/exceptions.rst
@@ -1,8 +1,0 @@
-Exceptions
-##########
-
-See the documentation on :doc:`/development/errors` for more information.
-
-.. meta::
-    :title lang=en: Exceptions
-    :keywords lang=en: uncaught exceptions,stack traces,logic errors,anonymous functions,renderer,html page,error messages,flexibility,lib,array,cakephp,php

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -509,7 +509,7 @@ This logic deletes the article specified by $id, and uses
 message after redirecting them on to ``/articles``. If the user attempts to
 do a delete using a GET request, the 'allowMethod' will throw an Exception.
 Uncaught exceptions are captured by CakePHP's exception handler, and a nice error page is
-displayed. There are many built-in :doc:`/development/exceptions` that can
+displayed. There are many built-in :doc:`Exceptions </development/errors>` that can
 be used to indicate the various HTTP errors your application might need
 to generate.
 


### PR DESCRIPTION
The `exception` page is totally empty and refers to the `error/exception` page.
![image](https://cloud.githubusercontent.com/assets/4977112/4023727/ca0f9cd6-2ba1-11e4-8303-6a7e3ca93706.png)

I propose to remove it, and I updated the toc and links.

We could also rename the `error.rst` to `error-exceptions.rst` if it does make sense
