### PR TITLE
3.0 use ``true``/``false``

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -124,7 +124,7 @@ All :php:class:`Cake\\Cache\\Cache\\CacheEngine` methods now honor/are responsib
 configured key prefix. The :php:meth:`Cake\\Cache\\CacheEngine::write()` no longer permits setting
 the duration on write - the duration is taken from the cache engine's runtime config. Calling a
 cache method with an empty key will now throw an :php:class:`InvalidArgumentException`, instead
-of returning false.
+of returning ``false``.
 
 
 Core

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -291,7 +291,7 @@ create a file at a given path::
 
 If the Shell is interactive, a warning will be generated, and the user asked if
 they want to overwrite the file if it already exists.  If the shell's
-interactive property is false, no question will be asked and the file will
+interactive property is ``false``, no question will be asked and the file will
 simply be overwritten.
 
 Console Output
@@ -608,7 +608,7 @@ parsed parameters.::
     $parser->addOption('no-commit', ['boolean' => true]);
 
 With this option, when calling a shell like ``cake myshell --no-commit something``
-the no-commit param would have a value of true, and 'something'
+the no-commit param would have a value of ``true``, and 'something'
 would be a treated as a positional argument.
 The built-in ``--help``, ``--verbose``, and ``--quiet`` options
 use this feature.
@@ -618,9 +618,9 @@ define the behavior of the option:
 
 * ``short`` - The single letter variant for this option, leave undefined for none.
 * ``help`` - Help text for this option. Used when generating help for the option.
-* ``default`` - The default value for this option. If not defined the default will be true.
+* ``default`` - The default value for this option. If not defined the default will be ``true``.
 * ``boolean`` - The option uses no value, it's just a boolean switch.
-  Defaults to false.
+  Defaults to ``false``.
 * ``choices`` An array of valid choices for this option. If left empty all
   values are valid. An exception will be raised when parse() encounters an invalid value.
 
@@ -655,7 +655,7 @@ Using Boolean Options
 Options can be defined as boolean options, which are useful when you need to create
 some flag options. Like options with defaults, boolean options always include
 themselves into the parsed parameters. When the flags are present they are set
-to true, when they are absent false::
+to ``true``, when they are absent they are set ot ``false``::
 
     $parser->addOption('verbose', [
         'help' => 'Enable verbose output.',

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -259,7 +259,7 @@ the view file in ``src/Template/Recipes/search.ctp`` will be rendered::
     }
 
 Although CakePHP will automatically call it after every action's logic
-(unless you've set ``$this->autoRender`` to false), you can use it to specify
+(unless you've set ``$this->autoRender`` to ``false``), you can use it to specify
 an alternate view file by specifying a view file name as first argument of
 ``render()`` method.
 

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -287,7 +287,7 @@ Callbacks
 
     Is invoked when the controller's redirect
     method is called but before any further action. If this method
-    returns false the controller will not continue on to redirect the
+    returns ``false`` the controller will not continue on to redirect the
     request. The $url, and $response paramaters allow you to inspect and modify
     the location or any other headers in the response.
 

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -62,7 +62,7 @@ are also all found in the request parameters:
   more information.
 * ``bare`` Present when the request came from :php:meth:`~Cake\\Controller\\Controller::requestAction()` and included the
   bare option. Bare requests do not have layouts rendered.
-* ``requested`` Present and set to true when the action came from :php:meth:`~Cake\\Controller\\Controller::requestAction()`.
+* ``requested`` Present and set to ``true`` when the action came from :php:meth:`~Cake\\Controller\\Controller::requestAction()`.
 
 Query String Parameters
 =======================
@@ -329,7 +329,7 @@ will often get the load balancer host, port and scheme in your requests. Often
 load balancers will also send ``HTTP-X-Forwarded-*`` headers with the original
 values. The forwarded headers will not be used by CakePHP out of the box. To
 have the request object use these headers set the ``trustProxy`` property to
-true::
+``true``::
 
     $this->request->trustProxy = true;
 

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -120,7 +120,7 @@ Other than configuring caching adapters, there are a few other cache related
 configuration properties:
 
 enabled
-    When set to true, persistent caching is disabled site-wide.
+    When set to ``true``, persistent caching is disabled site-wide.
     This will make all read/writes to :php:class:`Cake\\Cache\\Cache` fail.
     You can control this value with :php:meth:`Cake\\Cache\\Cache::enable()` and
     :php:meth:`Cake\\Cache\\Cache::disable()`. The current state can be read with
@@ -449,40 +449,40 @@ The required API for a CacheEngine is
 
 .. php:method:: read($key)
 
-    :return: The cached value or false for failure.
+    :return: The cached value or ``false`` for failure.
 
-    Read a key from the cache. Return false to indicate
+    Read a key from the cache. Return ``false`` to indicate
     the entry has expired or does not exist.
 
 .. php:method:: delete($key)
 
-    :return: Boolean true on success.
+    :return: Boolean ``true`` on success.
 
-    Delete a key from the cache. Return false to indicate that
+    Delete a key from the cache. Return ``false`` to indicate that
     the entry did not exist or could not be deleted.
 
 .. php:method:: clear($check)
 
-    :return: Boolean true on success.
+    :return: Boolean ``true`` on success.
 
-    Delete all keys from the cache. If $check is true, you should
+    Delete all keys from the cache. If $check is ``true``, you should
     validate that each value is actually expired.
 
 .. php:method:: clearGroup($group)
 
-    :return: Boolean true on success.
+    :return: Boolean ``true`` on success.
 
     Delete all keys from the cache belonging to the same group.
 
 .. php:method:: decrement($key, $offset = 1)
 
-    :return: Boolean true on success.
+    :return: Boolean ``true`` on success.
 
     Decrement a number under the key and return decremented value
 
 .. php:method:: increment($key, $offset = 1)
 
-    :return: Boolean true on success.
+    :return: Boolean ``true`` on success.
 
     Increment a number under the key and return incremented value
 

--- a/en/core-libraries/components/authentication.rst
+++ b/en/core-libraries/components/authentication.rst
@@ -230,7 +230,7 @@ Using Digest and Basic Authentication for Logging In
 Basic and digest are stateless authentication schemes and don't require an
 initial POST or a form. If using only basic / digest authenticators you don't
 require a login action in your controller. Also you can set
-``$this->Auth->sessionKey`` to false to ensure AuthComponent doesn't try to
+``$this->Auth->sessionKey`` to ``false`` to ensure AuthComponent doesn't try to
 read user info from session. You may also want to set config
 ``unauthorizedRedirect`` to ``false`` which will cause AuthComponent to throw
 a ``ForbiddenException`` instead of default behavior of redirecting to referer.
@@ -627,9 +627,9 @@ You configure authorization handlers using the ``authorize`` config key.
 You can configure one or many handlers for authorization. Using
 multiple handlers allows you to support different ways of checking
 authorization. When authorization handlers are checked, they will be
-called in the order they are declared. Handlers should return false, if
+called in the order they are declared. Handlers should return ``false``, if
 they are unable to check authorization, or the check has failed.
-Handlers should return true if they were able to check authorization
+Handlers should return ``true`` if they were able to check authorization
 successfully. Handlers will be called in sequence until one passes. If
 all checks fail, the user will be redirected to the page they came from.
 Additionally you can halt all authorization by throwing an exception.
@@ -859,7 +859,7 @@ logoutRedirect
 unauthorizedRedirect
     Controls handling of unauthorized access. By default unauthorized user is
     redirected to the referrer URL or ``loginAction`` or '/'.
-    If set to false a ForbiddenException exception is thrown instead of redirecting.
+    If set to ``false`` a ForbiddenException exception is thrown instead of redirecting.
 
 .. meta::
     :title lang=en: Authentication

--- a/en/core-libraries/components/cookie.rst
+++ b/en/core-libraries/components/cookie.rst
@@ -43,14 +43,14 @@ domain
     The domain that the cookie is available. To make the cookie
     available on all subdomains of example.com set domain to '.example.com'.
 secure
-    Indicates that the cookie should only be transmitted over a
-    secure HTTPS connection. When set to true, the cookie will only be set if
-    a secure connection exists.
+    Indicates that the cookie should only be transmitted over a secure HTTPS
+    connection. When set to ``true``, the cookie will only be set if a
+    secure connection exists.
 key
     Encryption key used when encrypted cookies are enabled. Defaults to Security.salt.
 httpOnly
-    Set to true to make HTTP only cookies. Cookies that are HTTP only
-    are not accessible in JavaScript. Defaults to false.
+    Set to ``true`` to make HTTP only cookies. Cookies that are HTTP only
+    are not accessible in JavaScript. Defaults to ``false``.
 encryption
     Type of encryption to use. Defaults to 'aes'. Can also be 'rijndael' for
     backwards compatibility.

--- a/en/core-libraries/components/csrf-component.rst
+++ b/en/core-libraries/components/csrf-component.rst
@@ -32,7 +32,7 @@ The available configuration options are:
 - ``cookieName`` The name of the cookie to send. Defaults to ``csrfToken``.
 - ``expiry`` How long the CSRF token should last. Defaults to browser session.
 - ``secure`` Whether or not the cookie will be set with the Secure flag.
-  Defaults to false.
+  Defaults to ``false``.
 - ``field`` The form field to check. Defaults to ``_csrfToken``. Changing this
   will also require configuring FormHelper.
 

--- a/en/core-libraries/components/request-handling.rst
+++ b/en/core-libraries/components/request-handling.rst
@@ -38,8 +38,8 @@ the client and its request.
 .. php:method:: accepts($type = null)
 
     $type can be a string, or an array, or null. If a string, accepts
-    will return true if the client accepts the content type. If an
-    array is specified, accepts return true if any one of the content
+    will return ``true`` if the client accepts the content type. If an
+    array is specified, accepts return ``true`` if any one of the content
     types is accepted by the client. If null returns an array of the
     content-types that the client accepts. For example::
 
@@ -65,20 +65,20 @@ Other request 'type' detection methods include:
 
 .. php:method:: isXml()
 
-    Returns true if the current request accepts XML as a response.
+    Returns ``true`` if the current request accepts XML as a response.
 
 .. php:method:: isRss()
 
-    Returns true if the current request accepts RSS as a response.
+    Returns ``true`` if the current request accepts RSS as a response.
 
 .. php:method:: isAtom()
 
-    Returns true if the current call accepts an Atom response, false
+    Returns ``true`` if the current call accepts an Atom response, false
     otherwise.
 
 .. php:method:: isMobile()
 
-    Returns true if user agent string matches a mobile web browser, or
+    Returns ``true`` if user agent string matches a mobile web browser, or
     if the client accepts WAP content. The supported Mobile User Agent
     strings are:
 
@@ -111,7 +111,7 @@ Other request 'type' detection methods include:
 
 .. php:method:: isWap()
 
-    Returns true if the client accepts WAP content.
+    Returns ``true`` if the client accepts WAP content.
 
 All of the above request detection methods can be used in a similar
 fashion to filter functionality intended for specific content
@@ -218,7 +218,7 @@ stopped, saving processing time, saving bandwidth and no content is returned to
 the client. The response status code is then set to ``304 Not Modified``.
 
 You can opt-out this automatic checking by setting the ``checkHttpCache``
-setting to false::
+setting to ``false``::
 
     public $components = [
         'RequestHandler' => [

--- a/en/core-libraries/components/sessions.rst
+++ b/en/core-libraries/components/sessions.rst
@@ -53,7 +53,7 @@ all Session component methods wherever a name/key is used.
 
 .. php:method:: check($name)
 
-    Used to check if a Session variable has been set. Returns true on
+    Used to check if a Session variable has been set. Returns ``true`` on
     existence and false on non-existence.
 
 .. php:method:: delete($name)

--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -104,10 +104,10 @@ such as debugging and translating content.
 
 .. php:function:: debug(mixed $var, boolean $showHtml = null, $showFrom = true)
 
-    If the core ``$debug`` variable is true, $var is printed out.
-    If ``$showHTML`` is true or left as null, the data is rendered to be
+    If the core ``$debug`` variable is ``true``, $var is printed out.
+    If ``$showHTML`` is ``true`` or left as ``null``, the data is rendered to be
     browser-friendly.
-    If ``$showFrom`` is not set to false, the debug output will start with the line from
+    If ``$showFrom`` is not set to ``false``, the debug output will start with the line from
     which it was called.
     Also see :doc:`/development/debugging`
 

--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -404,7 +404,7 @@ HTML attributes. The following will cover the options specific to
         <input name="name" type="text" value="" id="name" />
     </div>
 
-  Alternatively, set this key to false to disable the output of the
+  Alternatively, set this key to ``false`` to disable the output of the
   label::
 
     echo $this->Form->input('name', ['label' => false]);
@@ -442,7 +442,7 @@ HTML attributes. The following will cover the options specific to
   number of suboptions which control the wrapping element, wrapping element
   class name, and whether HTML in the error message will be escaped.
 
-  To disable error message output & field classes set the error key to false::
+  To disable error message output & field classes set the error key to ``false``::
 
     echo $this->Form->input('name', ['error' => false]);
 
@@ -497,12 +497,12 @@ common options shared by all input methods are as follows:
 
     You cannot use ``default`` to check a checkbox - instead you might
     set the value in ``$this->request->data`` in your controller,
-    or set the input option ``checked`` to true.
+    or set the input option ``checked`` to ``true``.
 
     Date and datetime fields' default values can be set by using the
     'selected' key.
 
-    Beware of using false to assign a default value. A false value is used to
+    Beware of using ``false`` to assign a default value. A ``false`` value is used to
     disable/exclude options of an input field, so ``'default' => false`` would
     not set any value at all. Instead use ``'default' => 0``.
 
@@ -527,7 +527,7 @@ Options for Select, Checkbox and Radio Inputs
     The value key for date and datetime inputs may also be a UNIX
     timestamp, or a DateTime object.
 
-* ``$options['empty']`` If set to true, forces the input to remain empty.
+* ``$options['empty']`` If set to ``true``, forces the input to remain empty.
 
   When passed to a select list, this creates a blank option with an
   empty value in your drop down list. If you want to have a empty
@@ -648,7 +648,7 @@ Datetime Options
 * ``$options['round']`` Can be set to `up` or `down` to force rounding in either direction.
   Defaults to null which rounds half up according to `interval`.
 
-* ``$options['monthNames']`` If false, 2 digit numbers will be used instead of text.
+* ``$options['monthNames']`` If ``false``, 2 digit numbers will be used instead of text.
   If it is given an array like ``['01' => 'Jan', '02' => 'Feb', ...]`` then the given array will be used.
 
 Creating Input Elements
@@ -815,7 +815,7 @@ Creates a set of radio button inputs.
   will disable all of the generated radio buttons.
 
 * ``$attributes['legend']`` Radio elements are wrapped with a legend and
-  fieldset by default. Set ``$attributes['legend']`` to false to remove
+  fieldset by default. Set ``$attributes['legend']`` to ``false`` to remove
   them.::
 
     $options = ['M' => 'Male', 'F' => 'Female'];
@@ -833,7 +833,7 @@ Creates a set of radio button inputs.
     <label for="gender-F">Female</label>
 
 If for some reason you don't want the hidden input, setting
-``$attributes['value']`` to a selected value or boolean false will
+``$attributes['value']`` to a selected value or boolean ``false`` will
 do just that.
 
 Creating Select Pickers
@@ -843,7 +843,7 @@ Creating Select Pickers
 
 Creates a select element, populated with the items in ``$options``,
 with the option specified by ``$attributes['value']`` shown as selected by
-default. Set the 'empty' key in the ``$attributes`` variable to false to
+default. Set the 'empty' key in the ``$attributes`` variable to ``false`` to
 turn off the default empty option::
 
     $options = ['M' => 'Male', 'F' => 'Female'];
@@ -862,7 +862,7 @@ Will output:
 The ``select`` input type allows for a special ``$option``
 attribute called ``'escape'`` which accepts a bool and determines
 whether to HTML entity encode the contents of the select options.
-Defaults to true::
+Defaults to ``true``::
 
     $options = ['M' => 'Male', 'F' => 'Female'];
     echo $this->Form->select('gender', $options, ['escape' => false]);
@@ -1049,18 +1049,18 @@ Creating Date and Time Inputs
 Creates a set of select inputs for date and time. This method accepts a number
 of options:
 
-* ``monthNames`` If false, 2 digit numbers will be used instead of text.
+* ``monthNames`` If ``false``, 2 digit numbers will be used instead of text.
   If an array, the given array will be used.
 * ``minYear`` The lowest year to use in the year select
 * ``maxYear`` The maximum year to use in the year select
 * ``interval`` The interval for the minutes select. Defaults to 1
-* ``empty`` - If true, the empty select option is shown. If a string,
+* ``empty`` - If ``true``, the empty select option is shown. If a string,
   that string is displayed as the empty element.
 * ``round`` - Set to ``up`` or ``down`` if you want to force rounding in either direction. Defaults to null.
 * ``default`` The default value to be used by the input. A value in ``$this->request->data``
   matching the field name will override this value. If no default is provided ``time()`` will be used.
 * ``timeFormat`` The time format to use, either 12 or 24.
-* ``second`` Set to true to enable seconds drop down.
+* ``second`` Set to ``true`` to enable seconds drop down.
 
 To control the order of inputs, and any elements/content between the inputs you
 can override the ``dateWidget`` template. By default the ``dateWidget`` template
@@ -1075,10 +1075,10 @@ Creating Year Inputs
 
 Creates a select element populated with the years from ``minYear``
 to ``maxYear``. Additionally, HTML attributes may be supplied in $options. If
-``$options['empty']`` is false, the select will not include an
+``$options['empty']`` is ``false``, the select will not include an
 empty option:
 
-* ``empty`` - If true, the empty select option is shown. If a string,
+* ``empty`` - If ``true``, the empty select option is shown. If a string,
   that string is displayed as the empty element.
 * ``orderYear`` - Ordering of year values in select options.
   Possible values 'asc', 'desc'. Default 'desc'
@@ -1143,7 +1143,7 @@ Will output:
 
 You can pass in your own array of months to be used by setting the
 'monthNames' attribute, or have months displayed as numbers by
-passing false. (Note: the default months can be localized with CakePHP
+passing ``false``. (Note: the default months can be localized with CakePHP
 :doc:`/core-libraries/internationalization-and-localization` features.)::
 
     echo $this->Form->month('mob', ['monthNames' => false]);
@@ -1263,7 +1263,7 @@ Options:
 
 .. php:method:: isFieldError(string $fieldName)
 
-Returns true if the supplied $fieldName has an active validation
+Returns ``true`` if the supplied $fieldName has an active validation
 error.::
 
     if ($this->Form->isFieldError('gender')) {
@@ -1334,7 +1334,7 @@ Will output:
     <button type="submit">Submit Form</button>
 
 The ``button`` input type supports the ``escape`` option, which accepts
-a boolean and defaults to false. It determines whether to HTML encode the
+a boolean and defaults to ``false``. It determines whether to HTML encode the
 ``$title`` of the button::
 
     echo $this->Form->button('Submit Form', ['type' => 'submit', 'escape' => true]);
@@ -1509,7 +1509,7 @@ You can configure the generated inputs by defining additional options in the
         'name' => ['label' => 'custom label']
     ]);
 
-To exclude specific fields from the generated inputs, set them to false in the
+To exclude specific fields from the generated inputs, set them to ``false`` in the
 fields parameter::
 
     echo $this->Form->inputs(['password' => false]);
@@ -1517,9 +1517,9 @@ fields parameter::
 When customizing, ``fields``, you can use the ``$options`` parameter to
 control the generated legend/fieldset.
 
-- ``fieldset`` Set to false to disable the fieldset. If a string is supplied
+- ``fieldset`` Set to ``false`` to disable the fieldset. If a string is supplied
   it will be used as the class name for the fieldset element.
-- ``legend`` Set to false to disable the legend for the generated input set.
+- ``legend`` Set to ``false`` to disable the legend for the generated input set.
   Or supply a string to customize the legend text.
 
 For example::

--- a/en/core-libraries/helpers/html.rst
+++ b/en/core-libraries/helpers/html.rst
@@ -62,7 +62,7 @@ Linking to CSS Files
 .. php:method:: css(mixed $path, array $options = [])
 
 Creates a link(s) to a CSS style-sheet. If the ``block`` option is set to
-true, the link tags are added to the ``css`` block which you can print
+``true``, the link tags are added to the ``css`` block which you can print
 inside the head tag of the document.
 
 You can use the ``block`` option to control which block the link element
@@ -133,7 +133,7 @@ Creating meta Tags
 This method is handy for linking to external resources like RSS/Atom feeds
 and favicons. Like css(), you can specify whether or not you'd like this tag
 to appear inline or appended to the ``meta`` block by setting the 'block'
-key in the $attributes parameter to true, ie - ``['block' => true]``.
+key in the $attributes parameter to ``true``, ie - ``['block' => true]``.
 
 If you set the "type" attribute using the $attributes parameter,
 CakePHP contains a few shortcuts:
@@ -361,7 +361,7 @@ Will output:
 
 HTML special characters in ``$title`` will be converted to HTML
 entities. To disable this conversion, set the escape option to
-false in the ``$options`` array.::
+``false`` in the ``$options`` array.::
 
     echo $this->Html->link(
         $this->Html->image("recipes/6.jpg", ["alt" => "Brownies"]),
@@ -377,7 +377,7 @@ Will output:
         <img src="/img/recipes/6.jpg" alt="Brownies" />
     </a>
 
-Setting ``escape`` to false will also disable escaping of attributes of the
+Setting ``escape`` to ``false`` will also disable escaping of attributes of the
 link. You can use the option ``escapeTitle`` to disable just
 escaping of title and not the attributes.::
 
@@ -452,14 +452,14 @@ Linking to Javascript Files
 Include a script file(s), contained either locally or as a remote URL.
 
 By default, script tags are added to the document inline. If you override
-this by setting ``$options['block']`` to true, the script tags will instead
+this by setting ``$options['block']`` to ``true``, the script tags will instead
 be added to the ``script`` block which you can print elsewhere in the document.
 If you wish to override which block name is used, you can do so by setting
 ``$options['block']``.
 
 ``$options['once']`` controls whether or
 not you want to include this script once per request or more than
-once. This defaults to true.
+once. This defaults to ``true``.
 
 You can use $options to set additional properties to the
 generated script tag. If an array of script tags is used, the
@@ -530,7 +530,7 @@ Creating Inline Javascript Blocks
 
 .. php:method:: scriptBlock($code, $options = [])
 
-Generate a code block containing ``$code`` set ``$options['block']`` to true
+Generate a code block containing ``$code`` set ``$options['block']`` to ``true``
 to have the script block appear in the ``script`` view block. Other options
 defined will be added as attributes to script tags.
 ``$this->Html->scriptBlock('stuff', ['defer' => true]);`` will create

--- a/en/core-libraries/helpers/paginator.rst
+++ b/en/core-libraries/helpers/paginator.rst
@@ -116,10 +116,10 @@ resultset is sorted 'asc' by the specified key the returned link will sort by
 Accepted keys for ``$options``:
 
 * ``escape`` Whether you want the contents HTML entity encoded, defaults to
-  true.
+  ``true``.
 * ``model`` The model to use, defaults to :php:meth:`PaginatorHelper::defaultModel()`.
 * ``direction`` The default direction to use when this link isn't active.
-* ``lock`` Lock direction. Will only use the default direction then, defaults to false.
+* ``lock`` Lock direction. Will only use the default direction then, defaults to ``false``.
 
 Assuming you are paginating some posts, and are on page one::
 
@@ -198,14 +198,14 @@ Supported options are:
 * ``modulus`` how many numbers to include on either side of the current page,
   defaults to 8.
 * ``first`` Whether you want first links generated, set to an integer to
-  define the number of 'first' links to generate. Defaults to false. If a
+  define the number of 'first' links to generate. Defaults to ``false``. If a
   string is set a link to the first page will be generated with the value as the
   title::
 
       echo $this->Paginator->numbers(['first' => 'First page']);
 
 * ``last`` Whether you want last links generated, set to an integer to define
-  the number of 'last' links to generate. Defaults to false. Follows the same
+  the number of 'last' links to generate. Defaults to ``false``. Follows the same
   logic as the ``first`` option. There is a
   :php:meth:`~PaginatorHelper::last()`` method to be used separately as well if
   you wish.
@@ -238,7 +238,7 @@ pages in the paged data set.
     ``$options`` supports the following keys:
 
     * ``escape`` Whether you want the contents HTML entity encoded,
-      defaults to true.
+      defaults to ``true``.
     * ``model`` The model to use, defaults to :php:meth:`PaginatorHelper::defaultModel()`.
     * ``disabledTitle`` The text to use when the link is disabled. Defaults to
       the ``$title`` parameter.
@@ -290,7 +290,7 @@ pages in the paged data set.
     The options parameter accepts the following:
 
     - ``model`` The model to use defaults to :php:meth:`PaginatorHelper::defaultModel()`
-    - ``escape`` Whether or not the text should be escaped. Set to false if your
+    - ``escape`` Whether or not the text should be escaped. Set to ``false`` if your
       content contains HTML.
 
 .. php:method:: last($last = 'last >>', $options = [])
@@ -314,15 +314,15 @@ Checking the Pagination State
 
 .. php:method:: hasNext(string $model = null)
 
-    Returns true if the given result set is not at the last page.
+    Returns ``true`` if the given result set is not at the last page.
 
 .. php:method:: hasPrev(string $model = null)
 
-    Returns true if the given result set is not at the first page.
+    Returns ``true`` if the given result set is not at the first page.
 
 .. php:method:: hasPage(string $model = null, integer $page = 1)
 
-    Returns true if the given result set has the page number given by ``$page``.
+    Returns ``true`` if the given result set has the page number given by ``$page``.
 
 Creating a Page Counter
 =======================
@@ -399,7 +399,7 @@ Sets all the options for the Paginator Helper. Supported options are:
   arguments and query string parameters.
 
 * ``escape`` Defines if the title field for links should be HTML escaped.
-  Defaults to true.
+  Defaults to ``true``.
 
 * ``model`` The name of the model being paginated, defaults to
   :php:meth:`PaginatorHelper::defaultModel()`.

--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -227,7 +227,7 @@ using the ``LogTrait`` Calling log() will internally call
 
 All configured log streams are written to sequentially each time
 :php:meth:`Cake\\Log\\Log::write()` is called. If you have not configured any
-logging adapters ``log()`` will return false and no log messages will be
+logging adapters ``log()`` will return ``false`` and no log messages will be
 written.
 
 .. _logging-levels:

--- a/en/core-utility-libraries/email.rst
+++ b/en/core-utility-libraries/email.rst
@@ -392,7 +392,7 @@ subject "Subject" and content "Message".
 The return of ``deliver()`` is a :php:class:`Cake\\Email\\Email` instance with all
 configurations set. If you do not want to send the email right away, and wish
 to configure a few things before sending, you can pass the 5th parameter as
-false.
+``false``.
 
 The 3rd parameter is the content of message or an array with variables (when
 using rendered content).

--- a/en/core-utility-libraries/file-folder.rst
+++ b/en/core-utility-libraries/file-folder.rst
@@ -71,7 +71,7 @@ Folder API
 
 .. php:method:: cd( $path )
 
-    Change directory to $path. Returns false on failure::
+    Change directory to $path. Returns ``false`` on failure::
 
         $folder = new Folder('/foo');
         echo $folder->path; // Prints /foo
@@ -195,11 +195,11 @@ Folder API
 
 .. php:method:: inCakePath(string $path = '')
 
-    Returns true if the file is in a given CakePath.
+    Returns ``true`` if the file is in a given CakePath.
 
 .. php:method:: inPath(string $path = '', boolean $reverse = false)
 
-    Returns true if the file is in the given path::
+    Returns ``true`` if the file is in the given path::
 
         $Folder = new Folder(WWW_ROOT);
         $result = $Folder->inPath(APP);
@@ -210,11 +210,11 @@ Folder API
 
 .. php:staticmethod:: isAbsolute(string $path)
 
-    Returns true if the given $path is an absolute path.
+    Returns ``true`` if the given $path is an absolute path.
 
 .. php:staticmethod:: isSlashTerm(string $path)
 
-    Returns true if given $path ends in a slash (i.e. is slash-terminated)::
+    Returns ``true`` if given $path ends in a slash (i.e. is slash-terminated)::
 
         $result = Folder::isSlashTerm('/my/test/path');
         // $result = false
@@ -223,7 +223,7 @@ Folder API
 
 .. php:staticmethod:: isWindowsPath(string $path)
 
-    Returns true if the given $path is a Windows path.
+    Returns ``true`` if the given $path is a Windows path.
 
 .. php:method:: messages()
 
@@ -337,11 +337,11 @@ File API
 
 .. php:method:: executable()
 
-    Returns true if the file is executable.
+    Returns ``true`` if the file is executable.
 
 .. php:method:: exists()
 
-    Returns true if the file exists.
+    Returns ``true`` if the file exists.
 
 .. php:method:: ext()
 
@@ -353,7 +353,7 @@ File API
 
 .. php:method:: group()
 
-    Returns the file's group, or false in case of an error.
+    Returns the file's group, or ``false`` in case of an error.
 
 .. php:method:: info()
 
@@ -365,12 +365,12 @@ File API
 
 .. php:method:: lastChange()
 
-    Returns last modified time, or false in case of an error.
+    Returns last modified time, or ``false`` in case of an error.
 
 .. php:method:: md5(integer|boolean $maxsize = 5)
 
     Get the MD5 Checksum of file with previous check of filesize,
-    or false in case of an error.
+    or ``false`` in case of an error.
 
 .. php:method:: name()
 
@@ -404,11 +404,11 @@ File API
 
 .. php:method:: read(string $bytes = false, string $mode = 'rb', boolean $force = false)
 
-    Return the contents of the current file as a string or return false on failure.
+    Return the contents of the current file as a string or return ``false`` on failure.
 
 .. php:method:: readable()
 
-    Returns true if the file is readable.
+    Returns ``true`` if the file is readable.
 
 .. php:method:: safe(string $name = null, string $ext = null)
 
@@ -420,7 +420,7 @@ File API
 
 .. php:method:: writable()
 
-    Returns true if the file is writable.
+    Returns ``true`` if the file is writable.
 
 .. php:method:: write(string $data, string $mode = 'w', boolean$force = false)
 
@@ -429,12 +429,12 @@ File API
 
 .. php:method:: mime()
 
-    Get the file's mimetype, returns false on failure.
+    Get the file's mimetype, returns ``false`` on failure.
 
 
 .. php:method:: replaceText( $search, $replace )
 
-    Replaces text in a file. Returns false on failure and true on success.
+    Replaces text in a file. Returns ``false`` on failure and ``true`` on success.
 
 
 .. todo::

--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -342,10 +342,10 @@ Attribute Matching Types
             'My Index 1' => ['First' => 'The first item']
         ];
         $result = Hash::check($set, 'My Index 1.First');
-        // $result == True
+        // $result == true
 
         $result = Hash::check($set, 'My Index 1');
-        // $result == True
+        // $result == true
 
         $set = [
             'My Index 1' => [
@@ -359,16 +359,16 @@ Attribute Matching Types
             ]
         ];
         $result = Hash::check($set, 'My Index 1.First.Second');
-        // $result == True
+        // $result == true
 
         $result = Hash::check($set, 'My Index 1.First.Second.Third');
-        // $result == True
+        // $result == true
 
         $result = Hash::check($set, 'My Index 1.First.Second.Third.Fourth');
-        // $result == True
+        // $result == true
 
         $result = Hash::check($set, 'My Index 1.First.Seconds.Third.Fourth');
-        // $result == False
+        // $result == false
 
 .. php:staticmethod:: filter(array $data, $callback = ['Hash', 'filter'])
 
@@ -684,7 +684,7 @@ Attribute Matching Types
 
 .. php:staticmethod:: normalize(array $data, $assoc = true)
 
-    Normalizes an array. If ``$assoc`` is true, the resulting array will be
+    Normalizes an array. If ``$assoc`` is ``true``, the resulting array will be
     normalized to be an associative array. Numeric keys with values, will be
     converted to string keys with null values. Normalizing an array, makes using
     the results with :php:meth:`Hash::merge()` easier::

--- a/en/core-utility-libraries/httpclient.rst
+++ b/en/core-utility-libraries/httpclient.rst
@@ -87,7 +87,7 @@ you can do the following::
     $http = new Client();
     $response = $http->get(
       'http://example.com/tasks',
-      ['q' => 'test', '_content' => json_encode($data)], 
+      ['q' => 'test', '_content' => json_encode($data)],
       ['type' => 'json']
     );
 
@@ -104,10 +104,10 @@ addition request information.  The following keys can be used in ``$options``:
 - ``proxy`` - Array of proxy information.
 - ``auth`` - Array of authentication data, the ``type`` key is used to delegate to
   an authentication strategy. By default Basic auth is used.
-- ``ssl_verify_peer`` - defaults to true. Set to false to disable SSL certification
+- ``ssl_verify_peer`` - defaults to ``true``. Set to ``false`` to disable SSL certification
   verification (not advised)
 - ``ssl_verify_depth`` - defaults to 5. Depth to traverse in the CA chain.
-- ``ssl_verify_host`` - defaults to true. Validate the SSL certificate against the host name.
+- ``ssl_verify_host`` - defaults to ``true``. Validate the SSL certificate against the host name.
 - ``ssl_cafile`` - defaults to built in cafile. Overwrite to use custom CA bundles.
 - ``timeout`` - Duration to wait before timing out.
 - ``type`` - Send a request body in a custom content type. Requires ``$data`` to
@@ -308,7 +308,7 @@ Response objects have a number of methods for inspecting the response data.
 .. php:method:: cookie($name = null, $all = false)
 
     Get a single cookie from the response. By default only the value of a cookie
-    is returned. If you set the second parameter to true, all the properties
+    is returned. If you set the second parameter to ``true``, all the properties
     set in the response will be returned.
 
 .. php:method:: statusCode()

--- a/en/core-utility-libraries/number.rst
+++ b/en/core-utility-libraries/number.rst
@@ -69,8 +69,8 @@ output. The following options are available:
 |                     | ie. '$'                                            |
 +---------------------+----------------------------------------------------+
 | after               | The currency symbol to place after decimal numbers |
-|                     | ie. 'c'. Set to boolean false to use no decimal    |
-|                     | symbol. eg. 0.35 => $0.35.                         |
+|                     | ie. 'c'. Set to boolean ``false`` to use no        |
+|                     | decimal symbol. eg. 0.35 => $0.35.                 |
 +---------------------+----------------------------------------------------+
 | zero                | The text to use for zero values, can be a string or|
 |                     | a number. ie. 0, 'Free!'.                          |
@@ -85,7 +85,7 @@ output. The following options are available:
 |                     | number will be wrapped with ( and ).               |
 +---------------------+----------------------------------------------------+
 | escape              | Should the output be htmlentity escaped? Defaults  |
-|                     | to true.                                           |
+|                     | to ``true``.                                       |
 +---------------------+----------------------------------------------------+
 | wholeSymbol         | String to use for whole numbers, ie. ' dollars'.   |
 +---------------------+----------------------------------------------------+

--- a/en/core-utility-libraries/security.rst
+++ b/en/core-utility-libraries/security.rst
@@ -52,7 +52,7 @@ Hashing Data
 .. php:staticmethod:: hash( $string, $type = NULL, $salt = false )
 
 Create a hash from string using given method. Fallback on next
-available method. If ``$salt`` is set to true, the applications salt
+available method. If ``$salt`` is set to ``true``, the applications salt
 value will be used::
 
     // Using the application's salt value

--- a/en/core-utility-libraries/string.rst
+++ b/en/core-utility-libraries/string.rst
@@ -111,7 +111,7 @@ You can provide an array of options that control how wrapping is done. The
 supported options are:
 
 * ``width`` The width to wrap to. Defaults to 72.
-* ``wordWrap`` Whether or not to wrap whole words. Defaults to true.
+* ``wordWrap`` Whether or not to wrap whole words. Defaults to ``true``.
 * ``indent`` The character to indent lines with. Defaults to ''.
 * ``indentAt`` The line number to start indenting text. Defaults to 0.
 
@@ -129,7 +129,7 @@ Options:
 
 -  'format' - string The piece of HTML with that the phrase will be
    highlighted
--  'html' - bool If true, will ignore any HTML tags, ensuring that
+-  'html' - bool If ``true``, will ignore any HTML tags, ensuring that
    only the correct text is highlighted
 
 Example::

--- a/en/core-utility-libraries/time.rst
+++ b/en/core-utility-libraries/time.rst
@@ -244,7 +244,7 @@ You can compare a ``Time`` instance with the present in a variety of ways::
     echo $time->isThisMonth();
     echo $time->isThisYear();
 
-Each of the above methods will return true/false based on whether or not the
+Each of the above methods will return ``true``/``false`` based on whether or not the
 ``Time`` instance matches the present.
 
 Comparing With Intervals

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -56,8 +56,8 @@ Below is a description of the variables and how they affect your CakePHP
 application.
 
 debug
-    Changes CakePHP debugging output. false = Production mode. No error
-    messages, errors, or warnings shown. true = Errors and warnings shown.
+    Changes CakePHP debugging output. ``false`` = Production mode. No error
+    messages, errors, or warnings shown. ``true`` = Errors and warnings shown.
 App.namespace
     The namespace to find app classes under.
 
@@ -75,7 +75,7 @@ App.baseUrl
     mod\_rewrite with CakePHP. Don’t forget to remove your .htaccess
     files too.
 App.base
-    The base directory the app resides in. If false this
+    The base directory the app resides in. If ``false`` this
     will be auto detected.
 App.encoding
     Define what encoding your application uses.  This encoding
@@ -108,8 +108,8 @@ Asset.timestamp
     file at the end of asset files URLs (CSS, JavaScript, Image) when
     using proper helpers.
     Valid values:
-    (bool) false - Doesn't do anything (default)
-    (bool) true - Appends the timestamp when debug > 0
+    (bool) ``false`` - Doesn't do anything (default)
+    (bool) ``true`` - Appends the timestamp when debug > 0
     (string) 'force' - Always appends the timestamp.
 
 Database Configuration
@@ -397,7 +397,7 @@ Once you've attached a config engine to Configure you can load configuration fil
 
 Loaded configuration files merge their data with the existing runtime configuration
 in Configure. This allows you to overwrite and add new values
-into the existing runtime configuration. By setting ``$merge`` to true, values
+into the existing runtime configuration. By setting ``$merge`` to ``true``, values
 will not ever overwrite the existing configuration.
 
 Creating or Modifying Configuration Files

--- a/en/development/debugging.rst
+++ b/en/development/debugging.rst
@@ -16,12 +16,12 @@ The ``debug()`` function is a globally available function that works
 similarly to the PHP function ``print\_r()``. The ``debug()`` function
 allows you to show the contents of a variable in a number of
 different ways. First, if you'd like data to be shown in an
-HTML-friendly way, set the second parameter to true. The function
+HTML-friendly way, set the second parameter to ``true``. The function
 also prints out the line and file it is originating from by
 default.
 
 Output from this function is only shown if the core ``$debug`` variable
-has been set to true.
+has been set to ``true``.
 
 .. php:function stackTrace()
 

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -82,7 +82,7 @@ only apply it some of the time. You can apply conditions using the ``for`` and
         }
     ]);
 
-The callable provided to ``when`` should return true when the filter should run.
+The callable provided to ``when`` should return ``true`` when the filter should run.
 The callable can expect to get the current request and response as arguments.
 
 Building a Filter

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -451,7 +451,7 @@ Logging Exceptions
 ------------------
 
 Using the built-in exception handling, you can log all the exceptions that are
-dealt with by ErrorHandler by setting the ``log`` option to true in your
+dealt with by ErrorHandler by setting the ``log`` option to ``true`` in your
 config/app.php. Enabling this will log every exception to
 :php:class:`Cake\\Log\\Log` and the configured loggers.
 

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -301,16 +301,17 @@ CakePHP, and should not be used unless you want the special meaning
 * ``plugin`` Used to name the plugin a controller is located in.
 * ``prefix`` Used for :ref:`prefix-routing`
 * ``_ext`` Used for :ref:`file-extensions` routing.
-* ``_base`` Set to false to remove the base path from the generated URL. If your application
+* ``_base`` Set to ``false`` to remove the base path from the generated URL. If your application
   is not in the root directory, this can be used to generate URLs that are 'cake relative'.
   cake relative URLs are required when using requestAction.
 * ``_scheme``  Set to create links on different schemes like `webcal` or `ftp`. Defaults
   to the current scheme.
 * ``_host`` Set the host to use for the link.  Defaults to the current host.
 * ``_port`` Set the port if you need to create links on non-standard ports.
-* ``_full``  If true the `FULL_BASE_URL` constant will be prepended to generated URLs.
+* ``_full``  If ``true`` the `FULL_BASE_URL` constant will be prepended to generated URLs.
 * ``#`` Allows you to set URL hash fragments.
-* ``_ssl`` Set to true to convert the generated URL to https, or false to force http.
+* ``_ssl`` Set to ``true`` to convert the generated URL to https or ``false``
+to force http.
 * ``_method`` Define the HTTP verb/method to use. Useful when working with
   :ref:`resource-routes`.
 * ``_name`` Name of route. If you have setup named routes, you can use this key
@@ -792,15 +793,16 @@ older versions of CakePHP.
 You can also use any of the special route elements when generating URLs:
 
 * ``_ext`` Used for :ref:`file-extensions` routing.
-* ``_base`` Set to false to remove the base path from the generated URL. If your application
+* ``_base`` Set to ``false`` to remove the base path from the generated URL. If your application
   is not in the root directory, this can be used to generate URLs that are 'cake relative'.
   cake relative URLs are required when using requestAction.
 * ``_scheme``  Set to create links on different schemes like `webcal` or `ftp`. Defaults
   to the current scheme.
 * ``_host`` Set the host to use for the link.  Defaults to the current host.
 * ``_port`` Set the port if you need to create links on non-standard ports.
-* ``_full``  If true the `FULL_BASE_URL` constant will be prepended to generated URLs.
-* ``_ssl`` Set to true to convert the generated URL to https, or false to force http.
+* ``_full``  If ``true`` the `FULL_BASE_URL` constant will be prepended to generated URLs.
+* ``_ssl`` Set to ``true`` to convert the generated URL to https or ``false``
+to force http.
 * ``_name`` Name of route. If you have setup named routes, you can use this key
   to specify it.
 

--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -38,7 +38,7 @@ level ``Session`` key, and a number of options are available:
   config. This combined with ``Session.handler`` replace the custom session
   handling features of previous versions
 
-CakePHP's defaults ``session.cookie_secure`` to true, when your application is
+CakePHP's defaults ``session.cookie_secure`` to ``true``, when your application is
 on an SSL protocol. If your application serves from both SSL and non-SSL
 protocols, then you might have problems with sessions being lost. If you need
 access to the session on both SSL and non-SSL domains you will want to disable

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -842,7 +842,7 @@ an entire class by not passing methods to it, like Session in the example above.
 
 Generated controllers are automatically used as the testing controller to test.
 To enable automatic generation, set the ``autoMock`` variable on the test case to
-true. If ``autoMock`` is false, your original controller will be used in the test.
+``true``. If ``autoMock`` is ``false``, your original controller will be used in the test.
 
 The response object in the generated controller is always replaced with a mock
 that does not send headers. After using ``generate()`` or ``testAction()`` you

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -106,10 +106,10 @@ init
 dsn
     A full PDO compatible data source name.
 log
-    Set to true to enable query logging. When enabled queries will be logged
+    Set to ``true`` to enable query logging. When enabled queries will be logged
     at a ``debug`` level with the ``queriesLog`` scope.
 quoteIdentifiers
-    Set to true if you are using reserved words or special characters in your
+    Set to ``true`` if you are using reserved words or special characters in your
     table or column names. Enabling this setting will result in queries built using the
     :ref:`query-builder` having identifiers quoted when creating SQL. It should be
     noted that this decreases performance because each query needs to be traversed
@@ -119,7 +119,7 @@ flags
     underlying PDO instance. See the PDO documentation for the flags supported
     by the driver you are using.
 cacheMetadata
-    Either boolean true, or a string containing the cache configuration to store
+    Either boolean ``true``, or a string containing the cache configuration to store
     meta data in. Having metadata caching disable is not advised and can result
     in very poor performance. See the :ref:`database-metadata-cache` section
     for more information.
@@ -518,7 +518,7 @@ Query Logging
 =============
 
 Query logging can be enabled when configuring your connection by setting the
-``log`` option to true. You can also toggle query logging at runtime, using
+``log`` option to ``true``. You can also toggle query logging at runtime, using
 ``logQueries``::
 
     // Turn query logging on.

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -224,7 +224,7 @@ fields::
 
     $article->set($properties, ['guard' => false]);
 
-By setting the ``guard`` option to false, you can ignore the accessible field
+By setting the ``guard`` option to ``false``, you can ignore the accessible field
 list for a single call to ``set()``.
 
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -991,6 +991,6 @@ Removing All Stacked Map-reduce Operations
 Under some circumstances you may want to modify a ``Query`` object so that no
 ``mapReduce`` operations are executed at all. This can be easily done by
 calling the method with both parameters as null and the third parameter
-(overwrite) as true::
+(overwrite) as ``true``::
 
     $query->mapReduce(null, null, true);

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -272,12 +272,12 @@ Possible keys for hasOne association arrays include:
   such as ``['Addresses.primary' => true]``
 - **joinType**: the type of the join to use in the SQL query, default
   is INNER. You may want to use LEFT if your hasOne association is optional.
-- **dependent**: When the dependent key is set to true, and an
+- **dependent**: When the dependent key is set to ``true``, and an
   entity is deleted, the associated model records are also deleted. In this
-  case we set it true so that deleting a User will also delete her associated
+  case we set it to ``true`` so that deleting a User will also delete her associated
   Address.
-- **cascadeCallbacks**: When this and **dependent** are true, cascaded deletes will
-  load and delete entities so that callbacks are properly triggered. When false,
+- **cascadeCallbacks**: When this and **dependent** are ``true``, cascaded deletes will
+  load and delete entities so that callbacks are properly triggered. When ``false``,
   ``deleteAll()`` is used to remove associated data and no callbacks are
   triggered.
 - **propertyName**: The property name that should be filled with data from the associated
@@ -436,11 +436,11 @@ Possible keys for hasMany association arrays include:
   strings such as ``['Comments.visible' => true]``
 - **sort**  an array of find() compatible order clauses or SQL
   strings such as ``['Comments.created' => 'ASC']``
-- **dependent**: When dependent is set to true, recursive model
+- **dependent**: When dependent is set to ``true``, recursive model
   deletion is possible. In this example, Comment records will be
   deleted when their associated Article record has been deleted.
-- **cascadeCallbacks**: When this and **dependent** are true, cascaded deletes will
-  load and delete entities so that callbacks are properly triggered. When false,
+- **cascadeCallbacks**: When this and **dependent** are ``true``, cascaded deletes will
+  load and delete entities so that callbacks are properly triggered. When ``false``,
   ``deleteAll()`` is used to remove associated data and no callbacks are
   triggered.
 - **propertyName**: The property name that should be filled with data from the associated
@@ -556,10 +556,10 @@ Possible keys for belongsToMany association arrays include:
   want used on the join table, or the instance itself. This makes customizing
   the join table keys possible, and allows you to customize the behavior of the
   pivot table.
-- **cascadeCallbacks**: When this is true, cascaded deletes will load and delete
+- **cascadeCallbacks**: When this is ``true``, cascaded deletes will load and delete
   entities so that callbacks are properly triggered on join table records. When
-  false, ``deleteAll()`` is used to remove associated data and no callbacks are
-  triggered. This defaults to false to help reduce overhead.
+  ``false``, ``deleteAll()`` is used to remove associated data and no callbacks are
+  triggered. This defaults to ``false`` to help reduce overhead.
 - **propertyName**: The property name that should be filled with data from the associated
   table into the source table results. By default this is the underscored & plural name of
   the association, so ``tags`` in our example.
@@ -1349,12 +1349,12 @@ When an entity is saved a few things happen:
 
 1. Validation will be started if not disabled.
 2. Validation will trigger the ``Model.beforeValidate`` event. If this event is
-   stopped the save operation will fail and return false.
+   stopped the save operation will fail and return ``false``.
 3. Validation will be applied. If validation fails, the save will be aborted,
-   and save() will return false.
+   and save() will return ``false``.
 4. The ``Model.afterValidate`` event will be triggered.
 5. The ``Model.beforeSave`` event is dispatched. If it is stopped, the save will
-   be aborted, and save() will return false.
+   be aborted, and save() will return ``false``.
 6. Parent associations are saved. For example, any listed belongsTo
    associations will be saved.
 7. The modified fields on the entity will be saved.
@@ -1700,7 +1700,7 @@ HasMany associations are configured as ``dependent``, delete operations will
 'cascade' to those entities as well. By default entities in associated tables
 are removed using :php:meth:`~Cake\\ORM\Table::deleteAll()`. You can elect to
 have the ORM load related entities, and delete them individually by setting the
-``cascadeCallbacks`` option to true. A sample HasMany association with both
+``cascadeCallbacks`` option to ``true``. A sample HasMany association with both
 these options enabled would be::
 
     $this->hasMany('Comments', [
@@ -1710,7 +1710,7 @@ these options enabled would be::
 
 .. note::
 
-    Setting ``cascadeCallbacks`` to true, results in considerably slower deletes
+    Setting ``cascadeCallbacks`` to ``true``, results in considerably slower deletes
     when compared to bulk deletes. The cascadeCallbacks option should only be
     enabled when your application has important work handled by event listeners.
 

--- a/en/views.rst
+++ b/en/views.rst
@@ -530,7 +530,7 @@ Caching Elements
 ----------------
 
 You can take advantage of CakePHP view caching if you supply a
-cache parameter. If set to true, it will cache the element in the
+cache parameter. If set to ``true``, it will cache the element in the
 'default' Cache configuration. Otherwise, you can set which cache configuration
 should be used. See :doc:`/core-libraries/caching` for more information on
 configuring ``Cache``. A simple example of caching an element would be::


### PR DESCRIPTION
Modification to use `true`/`false` instead of true/false when used as a boolean value in a sentence.
Up to now both syntax are used.

If this proposal is approved by others, I propose to also change null to `null`.
Let me know
