### PR TITLE
3.0 fix build warning

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -311,7 +311,7 @@ CakePHP, and should not be used unless you want the special meaning
 * ``_full``  If ``true`` the `FULL_BASE_URL` constant will be prepended to generated URLs.
 * ``#`` Allows you to set URL hash fragments.
 * ``_ssl`` Set to ``true`` to convert the generated URL to https or ``false``
-to force http.
+  to force http.
 * ``_method`` Define the HTTP verb/method to use. Useful when working with
   :ref:`resource-routes`.
 * ``_name`` Name of route. If you have setup named routes, you can use this key
@@ -802,7 +802,7 @@ You can also use any of the special route elements when generating URLs:
 * ``_port`` Set the port if you need to create links on non-standard ports.
 * ``_full``  If ``true`` the `FULL_BASE_URL` constant will be prepended to generated URLs.
 * ``_ssl`` Set to ``true`` to convert the generated URL to https or ``false``
-to force http.
+  to force http.
 * ``_name`` Name of route. If you have setup named routes, you can use this key
   to specify it.
 

--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -5,7 +5,7 @@ You can take advantage of themes, making it easy to switch the look and feel of
 your page quickly and easily. Themes in CakePHP are simply plugins that focus on
 providing view files. In addition to template files, they can also provide
 helpers and cells if your theming requires that. When using cells and helpers from your
-theme, you will need to continue using the :term:`plugin-syntax`.
+theme, you will need to continue using the :term:`plugin syntax`.
 
 To use themes, specify the theme name in your controller::
 


### PR DESCRIPTION
- correct bad indentation in routing (see following picture)

![image](https://cloud.githubusercontent.com/assets/4977112/4073447/ad6dd0d4-2e94-11e4-9c6e-3710e7302323.png)
- correct reference to `plugin syntax`
