### PR TITLE
patchEntity clarification.

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -2130,9 +2130,9 @@ important note should be made.
     those records will be discarded from the resulting entity.
     
 .. note::
-    Remember that using either ``patchEntity`` method:: or ``patchEntities`` method::
+    Remember that using either ``patchEntity`` or ``patchEntities`` 
     does not persist the data, it just edits (or creates) the given entities. In order to
-    persist the entity you will have to call the ``save`` method::
+    persist the entity you will have to call the ``save`` method
 
 For example, consider the following case::
 


### PR DESCRIPTION
Clarifying that save() method still needs to be called after patching an entity.

Due the new ORM in CakePHP 3, I find it important to clarify this to developers.
