### PR TITLE
Fixing method signatures for table callbacks

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -1778,7 +1778,7 @@ been replaced with the :ref:`map-reduce` features and entity constructors.
 beforeValidate
 --------------
 
-.. php:method:: beforeValidate(Event $event, Entity $entity, array $options, Validator $validator)
+.. php:method:: beforeValidate(Event $event, Entity $entity, ArrayObject $options, Validator $validator)
 
 The ``Model.beforeValidate`` method is fired before an entity is validated. By
 stopping this event, you can abort the validate + save operations.
@@ -1786,14 +1786,14 @@ stopping this event, you can abort the validate + save operations.
 afterValidate
 -------------
 
-.. php:method:: afterValidate(Event $event, Entity $entity, array $options, Validator $validator)
+.. php:method:: afterValidate(Event $event, Entity $entity, ArrayObject $options, Validator $validator)
 
 The ``Model.afterValidate`` event is fired after an entity is validated.
 
 beforeSave
 ----------
 
-.. php:method:: beforeSave(Event $event, Entity $entity, array $options)
+.. php:method:: beforeSave(Event $event, Entity $entity, ArrayObject $options)
 
 The ``Model.beforeSave`` event is fired before each entity is saved. Stopping
 this event will abort the save operation. When the event is stopped the result
@@ -1802,14 +1802,14 @@ of the event will be returned.
 afterSave
 ---------
 
-.. php:method:: afterSave(Event $event, Entity $entity, array $options)
+.. php:method:: afterSave(Event $event, Entity $entity, ArrayObject $options)
 
 The ``Model.afterSave`` event is fired after an entity is saved.
 
 beforeDelete
 ------------
 
-.. php:method:: beforeDelete(Event $event, Entity $entity, array $options)
+.. php:method:: beforeDelete(Event $event, Entity $entity, ArrayObject $options)
 
 The ``Model.beforeDelete`` event is fired before an entity is deleted. By
 stopping this event you will abort the delete operation.
@@ -1817,7 +1817,7 @@ stopping this event you will abort the delete operation.
 afterDelete
 -----------
 
-.. php:method:: afterDelete(Event $event, Entity $entity, array $options)
+.. php:method:: afterDelete(Event $event, Entity $entity, ArrayObject $options)
 
 Fired after an entity has been deleted.
 


### PR DESCRIPTION
Having the incorrect method signatures was misleading people into fatal erros
