### PR TITLE
Revert "Added Options -Indexes to webroot .htaccess"

### DIFF
--- a/en/installation/url-rewriting.rst
+++ b/en/installation/url-rewriting.rst
@@ -79,7 +79,6 @@ You may also take a look at http://wiki.apache.org/httpd/DistrosDefaultLayout fo
            RewriteCond %{REQUEST_FILENAME} !-d
            RewriteCond %{REQUEST_FILENAME} !-f
            RewriteRule ^(.*)$ index.php [QSA,L]
-           Options -Indexes
        </IfModule>
 
    If your CakePHP site still has problems with mod\_rewrite, you might


### PR DESCRIPTION
Reverts cakephp/docs#1691

The extra rule is not needed by CakePHP and is an unnecessary distraction.
