### PR TITLE
Line length

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -40,6 +40,17 @@ Or::
         }
     }
 
+Line Length
+===========
+
+It is recommended to keep lines at approximately 100 characters long for better code readability.
+No line must not be longer than 120 characters.
+
+In short:
+
+* 100 characters is the soft limit.
+* 120 characters is the hard limit.
+
 Control Structures
 ==================
 


### PR DESCRIPTION
We are missing a section about the recommended line length.

Thoughts?

The (historical) 80 char length might be a little bit too short in some cases.
So unifying it to 100 as recommended length sounds like a good idea to me.
