### PR TITLE
Uppercase 'Engine' Should be Lowercase

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -301,7 +301,7 @@ also easy. In your ``core.php`` make the session block look like the following::
     ));
 
     // Make sure to add a apc cache config
-    Cache::config('apc', array('Engine' => 'Apc'));
+    Cache::config('apc', array('engine' => 'Apc'));
 
 Now our application will start using our custom session handler for reading &
 writing session data.


### PR DESCRIPTION
Uppercase 'Engine' in the custom session handler example breaks the example.
