### PR TITLE
ComboSession issue with writing

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -266,11 +266,8 @@ something like::
 
         // write data into the session.
         public function write($id, $data) {
-            $result = Cache::write($id, $data, $this->cacheKey);
-            if ($result) {
-                return parent::write($id, $data);
-            }
-            return false;
+            Cache::write($id, $data, $this->cacheKey);
+            return parent::write($id, $data);
         }
 
         // destroy a session.


### PR DESCRIPTION
Follow up with my commit of a year ago, https://github.com/cakephp/docs/commit/23fc03c12c3eea8456e895c2696444e037cdcc56, we realize that there is another issue with the ComboSession. Take for example, if you have a cache server with two nodes, namely node#1 and node#2.
1. Write data to cache. Cache server chosen node#1 - write successful.
2. By definition, if cache writing is successful, then you write the data into database by calling `parent::write`. Since step#1 is successful, no data has been written into the cake_session database yet.
3. This time, app issues a read. Read trying to read data from cache server. Cache server chosen node#2 - read failure. When read fails, it fall back to database reading. Now database do not have such session, so session is lost - user logged out.

To tackle this, we should always write to both cache and database to synchronize database to the cache servers.
