### PR TITLE
Add event propagation example for behaviors.

### DIFF
--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -161,15 +161,15 @@ The above code shows a few interesting features of behaviors:
 - Behaviors can define a default configuration property. This property is merged
   with the overrides when a behavior is attached to the table.
 
-To prevent the saving to continue stop event propagation in your callback::
+To prevent the saving from continuing simply stop event propagation in your callback::
 
-        public function beforeSave(Event $event, Entity $entity) {
-            if (...) {
-           	    $event->stopPropagation();
-           	    return;
-            }
-            // ...
+    public function beforeSave(Event $event, Entity $entity) {
+        if (...) {
+            $event->stopPropagation();
+            return;
         }
+        $this->slug($entity);
+    }
 
 Defining Finders
 ----------------


### PR DESCRIPTION
Since there are quite a few examples regarding beforeSave() callbacks and alike, but not a single information on how to stop saving in 3.x (in 2.x you should returned false), here is a small example.
