### PR TITLE
Syntax error in example code

### DIFF
--- a/en/core-libraries/components/pagination.rst
+++ b/en/core-libraries/components/pagination.rst
@@ -126,7 +126,7 @@ your action::
         );
         $data = $this->Paginator->paginate('Recipe');
         $this->set(compact('data'));
-    );
+    }
 
 Custom Query Pagination
 =======================


### PR DESCRIPTION
Corrects a syntax error in the 'conditions' inside an action example code.
