### PR TITLE
Update Behaviors.rst

### DIFF
--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -138,6 +138,7 @@ behavior should now look like::
     use Cake\Event\Event;
     use Cake\ORM\Behavior;
     use Cake\ORM\Entity;
+    use Cake\ORM\Query
     use Cake\Utility\Inflector;
 
     class SluggableBehavior extends Behavior {


### PR DESCRIPTION
Add "use Cake\ORM\Query" to "Defining Event Listeners" example code

Prevents from : 
Warning (4096): Argument 1 passed to App\Model\Behavior\SluggableBehavior::findSlug() must be an instance of App\Model\Behavior\Query, instance of Cake\ORM\Query given [APP/Model/Behavior/SluggableBehavior.php, line 23]
