### PR TITLE
'Themed' should be 'Theme'

### DIFF
--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -83,7 +83,7 @@ directories in ``app/webroot`` with paths matching those used by CakePHP.
 -  ``app/Plugin/DebugKit/webroot/js/my_file.js`` becomes
    ``app/webroot/debug_kit/js/my_file.js``
 -  ``app/View/Themed/Navy/webroot/css/navy.css`` becomes
-   ``app/webroot/themed/Navy/css/navy.css``
+   ``app/webroot/theme/Navy/css/navy.css``
 
 
 .. meta::


### PR DESCRIPTION
Looks like a small typo there. While using assets from `app/webroot` the folder name should be `theme` instead of `themed`.

Tested on ver. 2.5.4 and 2.5.5. for JS files.
