### PR TITLE
3.0 - Fix version requirements for PHP.

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -10,7 +10,7 @@ this guide for all the new features and API changes.
 Requirements
 ============
 
-- CakePHP 3.x supports PHP Version 5.4.19 and above.
+- CakePHP 3.x supports PHP Version 5.4.16 and above.
 - CakePHP 3.x requires the mbstring extension.
 - CakePHP 3.x requires the mcrypt extension.
 - CakePHP 3.x requires the intl extension.

--- a/es/appendices/3-0-migration-guide.rst
+++ b/es/appendices/3-0-migration-guide.rst
@@ -15,7 +15,7 @@ this guide for all the new features and API changes.
 Requirements
 ============
 
-- CakePHP 3.x supports PHP Version 5.4.19 and above.
+- CakePHP 3.x supports PHP Version 5.4.16 and above.
 - CakePHP 3.x requires the mbstring extension.
 - CakePHP 3.x requires the mcrypt extension.
 

--- a/es/cakephp-overview/what-is-cakephp-why-use-it.rst
+++ b/es/cakephp-overview/what-is-cakephp-why-use-it.rst
@@ -29,7 +29,7 @@ CakePHP:
 
 - :ref:`cakephp-official-communities` activa y amigable.
 - `Licencia flexible <http://en.wikipedia.org/wiki/MIT_License>`_
-- Compatible con las versiones de PHP 5.4.19 y superiores.
+- Compatible con las versiones de PHP 5.4.16 y superiores.
 - Contiene
   `CRUD <http://en.wikipedia.org/wiki/Create,_read,_update_and_delete>`_ para la
   interacción de la base de datos.

--- a/es/contributing/code.rst
+++ b/es/contributing/code.rst
@@ -17,7 +17,7 @@ Before working on patches for CakePHP, it's a good idea to get your environment
 setup. You'll need the following software:
 
 * Git
-* PHP 5.4.19 or greater
+* PHP 5.4.16 or greater
 * PHPUnit 3.7.0 or greater
 
 Set up your user information with your name/handle and working email address::

--- a/es/installation.rst
+++ b/es/installation.rst
@@ -12,7 +12,7 @@ Requisitos
 
 - Servidor HTTP. Por ejemplo: Apache. mod\_rewrite es recomendado, pero
   no requerido.
-- PHP 5.4.19 o mayor.
+- PHP 5.4.16 o mayor.
 - extensión mbstring.
 - extensión mcrypt.
 - extensión intl.
@@ -43,7 +43,7 @@ para incorporar CakePHP en cualquier aplicación comercial o de código cerrado.
 Instalando CakePHP
 ==================
 
-CakePHP utiliza `Composer <http://getcomposer.org>`_, una herramienta de manejo de 
+CakePHP utiliza `Composer <http://getcomposer.org>`_, una herramienta de manejo de
 dependicias para PHP 5.3+, como el método de instalación oficialmente soportado.
 
 Primero, necesitas descargar e instalar Composer, si no lo has hecho ya.
@@ -51,7 +51,7 @@ Si tienes instalado cURL, es tan fácil como correr esto en un terminal::
 
     curl -s https://getcomposer.org/installer | php
 
-O, puedes descargar ``composer.phar`` desde el sitio web de 
+O, puedes descargar ``composer.phar`` desde el sitio web de
 `Composer <https://getcomposer.org/download/>`_.
 
 Para sistemas Windows, puedes descargar el Instalador de Composer para Windows
@@ -69,7 +69,7 @@ O si tienes Composer definido globalmente::
     composer create-project --prefer-dist -s dev cakephp/app [app_name]
 
 Una vez que Composer termine de descargar el esqueleto y la librería core
-de CakePHP, deberías tener una aplicación funcional de CakePHP instalada 
+de CakePHP, deberías tener una aplicación funcional de CakePHP instalada
 vía Composer. Asegúrate de que los ficheros composer.json y composer.lock
 se mantengan junto con el resto de tu código fuente.
 

--- a/es/tutorials-and-examples/blog/blog.rst
+++ b/es/tutorials-and-examples/blog/blog.rst
@@ -16,7 +16,7 @@ Esto es lo que necesitarás:
 #. Servidor web funcionando. Asumiremos que estás usando Apache, aunque las
    instrucciones para otros servidores son similares. Igual tendremos que ajustar
    un poco la configuración inicial, pero la mayoría pueden poner en marcha
-   CakePHP sin configuración alguna. Asegúrate de tener PHP 5.4.19 o superior
+   CakePHP sin configuración alguna. Asegúrate de tener PHP 5.4.16 o superior
    así como tener las extensiones ``mbstring``, ``intl`` y ``mcrypt`` activadas
    en PHP.
 #. Servidor de base de datos. Usaremos MySQL en este tutorial. Necesitarás saber

--- a/fr/appendices/3-0-migration-guide.rst
+++ b/fr/appendices/3-0-migration-guide.rst
@@ -11,7 +11,7 @@ fonctionnalités et les changements de l'API.
 Pré-requis
 ==========
 
-- CakePHP 3.x a besoin de la Version 5.4.19 ou supérieur de PHP.
+- CakePHP 3.x a besoin de la Version 5.4.16 ou supérieur de PHP.
 - CakePHP 3.x a besoin de l'extension mbstring.
 - CakePHP 3.x a besoin de l'extension mcrypt.
 - CakePHP 3.x a besoin de l'extension intl.

--- a/pt/appendices/3-0-migration-guide.rst
+++ b/pt/appendices/3-0-migration-guide.rst
@@ -10,7 +10,7 @@ this guide for all the new features and API changes.
 Requirements
 ============
 
-- CakePHP 3.x supports PHP Version 5.4.19 and above.
+- CakePHP 3.x supports PHP Version 5.4.16 and above.
 - CakePHP 3.x requires the mbstring extension.
 - CakePHP 3.x requires the mcrypt extension.
 - CakePHP 3.x requires the intl extension.


### PR DESCRIPTION
CakePHP 3 requires PHP 5.4.16 or greater.

Refs cakephp/cakephp#4611
