### PR TITLE
3.0 - Fix code example for enabling identifier quoting at runtime.

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -572,7 +572,7 @@ If you are using a legacy schema that requires identifier quoting you can enable
 it using the ``quoteIdentifiers`` setting in your
 :ref:`database-configuration`. You can also enable this feature at runtime::
 
-    $conn->quoteIdentifiers(true);
+    $conn->driver()->autoQuoting(true);
 
 When enabled, identifier quoting will cause additional query traversal that
 converts all identifiers into ``IdentifierExpression`` objects.

--- a/es/orm/database-basics.rst
+++ b/es/orm/database-basics.rst
@@ -576,7 +576,7 @@ If you are using a legacy schema that requires identifier quoting you can enable
 it using the ``quoteIdentifiers`` setting in your
 :ref:`database-configuration`. You can also enable this feature at runtime::
 
-    $conn->quoteIdentifiers(true);
+    $conn->driver()->autoQuoting(true);
 
 When enabled, identifier quoting will cause additional query traversal that
 converts all identifiers into ``IdentifierExpression`` objects.

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -600,7 +600,7 @@ pouvez l'activer en utilisant le paramètre ``quoteIdentifiers`` dans votre
 :ref:`database-configuration`. Vous pouvez aussi activer cette fonctionnalité
 à la volée::
 
-    $conn->quoteIdentifiers(true);
+    $conn->driver()->autoQuoting(true);
 
 Quand elle est activée, l'identifier quoting va entrainer des requêtes
 supplémentaires traversal qui convertissent tous les identifiers en objets

--- a/pt/orm/database-basics.rst
+++ b/pt/orm/database-basics.rst
@@ -571,7 +571,7 @@ If you are using a legacy schema that requires identifier quoting you can enable
 it using the ``quoteIdentifiers`` setting in your
 :ref:`database-configuration`. You can also enable this feature at runtime::
 
-    $conn->quoteIdentifiers(true);
+    $conn->driver()->autoQuoting(true);
 
 When enabled, identifier quoting will cause additional query traversal that
 converts all identifiers into ``IdentifierExpression`` objects.


### PR DESCRIPTION
...assuming that the actual problem isn't that the `Connection` class is missing a `quoteIdentifiers()` method.
