### PR TITLE
Add docs explaining requirement to select fk fields.

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -1067,9 +1067,11 @@ associations and filter them by conditions::
         }
     ]);
 
-When you limit the fields that are fetched from an association, you **must**
-ensure that the foreign key columns are selected. Failing to select foreign key
-fields will cause associated data to not be present in the final result.
+.. note::
+
+    When you limit the fields that are fetched from an association, you **must**
+    ensure that the foreign key columns are selected. Failing to select foreign
+    key fields will cause associated data to not be present in the final result.
 
 It is also possible to restrict deeply nested associations using the dot
 notation::


### PR DESCRIPTION
The ORM requires people to load the foreign keys when limiting the fields from an association. The docs should point that out.

Refs cakephp/cakephp#4951
