### PR TITLE
Add back to contents button.

### DIFF
--- a/themes/cakephp/localtoc.html
+++ b/themes/cakephp/localtoc.html
@@ -7,7 +7,8 @@
     :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-<div class="page-contents">
+<a id="back-to-contents" href="#page-contents">&#11014; Back to Contents</a>
+<div id="page-contents" class="page-contents">
 	<h3>{{ _('Page contents') }}</h3>
 	{{ toc }}
 </div>

--- a/themes/cakephp/static/app.js
+++ b/themes/cakephp/static/app.js
@@ -11,7 +11,6 @@ App.config = {
 App.Book = (function() {
 
 	function init() {
-
 		// Make top nav responsive.
 		$('#cakephp-global-navigation').menuSelect({'class': 'nav-select'});
 
@@ -38,12 +37,42 @@ App.Book = (function() {
 		dropdown.find('li:last-child a').bind('blur', function () {
 			$(this).parents('.dropdown').find('ul').css('display', '');
 		});
+
+		// Show back to contents button.
+		var backToTop = $('#back-to-contents'),
+			contents = $('#page-contents'),
+			doc = $(document),
+			offset = contents.offset(),
+			sidebarHeight = contents.height(),
+			showing = false;
+
+		var positionBackToTop = function() {
+			if (!showing && doc.scrollTop() > offset.top + sidebarHeight) {
+				showing = true;
+				backToTop.css({
+					position: 'fixed',
+					top: 20,
+					left: 20,
+					display:' block'
+				});
+			} else if (showing && doc.scrollTop() <= offset.top + sidebarHeight) {
+				showing = false;
+				backToTop.css({
+					display:'none'
+				});
+			}
+		};
+
+		backToTop.bind('click', function(evt) {
+			$('html,body').animate({scrollTop: offset.top}, 200);
+			return false;
+		});
+
+		doc.bind('scroll', function() {
+			positionBackToTop();
+		});
 	}
- 
-	function compare_scores(a, b) {
-		return b.score - a.score;
-	}
- 
+
 	return {
 		init : init
 	};

--- a/themes/cakephp/static/default.css
+++ b/themes/cakephp/static/default.css
@@ -667,3 +667,8 @@ dt tt {
 		float: none;
 	}
 }
+
+
+#back-to-contents {
+	display: none;
+}


### PR DESCRIPTION
This button conditionally shows when you are scrolled below the page contents and gives a quick way to get back to the page contents. I didn't go back go the root nav as it can be pretty large, and I think more people need an easy way to navigate around the current page.

![book-jump-link](https://cloud.githubusercontent.com/assets/24086/4785654/253b9d2c-5d83-11e4-9e30-952e66ec154a.gif)

Refs #1898
