### PR TITLE
Added add() method to RecipesController REST example in japanese

### DIFF
--- a/ja/development/rest.rst
+++ b/ja/development/rest.rst
@@ -81,6 +81,19 @@ POSTリクエストの中の、 *\_method* の値を使う方法は、ブラウ�
                 '_serialize' => array('recipe')
             ));
         }
+        
+        public function add() {
+            $this->Recipe->create();
+            if ($this->Recipe->save($this->request->data)) {
+                $message = 'Saved';
+            } else {
+                $message = 'Error';
+            }
+            $this->set(array(
+                'message' => $message,
+                '_serialize' => array('message')
+            ));
+        }
 
         public function edit($id) {
             $this->Recipe->id = $id;


### PR DESCRIPTION
Copy / Pasting the example worked fine except for the missing POST /recipes.json example: add() method was missing in japanese.

https://github.com/cakephp/docs/commit/fc16b1351cf70d7fb5a7370c66148ff96c5a363f
