### PR TITLE
Missing use Cake\View\Helper and extends from Helper

### DIFF
--- a/es/development/testing.rst
+++ b/es/development/testing.rst
@@ -128,8 +128,9 @@ method. The helper we're going to test will be formatting progress bar HTML.
 Our helper looks like::
 
     namespace App\View\Helper;
-
-    class ProgressHelper extends AppHelper {
+    use Cake\View\Helper;
+    
+    class ProgressHelper extends Helper {
         public function bar($value) {
             $width = round($value / 100, 2) * 100;
             return sprintf(


### PR DESCRIPTION
Maybe I'm wrong, but I follow the ProgressHelper Test instructions and I found 2 possible errors:

1) Line "use Cake\View\Helper;" is missing.
2) ¿Extends Helper insted of AppHelper?
