### PR TITLE
Document direct task execution subcommand necessity

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -229,9 +229,18 @@ You can also access tasks directly from the command line::
 
     In order to access tasks directly from the command line, the task
     **must** be included in the shell class' $tasks property.
-    Therefore, be warned that a method called "sound" in the SeaShell
-    class would override the ability to access the functionality in the
-    Sound task specified in the $tasks array.
+
+
+Also, the task name must be added as a sub command to the Shell's
+OptionParser:
+
+	public function getOptionParser() {
+		$parser = parent::getOptionParser();
+		$parser->addSubcommand('sound', [
+			'help' => 'Execute The Sound Task.'
+		]);
+		return $parser;
+	}
 
 Loading Tasks On The Fly with TaskRegistry
 ------------------------------------------


### PR DESCRIPTION
In order to be able to execute a task via its parent shell, a sub command must be added to the Shell's option parser.
