### PR TITLE
terme confus

### DIFF
--- a/fr/console-and-shells.rst
+++ b/fr/console-and-shells.rst
@@ -251,7 +251,7 @@ commande::
     tâche **doit** être inclue dans la propriété $tasks de la classe shell.
 
 
-De plus, le nom de la task doit être ajouté en tout que sous commande dans
+De plus, le nom de la task doit être ajouté en tant que sous commande dans
 l'OptionParser du Shell::   
 
     public function getOptionParser() {


### PR DESCRIPTION
Ligne 254, dans la phrase "De plus, le nom de la task doit être ajouté en tout que sous commande dans
l'OptionParser du Shell::", il me semble que l'on devrait lire "...être ajouté en tant que..."
