### PR TITLE
Fix Advanced Conditions samples which are wrong

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -280,7 +280,7 @@ conditions arrays in previous versions of CakePHP::
     $query = $articles->find()
         ->where([
             'author_id' => 3,
-            'OR' => ['view_count' => 2, 'view_count' => 3],
+            'OR' => [['view_count' => 2], ['view_count' => 3]],
         ]);
 
 The above would generate SQL like::


### PR DESCRIPTION
The documented results of the following samples are (thankfully) wrong:

``` php
$query = $articles->find()
    ->where([
        'author_id' => 3,
        'OR' => ['author_id' => 2],
    ]);
```

Would actually create: 

``` sql
SELECT * FROM articles WHERE (author_id = 2 AND author_id = 3)
```

``` php
$query = $articles->find()
        ->where(['author_id' => 2])
        ->orWhere(['author_id' => 3])
        ->andWhere([
            'published' => true,
            'view_count >' => 10
        ])
        ->orWhere(['promoted' => true]);
```

Would actually create: 

``` sql
SELECT * FROM articles WHERE (promoted = true OR ((published = true AND view_count > 10) AND (author_id = 2 OR author_id = 3)))
```
