### PR TITLE
Changed name of XmlReader class to MyXmlReader

### DIFF
--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -675,7 +675,7 @@ In your ``app/Config/bootstrap.php`` you could attach this reader and use it::
 
         It is not a good idea to call your custom configure class ``XmlReader`` because that
         classname is an internal PHP one already:
-        `XMLReader <http://php.net/manual/de/book.xmlreader.php>`_
+        `XMLReader <http://php.net/manual/en/book.xmlreader.php>`_
 
     Configure::load('my_xml');
 


### PR DESCRIPTION
to avoid collision with PHP's XMLReader class:

Argument 2 passed to Configure::config() must be an instance of ConfigReaderInterface, instance of XMLReader given.
