### PR TITLE
Add Contributing to the PDF version of the book

### DIFF
--- a/en/pdf-contents.rst
+++ b/en/pdf-contents.rst
@@ -16,6 +16,7 @@ Contents
    development
    deployment
    tutorials-and-examples
+   contributing
    appendices
 
 


### PR DESCRIPTION
The 3.x version of the book also has the Contributing section:
https://github.com/cakephp/docs/blame/66cc98a8775ceb67f627d4f3f54f1b3215e51f0e/en/pdf-contents.rst#L11

I see no reason not to include it.
There are valuable ressources such as the coding standard.
