### PR TITLE
Refer to "templates" not views

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -120,11 +120,11 @@ clarity::
     $variable = isset($options['variable']) ? isset($options['othervar']) ? true : false : false;
 
 
-View Files
-----------
+Template Files
+--------------
 
-In view files (.ctp files) developers should use keyword control structures.
-Keyword control structures are easier to read in complex view files. Control
+In template files (.ctp files) developers should use keyword control structures.
+Keyword control structures are easier to read in complex template files. Control
 structures can either be contained in a larger PHP block, or in separate PHP
 tags::
 
@@ -382,12 +382,12 @@ PHP Tags
 ========
 
 Always use long tags (``<?php ?>``) Instead of short tags (``<? ?>``). The short echo
-should be used in view files (``.ctp``) where appropriate.
+should be used in template files (``.ctp``) where appropriate.
 
 Short Echo
 ----------
 
-The short echo should be used in view files in place of ``<?php echo``. It should be
+The short echo should be used in template files in place of ``<?php echo``. It should be
 immediately followed by a single space, the variable or function value to ``echo``, a
 single space, and the php closing tag::
 

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -126,7 +126,7 @@ in ``src/Controller/RecipesController.php`` and contain::
             }
         }
 
-The view files for these actions would be ``src/Template/Recipes/view.ctp``,
+The template files for these actions would be ``src/Template/Recipes/view.ctp``,
 ``src/Template/Recipes/share.ctp``, and ``src/Template/Recipes/search.ctp``. The
 conventional view file name is the lowercased and underscored version of the
 action name.

--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -14,7 +14,7 @@ By default RequestHandler will automatically detect AJAX requests
 based on the HTTP-X-Requested-With header that many JavaScript
 libraries use. When used in conjunction with
 :php:meth:`Cake\\Routing\\Router::extensions()`, RequestHandler will
-automatically switch the layout and view files to those that match the requested
+automatically switch the layout and template files to those that match the requested
 type. Furthermore, if a helper with the same name as the requested
 extension exists, it will be added to the Controllers Helper array.
 Lastly, if XML/JSON data is POST'ed to your Controllers, it will be

--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -226,7 +226,7 @@ send multipart templated email messages as well::
         ->from('app@domain.com')
         ->send();
 
-This would use the following view files:
+This would use the following template files:
 
 * ``src/Template/Email/text/welcome.ctp``
 * ``src/Template/Layout/Email/text/fancy.ctp``
@@ -245,7 +245,7 @@ In your email templates you can use these with::
 
     <p>Here is your value: <b><?= $value ?></b></p>
 
-You can use helpers in emails as well, much like you can in normal view files.
+You can use helpers in emails as well, much like you can in normal template files.
 By default only the ``HtmlHelper`` is loaded. You can load additional
 helpers using the ``helpers()`` method::
 

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -327,8 +327,8 @@ Exception Renderer
 The ExceptionRenderer class with the help of ``ErrorController`` takes care of rendering
 the error pages for all the exceptions thrown by you application.
 
-The error page views are located at ``src/Template/Error/``. For all 4xx and 
-5xx errors the view files ``error400.ctp`` and ``error500.ctp`` are used
+The error page views are located at ``src/Template/Error/``. For all 4xx and
+5xx errors the template files ``error400.ctp`` and ``error500.ctp`` are used
 respectively. You can customize them as per your needs. By default your
 ``src/Template/Layout/default.ctp`` is used for error pages too. If for
 example, you want to use another layout ``src/Template/Layout/my_error.ctp``
@@ -346,7 +346,7 @@ Creating your own Application Exceptions
 
 You can create your own application exceptions using any of the built in `SPL
 exceptions <http://php.net/manual/en/spl.exceptions.php>`_, ``Exception``
-itself, or :php:exc:`Cake\\Core\\Exception\\Exception`. 
+itself, or :php:exc:`Cake\\Core\\Exception\\Exception`.
 If your application contained the following exception::
 
     use Cake\Core\Exception\Exception;

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -100,7 +100,7 @@ view variable is used to define which view variables ``XmlView`` should
 serialize into XML.
 
 If we wanted to modify the data before it is converted into XML we should not
-define the ``_serialize`` view variable, and instead use view files. We place
+define the ``_serialize`` view variable, and instead use template files. We place
 the REST views for our RecipesController inside ``src/Template/recipes/xml``. We can also use
 the :php:class:`Xml` for quick-and-easy XML output in those views. Here's what
 our index view might look like::

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -550,7 +550,7 @@ with the following router connection::
             ['routeClass' => 'DashedRoute']
         );
 
-        $routes->fallbacks();
+        $routes->fallbacks('DashedRoute');
     });
 
 Under the ``/`` routing scope, the previous example will attempt to catch all

--- a/en/intro/cakephp-folder-structure.rst
+++ b/en/intro/cakephp-folder-structure.rst
@@ -59,7 +59,7 @@ Locale
 Model
     Contains your application's tables, entities and behaviors.
 View
-    Presentational classes are placed here: cells, helpers, and view files.
+    Presentational classes are placed here: cells, helpers, and template files.
 Template
     Presentational files are placed here: elements, error pages,
     layouts, and view template files.

--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -393,12 +393,12 @@ If the plugin prefix is omitted, the layout/view file will be located normally.
     For information on how to use elements from a plugin, look up
     :ref:`view-elements`
 
-Overriding Plugin Views from Inside Your Application
+Overriding Plugin Templates from Inside Your Application
 ----------------------------------------------------
 
 You can override any plugin views from inside your app using special paths. If
-you have a plugin called 'ContactManager' you can override the view files of the
-plugin with more application specific view logic by creating files using the
+you have a plugin called 'ContactManager' you can override the template files of the
+plugin with application specific view logic by creating files using the
 following template ``src/Template/Plugin/[Plugin]/[Controller]/[view].ctp``. For the
 Contacts controller you could make the following file::
 

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -119,7 +119,7 @@ Remember in the last section how we assigned the 'articles' variable
 to the view using the ``set()`` method? That would hand down the query
 object to the view to be invoked with a ``foreach`` iteration.
 
-CakePHP's view files are stored in ``src/Template`` inside a folder
+CakePHP's template files are stored in ``src/Template`` inside a folder
 named after the controller they correspond to (we'll have to create
 a folder named 'Articles' in this case). To format this article data in a
 nice table, our view code might look something like this:

--- a/en/views.rst
+++ b/en/views.rst
@@ -60,7 +60,7 @@ The view layer of CakePHP is how you speak to your users. Most of the time your
 views will be showing (X)HTML documents to browsers, but you might also need to
 reply to a remote application via JSON, or output a CSV file for a user.
 
-By default CakePHP view files are written in plain PHP and have a default
+By default CakePHP template files are written in plain PHP and have a default
 extension of ``.ctp`` (CakePHP Template). These files contain all the
 presentational logic needed to get the data it received from the
 controller in a format that is ready for the audience you're
@@ -68,7 +68,7 @@ serving to. If you'd prefer using a templating language like
 Twig, a subclass of View will bridge your templating
 language and CakePHP.
 
-View files are stored in ``src/Template/``, in a folder named after the
+Template files are stored in ``src/Template/``, in a folder named after the
 controller that uses the files, and named after the action it
 corresponds to. For example, the view file for the Products
 controller's "view()" action, would normally be found in
@@ -82,7 +82,7 @@ chapter:
   action being run. They form the meat of your application's response.
 - **elements**: small, reusable bits of view code. Elements are
   usually rendered inside views.
-- **layouts**: view files that contain presentational code that
+- **layouts**: template files that contain presentational code that
   wraps many interfaces in your application. Most views are
   rendered inside a layout.
 - **helpers**: these classes encapsulate view logic that is needed
@@ -391,7 +391,7 @@ JavaScript and CSS files from views.
 .. note::
 
     When using ``HtmlHelper::css()`` or ``HtmlHelper::script()``
-    in view files, specify ``'block' => true`` to place the HTML
+    in template files, specify ``'block' => true`` to place the HTML
     source in a block with the same name. (See API for more details on usage).
 
 The ``content`` block contains the contents of the rendered view.
@@ -493,7 +493,7 @@ argument::
 
 Inside the element file, all the passed variables are available as
 members of the parameter array (in the same way that ``Controller::set()`` in
-the controller works with view files). In the above example, the
+the controller works with template files). In the above example, the
 ``src/Template/Element/helpbox.ctp`` file can use the ``$helptext``
 variable::
 

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -11,7 +11,7 @@ leverage the new view classes. ``XmlView`` and ``JsonView`` will be referred to
 as data views for the rest of this page.
 
 There are two ways you can generate data views. The first is by using the
-``_serialize`` key, and the second is by creating normal view files.
+``_serialize`` key, and the second is by creating normal template files.
 
 Enabling Data Views in Your Application
 =======================================
@@ -35,11 +35,11 @@ Using Data Views with the Serialize Key
 
 The ``_serialize`` key is a special view variable that indicates which other view
 variable(s) should be serialized when using a data view. This lets you skip
-defining view files for your controller actions if you don't need to do any
+defining template files for your controller actions if you don't need to do any
 custom formatting before your data is converted into json/xml.
 
 If you need to do any formatting or manipulation of your view variables before
-generating the response, you should use view files. The value of ``_serialize``
+generating the response, you should use template files. The value of ``_serialize``
 can be either a string or an array of view variables to serialize::
 
     namespace App\Controller;
@@ -79,10 +79,10 @@ If you use a string value for ``_serialize`` and XmlView, make sure that your
 view variable has a single top-level element. Without a single top-level
 element the Xml will fail to generate.
 
-Using a Data View with View Files
+Using a Data View with Template Files
 =================================
 
-You should use view files if you need to do some manipulation of your view
+You should use template files if you need to do some manipulation of your view
 content before creating the final output. For example if we had posts, that had
 a field containing generated HTML, we would probably want to omit that from a
 JSON response. This is a situation where a view file would be useful::

--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -3,7 +3,7 @@ Themes
 
 You can take advantage of themes, making it easy to switch the look and feel of
 your page quickly and easily. Themes in CakePHP are simply plugins that focus on
-providing view files. In addition to template files, they can also provide
+providing template files. In addition to template files, they can also provide
 helpers and cells if your theming requires that. When using cells and helpers from your
 theme, you will need to continue using the :term:`plugin syntax`.
 
@@ -18,7 +18,7 @@ You can also set or change the theme name within an action or within the
 
     $this->theme = 'AnotherExample';
 
-Theme view files need to be within a plugin with the same name. For example,
+Theme template files need to be within a plugin with the same name. For example,
 the above theme would be found in ``plugins/AnotherExample/src/Template``.
 It's important to remember that CakePHP expects CamelCase plugin/theme names. Beyond
 that, the folder structure within the ``plugins/AnotherExample/src/Template`` folder is
@@ -29,7 +29,7 @@ at ``plugins/Modern/src/Template/Posts/edit.ctp``. Layout files would reside in
 ``plugins/Modern/src/Template/Layout/``.
 
 If a view file can't be found in the theme, CakePHP will try to locate the view
-file in the ``src/Template/`` folder. This way, you can create master view files
+file in the ``src/Template/`` folder. This way, you can create master template files
 and simply override them on a case-by-case basis within your theme folder.
 
 Theme Assets
@@ -42,7 +42,7 @@ handled by :php:class:`Cake\\Routing\\Dispatcher`. To improve performance for pr
 environments, it's recommended that you :ref:`symlink-assets`.
 
 All of CakePHP's built-in helpers are aware of themes and will create the
-correct paths automatically. Like view files, if a file isn't in the theme
+correct paths automatically. Like template files, if a file isn't in the theme
 folder, it will default to the main webroot folder::
 
     // When in a theme with the name of 'purple_cupcake'


### PR DESCRIPTION
This hopefully removes/reduces some of the ambiguity regarding view v template.

The only section which still refers to "view files" is the migration guide, since views is the more familiar name to 2.x users.
