### PR TITLE
Improve examples regarding PHP5+

### DIFF
--- a/en/appendices/orm-migration.rst
+++ b/en/appendices/orm-migration.rst
@@ -346,7 +346,7 @@ fields gave::
     use Cake\ORM\Query;
 
     class ReviewsTable extends Table {
-        function findAverage(Query $query, array $options = []) {
+        public function findAverage(Query $query, array $options = []) {
             $avg = $query->func()->avg('rating');
             $query->select(['average' => $avg]);
             return $query;

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -199,7 +199,7 @@ For example, you often want to cache remote service call results. You could use
 
     class IssueService  {
 
-        function allIssues($repo) {
+        public function allIssues($repo) {
             return Cache::remember($repo . '-issues', function () use ($repo) {
                 return $this->fetchAll($repo);
             });

--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -701,7 +701,7 @@ The ``buffered()`` method is also useful for converting non-rewindable iterators
 into collections that can be iterated more than once::
 
     // In PHP 5.5+
-    function results() {
+    public function results() {
         ...
         foreach ($transientElements as $e) {
             yield $e;
@@ -723,7 +723,7 @@ places at the same time. In order to clone a collection out of another use the
 
     foreach ($ages as $age) {
         foreach ($collection as $element) {
-            echo $element->name . ' - ' . $age;
+            echo h($element->name) . ' - ' . $age;
         }
     }
 

--- a/en/core-libraries/hash.rst
+++ b/en/core-libraries/hash.rst
@@ -568,9 +568,9 @@ Attribute Matching Types
         // Call the noop function $this->noop() on every element of $data
         $result = Hash::map($data, "{n}", array($this, 'noop'));
 
-        function noop($array) {
-         // Do stuff to array and return the result
-         return $array;
+        public function noop(array $array) {
+            // Do stuff to array and return the result
+            return $array;
         }
 
 .. php:staticmethod:: reduce(array $data, $path, $function)

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -1071,14 +1071,14 @@ necessary.  In these cases it is more efficient to use a bulk-update to modify
 many rows at once::
 
     // Publish all the unpublished articles.
-    function publishAllUnpublished() {
+    public function publishAllUnpublished() {
         $this->updateAll(['published' => true], ['published' => false]);
     }
 
 If you need to do bulk updates and use SQL expressions, you will need to use an
 expression object as ``updateAll()`` uses prepared statements under the hood::
 
-    function incrementCounters() {
+    public function incrementCounters() {
         $expression = new QueryExpression('view_count = view_count + 1');
         $this->updateAll([$expression], ['published' => true]);
     }
@@ -1201,7 +1201,7 @@ In these cases it is more performant to use a bulk-delete to remove many rows at
 once::
 
     // Delete all the spam
-    function destroySpam() {
+    public function destroySpam() {
         return $this->deleteAll(['is_spam' => true]);
     }
 


### PR DESCRIPTION
Improved the examples a bit

E.g. avoid user confusion around public methods and callable `function ($value, $context) {}` functions.
