### PR TITLE
moves php:namespace after page title in validation.rst

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -1,7 +1,7 @@
-.. php:namespace:: Cake\Validation
-
 Validation
 ##########
+
+.. php:namespace:: Cake\Validation
 
 The validation package in CakePHP provides features to build validators that can
 validate arbitrary arrays of data with ease.


### PR DESCRIPTION
I noticed that the validation page has no bold title on the search-result popup:

![screen shot 2014-12-10 at 18 54 50](https://cloud.githubusercontent.com/assets/143224/5381077/3cdf7e7e-809e-11e4-8bf8-7cb5495e24e5.png)

I was lazy and didn't check the code, but I guess the reason is that the title tag is not first on page?
