### PR TITLE
Correct migration docs for Bake

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -253,7 +253,7 @@ ExtractTask
 BakeShell / TemplateTask
 ------------------------
 
-- Bake is nolonger part of the core source and is superceeded by
+- Bake is no longer part of the core source and is superseded by
   `CakePHP Bake Plugin <https://github.com/cakephp/bake>`_
 - Bake templates have been moved under ``src/Template/Bake``.
 - The syntax of Bake templates now uses erb-style tags (``<% %>``) to denote templating


### PR DESCRIPTION
Metion that bake is now a plugin, the new template syntax and remove the
theme->template change, since it was subsequently changed back.
