### PR TITLE
Corrects FormHelper templates list (views/helpers/form.rst)

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1439,30 +1439,30 @@ A list of the default templates and the variables they can expect are:
 
 * ``button`` {{attrs}}, {{text}}
 * ``checkbox`` {{name}}, {{value}}, {{attrs}}
+* ``checkboxFormGroup`` {{input}}, {{label}}, {{error}}
 * ``checkboxWrapper`` {{input}}, {{label}}
 * ``dateWidget`` {{year}}, {{month}}, {{day}}, {{hour}}, {{minute}}, {{second}}, {{meridian}}
 * ``error`` {{content}}
 * ``errorList`` {{content}}
 * ``errorItem`` {{text}}
 * ``file`` {{name}}, {{attrs}}
+* ``formGroup`` {{label}}, {{input}}, {{error}}
 * ``formstart`` {{attrs}}
 * ``formend`` No variables are provided.
 * ``hiddenblock`` {{content}}
 * ``input`` {{type}}, {{name}}, {{attrs}}
-* ``inputsubmit`` {{type}}, {{attrs}}
-* ``label`` {{attrs}}, {{text}}
-* ``option`` {{value}}, {{attrs}}, {{text}}
-* ``optgroup`` {{label}}, {{attrs}}, {{content}}
-* ``select`` {{name}}, {{attrs}}, {{content}}
-* ``selectMultiple`` {{name}}, {{attrs}}, {{content}}
-* ``radio`` {{name}}, {{value}}, {{attrs}}
-* ``radioWrapper``  {{input}}, {{label}},
-* ``textarea``  {{name}}, {{attrs}}, {{value}}
-* ``formGroup`` {{label}}, {{input}},
-* ``checkboxFormGroup`` {{input}}, {{label}},
 * ``inputContainer`` {{type}}, {{required}}, {{content}}
 * ``inputContainerError`` {{type}}, {{required}}, {{content}}, {{error}}
+* ``inputsubmit`` {{type}}, {{attrs}}
+* ``label`` {{attrs}}, {{text}}, {{hidden}}, {{input}}
+* ``option`` {{value}}, {{attrs}}, {{text}}
+* ``optgroup`` {{label}}, {{attrs}}, {{content}}
+* ``radio`` {{name}}, {{value}}, {{attrs}}
+* ``radioWrapper``  {{input}}, {{label}}
+* ``select`` {{name}}, {{attrs}}, {{content}}
+* ``selectMultiple`` {{name}}, {{attrs}}, {{content}}
 * ``submitContainer`` {{content}}
+* ``textarea``  {{name}}, {{attrs}}, {{value}}
 
 In addition to these templates, the ``input()`` method will attempt to use
 distinct templates for each input container. For example, when creating


### PR DESCRIPTION
- Reorder templates list by alphabetical order (easier to go through in my opinion)
- Update the variables for templates "formGroup", "label" and "checkboxFormGroup" (some variables were missing)

I hope I didn't miss anything.
If this is considered "mergeable", I can take care of the others languages.
