### PR TITLE
Update database-basics.rst

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -71,10 +71,14 @@ There are a number of keys supported in database configuration. A full list is
 as follows:
 
 className
-    The class name of the driver used to power the connection. This can either
-    be a short classname using :term:`plugin syntax`, a fully namespaced name, or
-    a constructed driver instance. Examples of short classnames are Mysql,
-    Sqlite, Postgres, and Sqlserver.
+    The fully namespaced class name of the class that represents the connection to a database server.
+    This class is responsible for loading the database driver, providing SQL
+    transaction mechanisms and preparing SQL statements among other things.
+driver
+    The class name of the driver used to implements all specificities for
+    a database engine. This can either be a short classname using :term:`plugin syntax`,
+    a fully namespaced name, or a constructed driver instance.
+    Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.
 persistent
     Whether or not to use a persistent connection to the database.
 host

--- a/es/orm/database-basics.rst
+++ b/es/orm/database-basics.rst
@@ -67,10 +67,14 @@ There are a number of keys supported in database configuration. A full list is
 as follows:
 
 className
-    The class name of the driver used to power the connection. This can either
-    be a short classname using :term:`plugin syntax`, a fully namespaced name, or
-    a constructed driver instance. Examples of short classnames are Mysql,
-    Sqlite, Postgres, and Sqlserver.
+    The fully namespaced class name of the class that represents the connection to a database server.
+    This class is responsible for loading the database driver, providing SQL
+    transaction mechanisms and preparing SQL statements among other things.
+driver
+    The class name of the driver used to implements all specificities for
+    a database engine. This can either be a short classname using :term:`plugin syntax`,
+    a fully namespaced name, or a constructed driver instance.
+    Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.
 persistent
     Whether or not to use a persistent connection to the database.
 host

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -74,11 +74,16 @@ Il y a un certain nombre de clés supportés dans la configuration de la base
 de données. Une liste complète est comme suit:
 
 className
-    Le nom de la classe du driver utilisée pour faire fonctionner la connection.
-    Ceci peut être soit un nom de classe court en utilisant la
-    :term:`syntaxe de plugin`, un nom complet en namespace, soit être une
-    instance de driver construite. Les exemples de noms de classe court sont
-    Mysql, Sqlite, Postgres, et Sqlserver.
+    Nom de classe complète (incluant le *namespace*) de la classe qui représente une connexion
+    au serveur de base de données.
+    Cette classe a la charge de charger le driver de base de données, d'apporter les méchanismes de
+    transaction SQL et de préparer les requêtes SQL (entres autres choses).
+driver
+    Le nom de la classe du driver utilisée pour implémenter les spécificités
+    du moteur de base de données. Cela peut être soit un nom de classe court en utilisant la
+    :term:`syntaxe de plugin`, un nom complet en namespace, soit être une instance
+    de driver construite. Les exemples de noms de classe courts sont Mysql,
+    Sqlite, Postgres, et Sqlserver.
 persistent
     S'il faut utiliser ou non une connection persistante à la base de données.
 host

--- a/pt/orm/database-basics.rst
+++ b/pt/orm/database-basics.rst
@@ -60,10 +60,14 @@ There are a number of keys supported in database configuration. A full list is
 as follows:
 
 className
-    The class name of the driver used to power the connection. This can either
-    be a short classname using :term:`plugin syntax`, a fully namespaced name, or
-    a constructed driver instance. Examples of short classnames are Mysql,
-    Sqlite, Postgres, and Sqlserver.
+    The fully namespaced class name of the class that represents the connection to a database server.
+    This class is responsible for loading the database driver, providing SQL
+    transaction mechanisms and preparing SQL statements among other things.
+driver
+    The class name of the driver used to implements all specificities for
+    a database engine. This can either be a short classname using :term:`plugin syntax`,
+    a fully namespaced name, or a constructed driver instance.
+    Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.
 persistent
     Whether or not to use a persistent connection to the database.
 host


### PR DESCRIPTION
The keys list for the Connection config was not up-to-date.
The key "driver" was missing and the "className" description matched the one of "driver".

I also corrected some mistakes for the French version around that area.
