### PR TITLE
Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -94,9 +94,12 @@ execute until you start fetching rows, convert it to an array, or when the
     // Converting the query to an array will execute it.
     $results = $query->toArray();
 
-Once you've started a query you can use the :doc:`/orm/query-builder` interface
-to build more complex queries, adding additional conditions, limits, or include
-associations using the fluent interface::
+.. note::
+
+    Once you've started a query you can use the :doc:`/orm/query-builder` interface
+    to build more complex queries, adding additional conditions, limits, or include
+    associations using the fluent interface::
+
 
     // In a controller or table method.
     $query = $articles->find('all')


### PR DESCRIPTION
The link to the query builder is quite important, since the query builder doc page extends this page. But when scrolling over this page, it's not very obvious. It just looks like the examples above are explained here and the link is pretty "hidden". This should help make the link (and it's importance) more clear.
