### PR TITLE
Complements Monolog example

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -413,7 +413,7 @@ After installing Monolog using composer, configure the logger using the
         return $log;
     });
 
-    // Optionally stop using the default separated logfiles
+    // Optionally stop using the now redundant default loggers
     Log::drop('debug');
     Log::drop('error');
 


### PR DESCRIPTION
Hopefully this minor update will make clear that:
- the example will result in a logger with a combined log containing all levels
- the user could/should disable the default loggers to prevent redundant/slower logging
