### PR TITLE
delete submenu margin

### DIFF
--- a/themes/cakephp/static/cake.css
+++ b/themes/cakephp/static/cake.css
@@ -305,10 +305,10 @@ a.improve {
 	float: right;
 }
 
-#sidebar-navigation > ul > li:nth-of-type(5) a:after,
-#sidebar-navigation > ul > li:nth-of-type(13) a:after,
-#sidebar-navigation > ul > li:nth-of-type(31) a:after,
-#sidebar-navigation > ul > li:nth-of-type(42) a:after {
+#sidebar-navigation > ul > li:nth-of-type(5):last-child:after,
+#sidebar-navigation > ul > li:nth-of-type(13):last-child:after,
+#sidebar-navigation > ul > li:nth-of-type(31):last-child:after,
+#sidebar-navigation > ul > li:nth-of-type(42):last-child:after {
     content: " ";
     display: block;
     margin-bottom: 1em;


### PR DESCRIPTION
The contributing menu had some strange margin as you can see below due to our CSS trick for the menu.
![capture](https://cloud.githubusercontent.com/assets/4977112/5564151/aec5905c-8eac-11e4-9547-001eac4c5b59.PNG)
