### PR TITLE
[fr] Corrige la syntaxe d'un exemple

### DIFF
--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -690,8 +690,7 @@ exemple, considérons la requête qui permet de récupérer les ids d'article et
 leur nombre de commentaires::
 
     $query = $articles->find();
-    $query->find()
-        ->select(['Articles.id', $query->func()->count('Comments.id')])
+    $query->select(['Articles.id', $query->func()->count('Comments.id')])
         ->matching('Comments')
         ->group(['Articles.id']);
     $total = $query->count();


### PR DESCRIPTION
Je suppose que les autres langues sont à corriger aussi car l'Anglais comporte cette même erreur.
