### PR TITLE
Update validation.rst

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -278,6 +278,7 @@ create ``Validator`` sub-classes for your reusable validation logic::
     {
         public function __construct()
         {
+            parent::__construct();
             // Add validation rules here.
         }
     }


### PR DESCRIPTION
The parent constructor must be called for translations to work. Although it's good practice to call it, the example seemed to imply it wasn't necessary.
