### PR TITLE
Wrong variable name

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -759,7 +759,7 @@ table class. Behaviors and other event subscribers can use the
 class::
 
     // In a table class
-    public function buildRules(RulesChecker $checker) {
+    public function buildRules(RulesChecker $rules) {
         // Add a rule that is applied for create and update operations
         $rules->add(function ($entity, $options) {
             // Return a boolean to indicate pass/fail


### PR DESCRIPTION
$rules is used in the method but $checker is use in the paramlist
