### PR TITLE
[en] saving-data.rst Improve explanations and example

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -759,6 +759,8 @@ table class. Behaviors and other event subscribers can use the
 ``Model.buildRules`` event to augment the rules checker for a given Table
 class::
 
+    use Cake\ORM\RulesChecker
+    
     // In a table class
     public function buildRules(RulesChecker $rules) {
         // Add a rule that is applied for create and update operations

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -759,7 +759,7 @@ table class. Behaviors and other event subscribers can use the
 ``Model.buildRules`` event to augment the rules checker for a given Table
 class::
 
-    use Cake\ORM\RulesChecker
+    use Cake\ORM\RulesChecker;
     
     // In a table class
     public function buildRules(RulesChecker $rules) {


### PR DESCRIPTION
I think that the doc should notice that now, setting a field with the set() method could be a problem in the way that all validation rules called with patchEntity and newEntity won't be applied.