### PR TITLE
Docs for CakeText.

### DIFF
--- a/en/appendices/2-7-migration-guide.rst
+++ b/en/appendices/2-7-migration-guide.rst
@@ -22,17 +22,19 @@ CakeSession
 -----------
 - :php:meth:`CakeSession::consume()` has been added to read and delete from
   session in a single step.
-- Argument `$renew` has been added to :php:meth:`CakeSession::clear()` to allow emptying the session
-without forcing a new id and renewing the session. It defaults to ``true``.
+- Argument `$renew` has been added to :php:meth:`CakeSession::clear()` to allow
+  emptying the session without forcing a new id and renewing the session. It
+  defaults to ``true``.
 
 
 Utility
 =======
 
 CakeText
-========
-The class ``String`` has been renamed to ``CakeText``. This resolves some conflicts around HHVM compatability as well
-as possibly PHP7+. There is a ``String`` class provided as well for compatibility reasons.
+--------
+The class ``String`` has been renamed to ``CakeText``. This resolves some
+conflicts around HHVM compatability as well as possibly PHP7+. There is
+a ``String`` class provided as well for compatibility reasons.
 
 
 Controller
@@ -50,6 +52,7 @@ View
 
 SessionHelper
 -------------
+
 - :php:meth:`SessionHelper::consume()` has been added to read and delete from
   session in a single step.
 
@@ -59,4 +62,5 @@ TestSuite
 
 ControllerTestCase
 ------------------
+
 - :php:meth:`ControllerTestCase::testAction()` now supports an array as URL.

--- a/en/appendices/2-7-migration-guide.rst
+++ b/en/appendices/2-7-migration-guide.rst
@@ -25,6 +25,16 @@ CakeSession
 - Argument `$renew` has been added to :php:meth:`CakeSession::clear()` to allow emptying the session
 without forcing a new id and renewing the session. It defaults to ``true``.
 
+
+Utility
+=======
+
+CakeText
+========
+The class ``String`` has been renamed to ``CakeText``. This resolves some conflicts around HHVM compatability as well
+as possibly PHP7+. There is a ``String`` class provided as well for compatibility reasons.
+
+
 Controller
 ==========
 


### PR DESCRIPTION
Docs for https://github.com/cakephp/cakephp/pull/5559

What about the docs regarding `string.rst`? Rename, as well + create a BC page with a link?

Feel free to add commits on top if something is missing.