### PR TITLE
Remove modindex from PDF contents...

### DIFF
--- a/en/pdf-contents.rst
+++ b/en/pdf-contents.rst
@@ -26,4 +26,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`

--- a/es/pdf-contents.rst
+++ b/es/pdf-contents.rst
@@ -15,4 +15,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`

--- a/fr/pdf-contents.rst
+++ b/fr/pdf-contents.rst
@@ -27,4 +27,3 @@ Indices et tables
 =================
 
 * :ref:`genindex`
-* :ref:`modindex`

--- a/ja/pdf-contents.rst
+++ b/ja/pdf-contents.rst
@@ -17,4 +17,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`

--- a/pt/pdf-contents.rst
+++ b/pt/pdf-contents.rst
@@ -20,4 +20,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`

--- a/zh/pdf-contents.rst
+++ b/zh/pdf-contents.rst
@@ -18,4 +18,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`


### PR DESCRIPTION
... as we do not have any module index page.

 http://book.cakephp.org/2.0/en/modindex.html
 http://book.cakephp.org/2.0/en/py-modindex.html

Like this one:
http://sphinx-doc.org/py-modindex.html
https://github.com/sphinx-doc/sphinx/blame/master/doc/contents.rst#L36

Partially relevant: https://github.com/cakephp/docs/issues/2068