### PR TITLE
Replace pear.phpunit.de with composer and phar.phpunit.de

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -12,13 +12,25 @@ Installing PHPUnit
 
 CakePHP uses PHPUnit as its underlying test framework. PHPUnit is the de-facto
 standard for unit testing in PHP. It offers a deep and powerful set of features
-for making sure your code does what you think it does. PHPUnit can be installed
-through the `pear installer <http://pear.php.net>`_. To install PHPUnit run the
-following::
+for making sure your code does what you think it does.::
 
-    pear upgrade PEAR
-    pear config-set auto_discover 1
-    pear install pear.phpunit.de/PHPUnit-3.7.32
+As of Dec. 31st, 2014 installation via pear.phpunit.de is no longer valid.
+    
+Install via Composer
+--------------------
+The newer versions of phpunit do not currently work with cake::
+
+    "phpunit/phpunit": "3.7.32"
+    
+Install via .phar Package
+-------------------------
+
+You can also download the file directly. Just make sure you get the correct version from https://phar.phpunit.de/. 
+Make sure /usr/local/bin is in your php.ini file's include_path::
+
+    wget https://phar.phpunit.de/phpunit-3.7.32.phar
+    chmod +x phpunit.phar
+    mv phpunit.phar /usr/local/bin/phpunit
 
 .. note::
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -12,9 +12,7 @@ Installing PHPUnit
 
 CakePHP uses PHPUnit as its underlying test framework. PHPUnit is the de-facto
 standard for unit testing in PHP. It offers a deep and powerful set of features
-for making sure your code does what you think it does.::
-
-As of Dec. 31st, 2014 installation via pear.phpunit.de is no longer valid.
+for making sure your code does what you think it does.
     
 Install via Composer
 --------------------


### PR DESCRIPTION
As of Dec. 31st 2014, phpunit is no longer available as a pear package.