### PR TITLE
Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -371,6 +371,23 @@ The above would translate into the following::
     additional performance overhead.
 
 
+Retrieving Associated Data
+==========================
+
+When you want to grab associated data, or filter based on associated data, there are basically two ways:
+ - use CakePHP ORM query functions like ``contain()`` and ``matching()``
+ - use join functions like ``innerJoin()``, ``leftJoin()``, and ``rightJoin()``
+ 
+When do you use ``contain()``?
+You use it when the main model hasOne or belongsTo the associated data models. 
+For more details on the ``contain()``, look at :doc:`/orm/retrieving-data-and-resultsets#eager-loading-associations`
+
+When do you use ``matching()``?
+You use it when the main model hasMany associated data models. 
+For more details on the ``matching()``, look at :doc:`/orm/retrieving-data-and-resultsets#filtering-by-associated-data`
+
+If you prefer to use join functions, you can look at :doc:`/orm/query-builder#adding-joins` for details.
+ 
 Eager Loading Associations
 ==========================
 


### PR DESCRIPTION
The documentation write mainly from the point of view of features rather than from the point of view of benefits.

Beginners may not even be aware of matching so how can they even find something they are not aware of?

Beginners search by the question they have: how do I grab associated data, how do I filter based on associated data? how do i pass options into the inner query?

That is basically what prompted me to write this stackoverflow question, answered brilliantly by ndm.

http://stackoverflow.com/a/28002497/80353

I am adding this change so that a beginner will find it easier to get what I had to ask through stackoverflow.