### PR TITLE
Use correct value for development cache flush

### DIFF
--- a/en/deployment.rst
+++ b/en/deployment.rst
@@ -14,7 +14,7 @@ things:
 
 * Debug messages, created with :php:func:`pr()` and :php:func:`debug()` are
   disabled.
-* Core CakePHP caches are by default flushed every 999 days, instead of every
+* Core CakePHP caches are by default flushed every year (about 365 days), instead of every
   10 seconds as in development.
 * Error views are less informative, and give generic error messages instead.
 * PHP Errors are not displayed.


### PR DESCRIPTION
~ line 80 of `config/bootstrap.php` uses `+1 years` for cache expiration when in development mode.