### PR TITLE
add link to i18n shell in internationalization

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -89,7 +89,7 @@ Extract Pot Files with I18n Shell
 
 To create the pot files from `__()` and other internationalized types of
 messages that can be found in your code, you can use the i18n shell. Please read
-the `following chapter </console-and-shells/i18n-shell>` to learn more.
+the :doc:`following chapter </console-and-shells/i18n-shell>` to learn more.
 
 Setting the Default Locale
 --------------------------

--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -89,7 +89,7 @@ Extract Pot Files with I18n Shell
 
 To create the pot files from `__()` and other internationalized types of
 messages that can be found in your code, you can use the i18n shell. Please read
-the `following chapter </intro/where-to-get-help>` to learn more.
+the `following chapter </console-and-shells/i18n-shell>` to learn more.
 
 Setting the Default Locale
 --------------------------

--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -19,8 +19,8 @@ Setting Up Translations
 
 There are only a few steps to go from a single-language application
 to a multi-lingual application, the first of which is to make use
-of the :php:func:`__()` function in your code. Below is an example of some code for a
-single-language application::
+of the :php:func:`__()` function in your code. Below is an example of some code
+for a single-language application::
 
     <h2>Popular Articles</h2>
 
@@ -84,6 +84,13 @@ An example translation file could look like this:
      msgid "I'm {0,number} years old"
      msgstr "J'ai {0,number} ans"
 
+Extract Pot Files with I18n Shell
+---------------------------------
+
+To create the pot files from `__()` and other internationalized types of
+messages that can be found in your code, you can use the i18n shell. Please read
+the `following chapter </intro/where-to-get-help>` to learn more.
+
 Setting the Default Locale
 --------------------------
 
@@ -119,7 +126,8 @@ translation was found::
     echo __('Popular Articles');
 
 If you need to group your messages, for example, translations inside a plugin,
-you can use the :php:func:`__d()` function to fetch messages from another domain::
+you can use the :php:func:`__d()` function to fetch messages from another
+domain::
 
     echo __d('my_plugin', 'Trending right now');
 
@@ -407,7 +415,7 @@ application. Next, create the translations file under
 And finally, configure the translation loader for the domain and locale::
 
     use Cake\I18n\MessagesFileLoader as Loader;
-    
+
     I18n::translator(
         'animals',
         'fr_FR',
@@ -447,9 +455,9 @@ Plurals and Context in Custom Translators
 -----------------------------------------
 
 The arrays used for ``setMessages()`` can be crafted to instruct the translator
-to store messages under different domains or to trigger Gettext-style plural selection.
-The following is an example of storing translations for the same key in
-different contexts::
+to store messages under different domains or to trigger Gettext-style plural
+selection. The following is an example of storing translations for the same key
+in different contexts::
 
     [
         'He reads the letter {0}' => [
@@ -474,8 +482,8 @@ Using Different Formatters
 
 In previous examples we have seen that Packages are built using ``default`` as
 first argument, and it was indicated with a comment that it corresponded to the
-formatter to be used. Formatters are  classes responsible for interpolating variables
-in translation messages and selecting the correct plural form.
+formatter to be used. Formatters are  classes responsible for interpolating
+variables in translation messages and selecting the correct plural form.
 
 If you're dealing with a legacy application, or you don't need the power offered
 by the ICU message formatting, CakePHP also provides the ``sprintf`` formatter::

--- a/fr/core-libraries/internationalization-and-localization.rst
+++ b/fr/core-libraries/internationalization-and-localization.rst
@@ -89,7 +89,7 @@ Extract Pot Files with I18n Shell
 
 To create the pot files from `__()` and other internationalized types of
 messages that can be found in your code, you can use the i18n shell. Please read
-the `following chapter </console-and-shells/i18n-shell>` to learn more.
+the :doc:`following chapter </console-and-shells/i18n-shell>` to learn more.
 
 Définir la Locale par Défaut
 ----------------------------

--- a/fr/core-libraries/internationalization-and-localization.rst
+++ b/fr/core-libraries/internationalization-and-localization.rst
@@ -37,7 +37,7 @@ traduction est disponible, sinon elle la renverra non modifiée.
 Fichiers de Langues
 -------------------
 
-Les traductions peuvent être mis à disposition en utilisant des fichiers 
+Les traductions peuvent être mis à disposition en utilisant des fichiers
 de langue stockés dans votre application. Le format par défaut pour ces fichiers est
 le format `Gettext <http://en.wikipedia.org/wiki/Gettext>`_. Ces fichiers doivent être
 placés dans ``src/Locale/`` et dans ce répertoire, il devrait y avoir
@@ -54,12 +54,12 @@ un sous-dossier par langue que l'application doit prendre en charge::
             /es
                 default.po
 
-Le domaine par défaut est 'default', votre dossier ``locale`` devrait donc 
+Le domaine par défaut est 'default', votre dossier ``locale`` devrait donc
 contenir au minimum le fichier ``default.po`` (cf. ci-dessus). Un domaine se réfère à un regroupement
 arbitraire de messages de traduction. Si aucun groupe n'est utilisé, le groupe par défaut
 est sélectionné.
 
-Les plugins peuvent également contenir des fichiers de traduction, la convention est d'utiliser la version 
+Les plugins peuvent également contenir des fichiers de traduction, la convention est d'utiliser la version
 ``under_scored`` du nom du plugin comme domaine de la traduction des messages::
 
     MyPlugin
@@ -70,8 +70,8 @@ Les plugins peuvent également contenir des fichiers de traduction, la conventio
                 /de
                     my_plugin.po
 
-Les dossiers de traduction peuvent être composées d'un code à deux lettres ISO de 
-la langue ou du nom de la locale, par exemple ``fr_FR``, ``es_AR``, ``da_DK``, 
+Les dossiers de traduction peuvent être composées d'un code à deux lettres ISO de
+la langue ou du nom de la locale, par exemple ``fr_FR``, ``es_AR``, ``da_DK``,
 qui contient en même temps la langue et le pays où elle est parlée.
 
 Un fichier de traduction pourrait ressembler à ceci :
@@ -84,6 +84,13 @@ Un fichier de traduction pourrait ressembler à ceci :
      msgid "I'm {0,number} years old"
      msgstr "J'ai {0,number} ans"
 
+Extract Pot Files with I18n Shell
+---------------------------------
+
+To create the pot files from `__()` and other internationalized types of
+messages that can be found in your code, you can use the i18n shell. Please read
+the `following chapter </console-and-shells/i18n-shell>` to learn more.
+
 Définir la Locale par Défaut
 ----------------------------
 
@@ -92,9 +99,9 @@ via::
 
     ini_set('intl.default_locale', 'fr_FR');
 
-Cela permet de contrôler plusieurs aspects de votre application, incluant la langue 
-de traduction par défaut, le format des dates, des nombres, et devises 
-à chaque fois qu'un de ces éléments s'affiche, en utilisant les bibliothèques 
+Cela permet de contrôler plusieurs aspects de votre application, incluant la langue
+de traduction par défaut, le format des dates, des nombres, et devises
+à chaque fois qu'un de ces éléments s'affiche, en utilisant les bibliothèques
 de localisation fournies par CakePHP.
 
 Changing the Locale at Runtime
@@ -408,7 +415,7 @@ application. Next, create the translations file under
 And finally, configure the translation loader for the domain and locale::
 
     use Cake\I18n\MessagesFileLoader as Loader;
-    
+
     I18n::translator(
         'animals',
         'fr_FR',


### PR DESCRIPTION
I found that we can have a link to the I18n shell in the main internationalization chapter.