### PR TITLE
Correcting closure example

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -197,8 +197,9 @@ callable, including anonymous functions, as validation rules::
     ]);
 
     // Use a closure
+    $value = 'Some additional value needed inside the closure';
     $validator->add('title', 'custom', [
-        'rule' => function ($value, $context) {
+        'rule' => function ($context) use ($value) {
             // Custom logic that returns true/false
         }
     ]);


### PR DESCRIPTION
Using $value in there is wrong, the only argument is the first being $closure directly. So it should be

    function ($context) {}

But I added a custom value in the use part to show how to insert those into the closure if desired.