### PR TITLE
Add Flash message and redirect in case delete fails

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -563,8 +563,13 @@ Next, let's make a way for users to delete posts. Start with a
             $this->Session->setFlash(
                 __('The post with id: %s has been deleted.', h($id))
             );
-            return $this->redirect(array('action' => 'index'));
+        } else {
+            $this->Session->setFlash(
+                __('The post with id: %s could not be deleted.', h($id))
+            );
         }
+
+        return $this->redirect(array('action' => 'index'));
     }
 
 This logic deletes the post specified by $id, and uses

--- a/ja/tutorials-and-examples/blog/part-two.rst
+++ b/ja/tutorials-and-examples/blog/part-two.rst
@@ -480,9 +480,16 @@ PostsControllerの ``delete()`` アクションを作るところから始めま
         }
 
         if ($this->Post->delete($id)) {
-            $this->Session->setFlash(__('The post with id: %s has been deleted.', h($id)));
-            return $this->redirect(array('action' => 'index'));
+            $this->Session->setFlash(
+                __('The post with id: %s has been deleted.', h($id))
+            );
+        } else {
+            $this->Session->setFlash(
+                __('The post with id: %s could not be deleted.', h($id))
+            );
         }
+
+        return $this->redirect(array('action' => 'index'));
     }
 
 このロジックは、$idで指定された記事を削除し、

--- a/zh/tutorials-and-examples/blog/part-two.rst
+++ b/zh/tutorials-and-examples/blog/part-two.rst
@@ -494,8 +494,13 @@ edit 视图会是这样:
             $this->Session->setFlash(
                 __('The post with id: %s has been deleted.', h($id))
             );
-            return $this->redirect(array('action' => 'index'));
+        } else {
+            $this->Session->setFlash(
+                __('The post with id: %s could not be deleted.', h($id))
+            );
         }
+
+        return $this->redirect(array('action' => 'index'));
     }
 
 这个逻辑删除 `$id` 指定的文章(*post*)，然后使用 ``$this->Session->setFlash()``，


### PR DESCRIPTION
With the current tutorial, if a delete operation fails you are met with a cakePHP error message informing you about the delete action not having its own View (because in case of failure not redirection takes place).

Instead, you should be shown a corresponding flash message and be redirected to the index page.

The simplest case to reproduce this is to open the posts/index page in 2 tabs and delete one post from the one tab and then try to delete the same post from the other tab.