### PR TITLE
Recommend EventManager::on/off.

### DIFF
--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -21,8 +21,8 @@ be used::
 
     use Cake\Event\Event;
     use Cake\Event\EventManager;
-    
-    EventManager::instance()->attach(function (Event $event) {
+
+    EventManager::instance()->on('Bake.initialize', function (Event $event) {
         $view = $event->subject;
 
         // In my bake templates, allow the use of the MySpecial helper
@@ -31,7 +31,7 @@ be used::
         // And add an $author variable so it's always available
         $view->set('author', 'Andy');
 
-    }, 'Bake.initialize');
+    });
 
 Bake events can also be useful for making small changes to existing templates.
 For example, to change the variable names used when baking controller/template
@@ -43,8 +43,8 @@ variables used in the bake templates::
 
     use Cake\Event\Event;
     use Cake\Event\EventManager;
-    
-    EventManager::instance()->attach(function (Event $event) {
+
+    EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
         $view = $event->subject;
 
         // Use $rows for the main data variable in indexes
@@ -63,7 +63,7 @@ variables used in the bake templates::
             $view->set('singularVar', 'theOne');
         }
 
-    }, 'Bake.beforeRender');
+    });
 
 
 Bake Template Syntax

--- a/en/controllers/components/csrf.rst
+++ b/en/controllers/components/csrf.rst
@@ -72,7 +72,7 @@ requests. You can do this using the controller's event dispatcher, during the
 
     public function beforeFilter(Event $event)
     {
-        $this->eventManager()->detach($this->Csrf);
+        $this->eventManager()->off($this->Csrf);
     }
 
 .. meta::

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -103,9 +103,9 @@ access the global manager using a static method::
     // In any configuration file or piece of code that executes before the event
     use Cake\Event\EventManager;
 
-    EventManager::instance()->attach(
-        $aCallback,
-        'Model.Order.afterPlace'
+    EventManager::instance()->on(
+        'Model.Order.afterPlace',
+        $aCallback
     );
 
 One important thing you should consider is that there are events that will be
@@ -153,17 +153,17 @@ Finally, the third argument is any additional event data.This can be any data yo
 useful to pass around so listeners can act upon it. While this can be an argument
 of any type, we recommend passing an associative array.
 
-The :php:meth:`~Cake\\Event\\EventManager::dispatch()` method accepts an event object as an argument
-and notifies all subscribed listeners.
+The :php:meth:`~Cake\\Event\\EventManager::dispatch()` method accepts an event
+object as an argument and notifies all subscribed listeners.
 
 Registering Listeners
 =====================
 
-Listeners are the preferred way to register callbacks for an event. This is done by
-implementing the :php:class:`Cake\\Event\\EventListenerInterface` interface in any class you wish
-to register some callbacks. Classes implementing it need to provide the
-``implementedEvents()`` method. This method must return an associative array
-with all event names that the class will handle.
+Listeners are the preferred way to register callbacks for an event. This is done
+by implementing the :php:class:`Cake\\Event\\EventListenerInterface` interface
+in any class you wish to register some callbacks. Classes implementing it need
+to provide the ``implementedEvents()`` method. This method must return an
+associative array with all event names that the class will handle.
 
 To continue our previous example, let's imagine we have a UserStatistic class
 responsible for calculating a user's purchasing history, and compiling into
@@ -191,9 +191,9 @@ necessary. Our ``UserStatistics`` listener might start out like::
 
     // Attach the UserStatistic object to the Order's event manager
     $statistics = new UserStatistic();
-    $this->Orders->eventManager()->attach($statistics);
+    $this->Orders->eventManager()->on($statistics);
 
-As you can see in the above code, the ``attach`` function will accept instances
+As you can see in the above code, the ``on`` function will accept instances
 of the ``EventListener`` interface. Internally, the event manager will use
 ``implementedEvents`` to attach the correct callbacks.
 
@@ -207,12 +207,12 @@ function to do so::
 
     use Cake\Log\Log;
 
-    $this->Orders->eventManager()->attach(function ($event) {
+    $this->Orders->eventManager()->on('Model.Order.afterPlace', function ($event) {
         Log::write(
             'info',
             'A new order was placed with id: ' . $event->subject()->id
         );
-    }, 'Model.Order.afterPlace');
+    });
 
 In addition to anonymous functions you can use any other callable type that PHP
 supports::
@@ -222,7 +222,7 @@ supports::
         'inventory' => [$this->InventoryManager, 'decrement'],
     ];
     foreach ($events as $callable) {
-        $eventManager->attach($callable, 'Model.Order.afterPlace');
+        $eventManager->on('Model.Order.afterPlace', $callable);
     }
 
 .. _event-priorities:
@@ -251,10 +251,10 @@ event listeners::
 
     // Setting priority for a callback
     $callback = [$this, 'doSomething'];
-    $this->eventManager()->attach(
-        $callback,
+    $this->eventManager()->on(
         'Model.Order.afterPlace',
-        ['priority' => 2]
+        ['priority' => 2],
+        $callback
     );
 
     // Setting priority for a listener
@@ -399,31 +399,31 @@ Removing Callbacks and Listeners
 --------------------------------
 
 If for any reason you want to remove any callback from the event manager just
-call the :php:meth:`Cake\\Event\\EventManager::detach()` method using as
+call the :php:meth:`Cake\\Event\\EventManager::off()` method using as
 arguments the first two params you used for attaching it::
 
     // Attaching a function
-    $this->eventManager()->attach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->on('My.event', [$this, 'doSomething']);
 
     // Detaching the function
-    $this->eventManager()->detach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->off('My.event', [$this, 'doSomething']);
 
     // Attaching an anonymous function.
     $myFunction = function ($event) { ... };
-    $this->eventManager()->attach($myFunction, 'My.event');
+    $this->eventManager()->on('My.event', $myFunction);
 
     // Detaching the anonymous function
-    $this->eventManager()->detach($myFunction, 'My.event');
+    $this->eventManager()->off('My.event', $myFunction);
 
-    // Attaching a EventListener
+    // Adding a EventListener
     $listener = new MyEventLister();
-    $this->eventManager()->attach($listener);
+    $this->eventManager()->on($listener);
 
     // Detaching a single event key from a listener
-    $this->eventManager()->detach($listener, 'My.event');
+    $this->eventManager()->off('My.event', $listener);
 
     // Detaching all callbacks implemented by a listener
-    $this->eventManager()->detach($listener);
+    $this->eventManager()->off($listener);
 
 Conclusion
 ==========

--- a/en/core-libraries/registry-objects.rst
+++ b/en/core-libraries/registry-objects.rst
@@ -47,10 +47,10 @@ the events system. For example you could disable component callbacks in the
 following way::
 
     // Remove Auth from callbacks.
-    $this->eventManager()->detach($this->Auth);
+    $this->eventManager()->off($this->Auth);
 
     // Re-enable Auth for callbacks.
-    $this->eventManager()->attach($this->Auth);
+    $this->eventManager()->on($this->Auth);
 
 
 .. meta::

--- a/es/core-libraries/components/csrf-component.rst
+++ b/es/core-libraries/components/csrf-component.rst
@@ -75,7 +75,7 @@ requests. You can do this using the controller's event dispatcher, during the
 
     public function beforeFilter(Event $event)
     {
-        $this->eventManager()->detach($this->Csrf);
+        $this->eventManager()->off($this->Csrf);
     }
 
 .. meta::

--- a/es/core-libraries/events.rst
+++ b/es/core-libraries/events.rst
@@ -108,9 +108,9 @@ access the global manager using a static method::
     // In any configuration file or piece of code that executes before the event
     use Cake\Event\EventManager;
 
-    EventManager::instance()->attach(
-        $aCallback,
-        'Model.Order.afterPlace'
+    EventManager::instance()->on(
+        'Model.Order.afterPlace',
+        $aCallback
     );
 
 One important thing you should consider is that there are events that will be
@@ -196,7 +196,7 @@ necessary. Our ``UserStatistics`` listener might start out like::
 
     // Attach the UserStatistic object to the Order's event manager
     $statistics = new UserStatistic();
-    $this->Orders->eventManager()->attach($statistics);
+    $this->Orders->eventManager()->on($statistics);
 
 As you can see in the above code, the ``attach`` function will accept instances
 of the ``EventListener`` interface. Internally, the event manager will use
@@ -212,12 +212,12 @@ function to do so::
 
     use Cake\Log\Log;
 
-    $this->Orders->eventManager()->attach(function($event) {
+    $this->Orders->eventManager()->on('Model.Order.afterPlace', function($event) {
         Log::write(
             'info',
             'A new order was placed with id: ' . $event->subject()->id
         );
-    }, 'Model.Order.afterPlace');
+    });
 
 In addition to anonymous functions you can use any other callable type that PHP
 supports::
@@ -227,7 +227,7 @@ supports::
         'inventory' => array($this->InventoryManager, 'decrement'),
     );
     foreach ($events as $callable) {
-        $eventManager->attach($callable, 'Model.Order.afterPlace');
+        $eventManager->on('Model.Order.afterPlace', $callable);
     }
 
 .. _event-priorities:
@@ -256,10 +256,10 @@ event listeners::
 
     // Setting priority for a callback
     $callback = array($this, 'doSomething');
-    $this->eventManager()->attach(
-        $callback,
+    $this->eventManager()->on(
         'Model.Order.afterPlace',
-        array('priority' => 2)
+        array('priority' => 2),
+        $callback
     );
 
     // Setting priority for a listener
@@ -404,31 +404,31 @@ Removing Callbacks and Listeners
 --------------------------------
 
 If for any reason you want to remove any callback from the event manager just
-call the :php:meth:`Cake\\Event\\EventManager::detach()` method using as
+call the :php:meth:`Cake\\Event\\EventManager::off()` method using as
 arguments the first two params you used for attaching it::
 
     // Attaching a function
-    $this->eventManager()->attach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->on('My.event', [$this, 'doSomething']);
 
     // Detaching the function
-    $this->eventManager()->detach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->off('My.event', [$this, 'doSomething']);
 
     // Attaching an anonymous function.
     $myFunction = function ($event) { ... };
-    $this->eventManager()->attach($myFunction, 'My.event');
+    $this->eventManager()->on('My.event', $myFunction);
 
     // Detaching the anonymous function
-    $this->eventManager()->detach($myFunction, 'My.event');
+    $this->eventManager()->off('My.event', $myFunction);
 
     // Attaching a EventListener
     $listener = new MyEventLister();
-    $this->eventManager()->attach($listener);
+    $this->eventManager()->on($listener);
 
     // Detaching a single event key from a listener
-    $this->eventManager()->detach($listener, 'My.event');
+    $this->eventManager()->off('My.event', $listener);
 
     // Detaching all callbacks implemented by a listener
-    $this->eventManager()->detach($listener);
+    $this->eventManager()->off($listener);
 
 Conclusion
 ==========

--- a/es/core-libraries/registry-objects.rst
+++ b/es/core-libraries/registry-objects.rst
@@ -52,10 +52,10 @@ the events system. For example you could disable component callbacks in the
 following way::
 
     // Remove Auth from callbacks.
-    $this->eventManager()->detach($this->Auth);
+    $this->eventManager()->off($this->Auth);
 
     // Re-enable Auth for callbacks.
-    $this->eventManager()->attach($this->Auth);
+    $this->eventManager()->on($this->Auth);
 
 
 .. meta::

--- a/fr/bake/development.rst
+++ b/fr/bake/development.rst
@@ -23,7 +23,7 @@ un autre helper à la classe de vue bake, cet event peut être utilisé::
     use Cake\Event\Event;
     use Cake\Event\EventManager;
 
-    EventManager::instance()->attach(function (Event $event) {
+    EventManager::instance()->on('Bake.initialize', function (Event $event) {
         $view = $event->subject;
 
         // Dans mes templates de bake, permet l'utilisation du helper MySpecial
@@ -32,7 +32,7 @@ un autre helper à la classe de vue bake, cet event peut être utilisé::
         // Et ajoute une variable $author pour qu'elle soit toujours disponible
         $view->set('author', 'Andy');
 
-    }, 'Bake.initialize');
+    });
 
 Les events de Bake peuvent aussi être utiles pour faire des petits
 changements aux templates existants. Par exemple, pour changer les noms de
@@ -47,7 +47,7 @@ de bake::
     use Cake\Event\Event;
     use Cake\Event\EventManager;
 
-    EventManager::instance()->attach(function (Event $event) {
+    EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
         $view = $event->subject;
 
         // Utilise $rows pour les principales variables de données dans les indexes
@@ -66,7 +66,7 @@ de bake::
             $view->set('singularVar', 'theOne');
         }
 
-    }, 'Bake.beforeRender');
+    });
 
 
 Syntaxe de Template de Bake

--- a/fr/controllers/components/csrf.rst
+++ b/fr/controllers/components/csrf.rst
@@ -78,7 +78,7 @@ controller, au cours de la méthode ``beforeFilter``::
 
     public function beforeFilter(Event $event)
     {
-        $this->eventManager()->detach($this->Csrf);
+        $this->eventManager()->off($this->Csrf);
     }
 
 .. meta::

--- a/fr/core-libraries/events.rst
+++ b/fr/core-libraries/events.rst
@@ -120,9 +120,9 @@ en utilisant une méthode statique::
     // Dans tout fichier de configuration ou partie de code qui s'execute avant l'evenement
     use Cake\Event\EventManager;
 
-    EventManager::instance()->attach(
-        $aCallback,
-        'Model.Order.afterPlace'
+    EventManager::instance()->on(
+        'Model.Order.afterPlace',
+        $aCallback
     );
 
 Une chose importante que vous devriez considérer est que les evenements qui
@@ -218,7 +218,7 @@ comme ceci::
 
     // Attache l'objet UserStatistic au gestionnaire globale d'évènement de la Commande
     $statistics = new UserStatistic();
-    $this->Order->eventManager()->attach($statistics);
+    $this->Order->eventManager()->on($statistics);
 
 Comme vous pouvez le voir dans le code ci-dessus, la fonction ``attach`` va
 accepter les instances de l'interface ``EventListener``. En interne, le
@@ -236,12 +236,12 @@ anonyme simple pour le faire::
 
     use Cake\Log\Log;
 
-    $this->Orders->eventManager()->attach(function ($event) {
+    $this->Orders->eventManager()->on('Model.Order.afterPlace', function ($event) {
         Log::write(
             'info',
             'A new order was placed with id: ' . $event->subject()->id
         );
-    }, 'Model.Order.afterPlace');
+    });
 
 En plus des fonctions anonymes, vous pouvez utiliser tout autre type callable
 que PHP supporte::
@@ -251,7 +251,7 @@ que PHP supporte::
         'inventory' => [$this->InventoryManager, 'decrement'],
     ];
     foreach ($events as $callable) {
-        $eventManager->attach($callable, 'Model.Order.afterPlace');
+        $eventManager->on('Model.Order.afterPlace', $callable);
     }
 
 .. _event-priorities:
@@ -281,10 +281,10 @@ la fonction ``implementedEvents`` pour les listeners d'évènement::
 
     // Définir la priorité pour une callback
     $callback = [$this, 'doSomething'];
-    $this->eventManager()->attach(
-        $callback,
+    $this->eventManager()->on(
         'Model.Order.afterPlace',
-        ['priority' => 2]
+        ['priority' => 2],
+        $callback
     );
 
     // Définir la priorité pour un listener
@@ -435,31 +435,31 @@ Retirer les Callbacks et les Listeners
 
 Si pour certaines raisons, vous voulez retirer toute callback d'un gestionnaire
 d'évènement, appelez seulement la méthode
-:php:meth:`Cake\\Event\\EventManager::detach()` en utilisant des arguments
+:php:meth:`Cake\\Event\\EventManager::off()` en utilisant des arguments
 les deux premiers paramètres que vous utilisiez pour l'attacher::
 
     // Attacher une fonction
-    $this->eventManager()->attach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->on('My.event', [$this, 'doSomething']);
 
     // Détacher une fonction
-    $this->eventManager()->detach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->off([$this, 'doSomething']);
 
     // Attacher une fonction anonyme.
     $myFunction = function ($event) { ... };
-    $this->eventManager()->attach($myFunction, 'My.event');
+    $this->eventManager()->on('My.event', $myFunction);
 
     // Détacher la fonction anonyme
-    $this->eventManager()->detach($myFunction, 'My.event');
+    $this->eventManager()->off('My.event', $myFunction);
 
     // Attacher un EventListener
     $listener = new MyEventLister();
-    $this->eventManager()->attach($listener);
+    $this->eventManager()->on($listener);
 
     // Détacher une clé d'évènement unique d'un listener
-    $this->eventManager()->detach($listener, 'My.event');
+    $this->eventManager()->off('My.event', $listener);
 
     // Détacher tous les callbacks intégrés par un listener
-    $this->eventManager()->detach($listener);
+    $this->eventManager()->off($listener);
 
 Conclusion
 ==========

--- a/fr/core-libraries/registry-objects.rst
+++ b/fr/core-libraries/registry-objects.rst
@@ -49,10 +49,10 @@ d'evènements. Par exemple, vous pouvez désactiver les callbacks du component
 de la façon suivante::
 
     // Retire Auth des callbacks.
-    $this->eventManager()->detach($this->Auth);
+    $this->eventManager()->off($this->Auth);
 
     // Re-active Auth pour les callbacks.
-    $this->eventManager()->attach($this->Auth);
+    $this->eventManager()->on($this->Auth);
 
 
 .. meta::

--- a/ja/core-libraries/events.rst
+++ b/ja/core-libraries/events.rst
@@ -251,14 +251,14 @@ CakePHP 2.1 以前の何人かの開発者は、この問題を解決するた�
 ..
   How do we register callbacks or observers to our new `afterPlace` event? This
   is subject to a wide variety of different implementations, but they all have
-  to call the :php:meth:`CakeEventManager::attach()` method to register new actors.
+  to call the :php:meth:`CakeEventManager::on()` method to register new actors.
   For simplicity's sake, let's imagine we know in the plugin what the callbacks
   are available in the controller, and say this controller is responsible for
   attaching them. The possible code would look like this::
 
 新しいafterPlaceイベントにコールバックやオブザーバを登録するにはどうすればよいのでしょうか？
 これは多種多様な異なる実装がなされますが、どのような場合であっても新しいアクターを登録する
-:php:meth:`CakeEventManager::attach()` メソッドを呼び出す必要はあります。わかりやすくするために、
+:php:meth:`CakeEventManager::on()` メソッドを呼び出す必要はあります。わかりやすくするために、
 このプラグインにおいてコントローラでコールバックを使用可能であることを我々は知っており、
 このコントローラは、それらを責任を持って接続するとしましょう。可能なコードは次のようになります::
 
@@ -279,7 +279,7 @@ CakePHP 2.1 以前の何人かの開発者は、この問題を解決するた�
         public function finish()
         {
             foreach (Configure::read('Order.afterPlace') as $l) {
-                $this->Order->getEventManager()->attach($l, 'Model.Order.afterPlace');
+                $this->Order->getEventManager()->on('Model.Order.afterPlace', $l);
             }
             if ($this->Order->place($this->Cart->items())) {
                 // ...
@@ -307,13 +307,13 @@ CakePHP 2.1 以前の何人かの開発者は、この問題を解決するた�
 第1の引数としてイベントオブジェクトを受け取ります。
 
 ..
-  :php:meth:`CakeEventManager::attach()` Accepts three arguments. The leftmost one is
+  :php:meth:`CakeEventManager::on()` Accepts three arguments. The leftmost one is
   the callback itself, anything that PHP can treat as a callable function. The second
   argument is the event name, and the callback will only get fired if the `CakeEvent`
   object dispatched has a matching name. The last argument is an array of options to
   configure the callback priority, and the preference of arguments to be passed.
 
-:php:meth:`CakeEventManager::attach()` は3つの引数を受け取ります。左端の1つはコールバック自身、
+:php:meth:`CakeEventManager::on()` は3つの引数を受け取ります。左端の1つはコールバック自身、
 PHPが呼び出し可能な関数として扱うことができる何かです。第二引数にはイベント名で、
 `CakeEvent` オブジェクトはこれとマッチした名前でディスパッチされたときにのみ動作します。
 最後の引数はコールバックのプライオリティ、および渡される引数のプライオリティを設定するためのオプションの配列です。
@@ -367,14 +367,14 @@ PHPが呼び出し可能な関数として扱うことができる何かです�
 
     // Attach the UserStatistic object to the Order's event manager
     $statistics = new UserStatistic();
-    $this->Order->getEventManager()->attach($statistics);
+    $this->Order->getEventManager()->on($statistics);
 
 ..
-  As you can see in the above code, the `attach` function can handle instances of
+  As you can see in the above code, the ``on`` function can handle instances of
   the `CakeEventListener` interface. Internally, the event manager will read the
   array returned by `implementedEvents` method and wire the callbacks accordingly.
 
-上記のコードを見るとわかるように、`attach` 関数は `CakeEventListener` インターフェイスの
+上記のコードを見るとわかるように、``on`` 関数は `CakeEventListener` インターフェイスの
 インスタンスを操ることができます。内部的には、イベント·マネージャーは `implementedEvents`
 メソッドが返す配列を読み取り、ただちにコールバックを結びつけます。
 
@@ -422,12 +422,16 @@ PHPが呼び出し可能な関数として扱うことができる何かです�
 
 2つのコールバックが同じプライオリティキューに割り当てられるた場合は、
 それらはFIFOポリシーで実行され、最初にアタッチされたリスナーメソッドは最初に、
-という具合に実行されます。コールバックのプライオリティを設定するためにはattachメソッドを用い、
+という具合に実行されます。コールバックのプライオリティを設定するためにはonメソッドを用い、
 リスナーのプライオリティを設定するためには `implementedEvent` 関数内での宣言を行います::
 
     // Setting priority for a callback
     $callback = array($this, 'doSomething');
-    $this->getEventManager()->attach($callback, 'Model.Order.afterPlace', array('priority' => 2));
+    $this->getEventManager()->on(
+        'Model.Order.afterPlace',
+        array('priority' => 2),
+        $callback
+    );
 
     // Setting priority for a listener
     class UserStatistic implements CakeEventListener
@@ -473,13 +477,13 @@ PHPが呼び出し可能な関数として扱うことができる何かです�
   third argument of the `attach` method, or declare it in the `implementedEvents`
   returned array similar to what you do with priorities::
 
-この方法を選択する場合、プライオリティの設定でやったのと同じように、`attach`メソッドの
-3番目の引数に`passParams`オプションを追加するか `implementedEvents` が返す配列に
+この方法を選択する場合、プライオリティの設定でやったのと同じように、``on``メソッドの
+3番目の引数に`passParams`オプションを追加するか ``implementedEvents`` が返す配列に
 それを宣言する必要があります::
 
     // Setting priority for a callback
     $callback = array($this, 'doSomething');
-    $this->getEventManager()->attach($callback, 'Model.Order.afterPlace', array('passParams' => true));
+    $this->getEventManager()->on('Model.Order.afterPlace', $callback);
 
     // Setting priority for a listener
     class UserStatistic implements CakeEventListener
@@ -666,35 +670,35 @@ PHPが呼び出し可能な関数として扱うことができる何かです�
 
 ..
   If for any reason you want to remove any callback from the event manager just call
-  the :php:meth:`CakeEventManager::detach()` method using as arguments the first two
+  the :php:meth:`CakeEventManager::off()` method using as arguments the first two
   params you used for attaching it::
 
 何らかの理由でイベントマネージャーから任意のコールバックを削除したい場合は、
-:php:meth:`CakeEventManager::detach()` を引数の最初の2つの変数を attach のときと
+:php:meth:`CakeEventManager::off()` を引数の最初の2つの変数を attach のときと
 同様の用い方で呼び出すだけで良いです::
 
     // Attaching a function
-    $this->getEventManager()->attach(array($this, 'doSomething'), 'My.event');
+    $this->getEventManager()->on('My.event', array($this, 'doSomething'));
 
     // Detaching the function
-    $this->getEventManager()->detach(array($this, 'doSomething'), 'My.event');
+    $this->getEventManager()->off('My.event', array($this, 'doSomething'));
 
-    // Attaching an anonymous function (PHP 5.3+ only);
+    // Attaching an anonymous function
     $myFunction = function ($event) { ... };
-    $this->getEventManager()->attach($myFunction, 'My.event');
+    $this->getEventManager()->on('My.event', $myFunction);
 
     // Detaching the anonymous function
-    $this->getEventManager()->detach($myFunction, 'My.event');
+    $this->getEventManager()->off('My.event', $myFunction);
 
     // Attaching a CakeEventListener
     $listener = new MyCakeEventLister();
-    $this->getEventManager()->attach($listener);
+    $this->getEventManager()->on($listener);
 
     // Detaching a single event key from a listener
-    $this->getEventManager()->detach($listener, 'My.event');
+    $this->getEventManager()->off('My.event', $listener);
 
     // Detaching all callbacks implemented by a listener
-    $this->getEventManager()->detach($listener);
+    $this->getEventManager()->off($listener);
 
 .. The global event manager
 

--- a/pt/bake/development.rst
+++ b/pt/bake/development.rst
@@ -22,7 +22,7 @@ be used::
     use Cake\Event\Event;
     use Cake\Event\EventManager;
     
-    EventManager::instance()->attach(function (Event $event) {
+    EventManager::instance()->on('Bake.initialize', function (Event $event) {
         $view = $event->subject;
 
         // In my bake templates, allow the use of the MySpecial helper
@@ -31,7 +31,7 @@ be used::
         // And add an $author variable so it's always available
         $view->set('author', 'Andy');
 
-    }, 'Bake.initialize');
+    });
 
 Bake events can also be useful for making small changes to existing templates.
 For example, to change the variable names used when baking controller/template
@@ -44,7 +44,7 @@ variables used in the bake templates::
     use Cake\Event\Event;
     use Cake\Event\EventManager;
     
-    EventManager::instance()->attach(function (Event $event) {
+    EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
         $view = $event->subject;
 
         // Use $rows for the main data variable in indexes
@@ -63,7 +63,7 @@ variables used in the bake templates::
             $view->set('singularVar', 'theOne');
         }
 
-    }, 'Bake.beforeRender');
+    });
 
 
 Bake Template Syntax

--- a/pt/controllers/components/csrf.rst
+++ b/pt/controllers/components/csrf.rst
@@ -72,7 +72,7 @@ requests. You can do this using the controller's event dispatcher, during the
 
     public function beforeFilter(Event $event)
     {
-        $this->eventManager()->detach($this->Csrf);
+        $this->eventManager()->off($this->Csrf);
     }
 
 .. meta::

--- a/pt/core-libraries/events.rst
+++ b/pt/core-libraries/events.rst
@@ -103,9 +103,9 @@ access the global manager using a static method::
     // In any configuration file or piece of code that executes before the event
     use Cake\Event\EventManager;
 
-    EventManager::instance()->attach(
-        $aCallback,
-        'Model.Order.afterPlace'
+    EventManager::instance()->on(
+        'Model.Order.afterPlace',
+        $aCallback
     );
 
 One important thing you should consider is that there are events that will be
@@ -191,9 +191,9 @@ necessary. Our ``UserStatistics`` listener might start out like::
 
     // Attach the UserStatistic object to the Order's event manager
     $statistics = new UserStatistic();
-    $this->Orders->eventManager()->attach($statistics);
+    $this->Orders->eventManager()->on($statistics);
 
-As you can see in the above code, the ``attach`` function will accept instances
+As you can see in the above code, the ``on`` function will accept instances
 of the ``EventListener`` interface. Internally, the event manager will use
 ``implementedEvents`` to attach the correct callbacks.
 
@@ -207,12 +207,12 @@ function to do so::
 
     use Cake\Log\Log;
 
-    $this->Orders->eventManager()->attach(function ($event) {
+    $this->Orders->eventManager()->on('Model.Order.afterPlace', function ($event) {
         Log::write(
             'info',
             'A new order was placed with id: ' . $event->subject()->id
         );
-    }, 'Model.Order.afterPlace');
+    });
 
 In addition to anonymous functions you can use any other callable type that PHP
 supports::
@@ -222,7 +222,7 @@ supports::
         'inventory' => [$this->InventoryManager, 'decrement'],
     ];
     foreach ($events as $callable) {
-        $eventManager->attach($callable, 'Model.Order.afterPlace');
+        $eventManager->on('Model.Order.afterPlace', $callable);
     }
 
 .. _event-priorities:
@@ -251,10 +251,10 @@ event listeners::
 
     // Setting priority for a callback
     $callback = [$this, 'doSomething'];
-    $this->eventManager()->attach(
-        $callback,
+    $this->eventManager()->on(
         'Model.Order.afterPlace',
-        ['priority' => 2]
+        ['priority' => 2],
+        $callback
     );
 
     // Setting priority for a listener
@@ -399,31 +399,31 @@ Removing Callbacks and Listeners
 --------------------------------
 
 If for any reason you want to remove any callback from the event manager just
-call the :php:meth:`Cake\\Event\\EventManager::detach()` method using as
+call the :php:meth:`Cake\\Event\\EventManager::off()` method using as
 arguments the first two params you used for attaching it::
 
     // Attaching a function
-    $this->eventManager()->attach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->on('My.event', [$this, 'doSomething']);
 
     // Detaching the function
-    $this->eventManager()->detach([$this, 'doSomething'], 'My.event');
+    $this->eventManager()->off('My.event', [$this, 'doSomething']);
 
     // Attaching an anonymous function.
     $myFunction = function ($event) { ... };
-    $this->eventManager()->attach($myFunction, 'My.event');
+    $this->eventManager()->on('My.event', $myFunction);
 
     // Detaching the anonymous function
-    $this->eventManager()->detach($myFunction, 'My.event');
+    $this->eventManager()->off('My.event', $myFunction);
 
-    // Attaching a EventListener
+    // Adding a EventListener
     $listener = new MyEventLister();
-    $this->eventManager()->attach($listener);
+    $this->eventManager()->on($listener);
 
     // Detaching a single event key from a listener
-    $this->eventManager()->detach($listener, 'My.event');
+    $this->eventManager()->off('My.event', $listener);
 
     // Detaching all callbacks implemented by a listener
-    $this->eventManager()->detach($listener);
+    $this->eventManager()->off($listener);
 
 Conclusion
 ==========

--- a/pt/core-libraries/registry-objects.rst
+++ b/pt/core-libraries/registry-objects.rst
@@ -47,10 +47,10 @@ the events system. For example you could disable component callbacks in the
 following way::
 
     // Remove Auth from callbacks.
-    $this->eventManager()->detach($this->Auth);
+    $this->eventManager()->off($this->Auth);
 
     // Re-enable Auth for callbacks.
-    $this->eventManager()->attach($this->Auth);
+    $this->eventManager()->on($this->Auth);
 
 
 .. meta::


### PR DESCRIPTION
Instead of attach/detach we should document and recommend the new methods as they are likely to be familiar and are less work to use.