### PR TITLE
Remove Component/Helper/Behavior suffixes

### DIFF
--- a/en/controllers/components/cookie.rst
+++ b/en/controllers/components/cookie.rst
@@ -1,5 +1,5 @@
-CookieComponent
-###############
+Cookie
+######
 
 .. php:namespace:: Cake\Controller\Component
 

--- a/en/controllers/components/csrf.rst
+++ b/en/controllers/components/csrf.rst
@@ -1,5 +1,5 @@
-Cross Site Request Forgery Component
-####################################
+Cross Site Request Forgery
+##########################
 
 By enabling the CSRF Component you get protection against attacks. `CSRF
 <http://en.wikipedia.org/wiki/Cross-site_request_forgery>`_ or Cross Site

--- a/en/controllers/components/flash.rst
+++ b/en/controllers/components/flash.rst
@@ -1,5 +1,5 @@
-FlashComponent
-##############
+Flash
+#####
 
 .. php:namespace:: Cake\Controller\Component
 

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -1,5 +1,5 @@
-SecurityComponent
-##################
+Security
+########
 
 .. php:class:: SecurityComponent(ComponentCollection $collection, array $config = [])
 

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -1,5 +1,5 @@
-CounterCache Behavior
-#####################
+CounterCache
+############
 
 .. php:namespace:: Cake\ORM\Behavior
 

--- a/en/orm/behaviors/timestamp.rst
+++ b/en/orm/behaviors/timestamp.rst
@@ -1,5 +1,5 @@
-Timestamp Behavior
-##################
+Timestamp
+#########
 
 .. php:namespace:: Cake\ORM\Behavior
 

--- a/en/orm/behaviors/tree.rst
+++ b/en/orm/behaviors/tree.rst
@@ -1,5 +1,5 @@
-TreeBehavior
-############
+Tree
+####
 
 .. php:namespace:: Cake\ORM\Behavior
 

--- a/en/views/helpers/flash.rst
+++ b/en/views/helpers/flash.rst
@@ -1,5 +1,5 @@
-FlashHelper
-###########
+Flash
+#####
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1,5 +1,5 @@
-FormHelper
-##########
+Form
+####
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/html.rst
+++ b/en/views/helpers/html.rst
@@ -1,5 +1,5 @@
-HtmlHelper
-##########
+Html
+####
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/number.rst
+++ b/en/views/helpers/number.rst
@@ -1,5 +1,5 @@
-NumberHelper
-############
+Number
+######
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -1,5 +1,5 @@
-PaginatorHelper
-###############
+Paginator
+#########
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/rss.rst
+++ b/en/views/helpers/rss.rst
@@ -1,5 +1,5 @@
-RssHelper
-#########
+Rss
+###
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/session.rst
+++ b/en/views/helpers/session.rst
@@ -1,5 +1,5 @@
-SessionHelper
-#############
+Session
+#######
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/text.rst
+++ b/en/views/helpers/text.rst
@@ -1,5 +1,5 @@
-TextHelper
-##########
+Text
+####
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/time.rst
+++ b/en/views/helpers/time.rst
@@ -1,5 +1,5 @@
-TimeHelper
-##########
+Time
+####
 
 .. php:namespace:: Cake\View\Helper
 

--- a/en/views/helpers/url.rst
+++ b/en/views/helpers/url.rst
@@ -1,5 +1,5 @@
-UrlHelper
-##########
+Url
+###
 
 .. php:namespace:: Cake\View\UrlHelper
 


### PR DESCRIPTION
Currently.. Component, Helper, and Behavior page titles are mixed in including their suffixes or not. This makes them consistent. I went with omitting the suffixes because they are already nested under their respective categories in the TOC, looks cleaner within the TOC, and removes redundancy.