### PR TITLE
Fixing sphinx dependency reference

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -10,12 +10,12 @@ You can read all of the documentation within as its just in plain text files, ma
 
 * Make
 * Python
-* Sphinx
+* Sphinx 1.2.* (currently the make commands will not work in 1.3.*)
 * PhpDomain for sphinx
 
 You can install sphinx using:
 
-	easy_install sphinx
+	easy_install sphinx=1.2.3
 
 You can install the phpdomain using:
 


### PR DESCRIPTION
Right now the sphinx version installed through easy_install is 1.3 beta2 release, which is not supporting current documentation scripts.