### PR TITLE
Update authentication.rst

### DIFF
--- a/en/core-libraries/components/authentication.rst
+++ b/en/core-libraries/components/authentication.rst
@@ -870,7 +870,7 @@ and authentication mechanics in CakePHP.
 .. php:attr:: unauthorizedRedirect
 
     Controls handling of unauthorized access. By default unauthorized user is
-    redirected to the referrer URL or ``AuthComponent::$loginAction`` or '/'.
+    redirected to the referrer URL or ``AuthComponent::$loginRedirect`` or '/'.
     If set to false a ForbiddenException exception is thrown instead of redirecting.
 
 .. php:attr:: request


### PR DESCRIPTION
There is just a typo, which can be easily verified in `AuthComponent` Line 414 (`_unautorized`):
https://github.com/cakephp/cakephp/blob/396d501d1e70da79494bba21161d66f0aede8852/lib/Cake/Controller/Component/AuthComponent.php#L414