### PR TITLE
Update the custom widget example

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1625,9 +1625,12 @@ Building a Widget Class
 
 Widget classes have a very simple required interface. They must implement the
 :php:class:`Cake\\View\\Widget\\WidgetInterface`. This interface requires
-the ``render(array $data)`` method to be implemented. The render method
-expects an array of data to build the widget and is expected to return a string
-of HTML for the widget. If CakePHP is constructing your widget you can expect to
+the ``render(array $data)`` and ``secureFields(array $data)`` methods to be implemented.
+The ``render`` method expects an array of data to build the widget and is expected to return a string
+of HTML for the widget.
+The ``secureFields`` method expects an array of data as well and is expected to return an
+array containing the list of fields to secure for this widget.
+If CakePHP is constructing your widget you can expect to
 get a ``Cake\View\StringTemplate`` instance as the first argument, followed by
 any dependencies you define. If we wanted to build an Autocomplete widget you
 could do the following::
@@ -1657,6 +1660,10 @@ could do the following::
             ]);
         }
 
+        public function secureFields(array $data)
+        {
+            return [$data['name']];
+        }
     }
 
 Obviously, this is a very simple example, but it demonstrates how a custom

--- a/fr/views/helpers/form.rst
+++ b/fr/views/helpers/form.rst
@@ -1677,9 +1677,12 @@ Construire une Classe Widget
 
 Les classes Widget ont une interface requise vraiment simple. Elles doivent
 implémenter la :php:class:`Cake\\View\\Widget\\WidgetInterface`. Cette interface
-nécessite que la méthde ``render(array $data)`` soit implémentée. La méthode
-render attend un tableau de données pour constuire le widget et doit renvoyer
-un chaine HTML pour le widget. Si CakePHP construit votre widget, vous pouvez
+nécessite que les méthodes ``render(array $data)`` et ``secureFields(array $data)`` soient implémentées.
+La méthode ``render`` attend un tableau de données pour constuire le widget et doit renvoyer
+un chaine HTML pour le widget.
+La méthode ``secureFields`` attend également un tableau de données et doit retourner un tableau
+contenant la liste des champs à sécuriser pour ce widget.
+Si CakePHP construit votre widget, vous pouvez
 vous attendre à recevoir une instance de ``Cake\View\StringTemplate`` en premier
 argument, suivi de toutes les dépendances que vous aurez définies. Si vous voulez
 construire un widget Autocomplete, vous pouvez le faire comme ceci::
@@ -1709,6 +1712,10 @@ construire un widget Autocomplete, vous pouvez le faire comme ceci::
             ]);
         }
 
+        public function secureFields(array $data)
+        {
+            return [$data['name']];
+        }
     }
 
 


### PR DESCRIPTION
The custom widget example does not completely satisfy the WidgetInterface, resulting in an error if one is to copy / paste it directly.
For the example of the secureFields method, I went with the one from the BasicWidget

I also updated the text above the example to add details about the other method that needs to be implemented by Widget classes implementing the interface.