### PR TITLE
Update testing.rst

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1140,8 +1140,8 @@ Now we create our tests::
         public function setUp()
         {
             parent::setUp();
-            $view = new View();
-            $this->helper = new CurrencyRendererHelper($view);
+            $View = new View();
+            $this->helper = new CurrencyRendererHelper($View);
         }
 
         // Testing the usd() function


### PR DESCRIPTION
Making the `$View` var in the example follow [coding conventions](http://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html#variables):

> Variables referencing objects should start with a capital letter