### PR TITLE
[en] Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -497,8 +497,9 @@ load fields off of contained associations, you can use ``autoFields()``::
 
     // Select id & title from articles, but all fields off of Users.
     $query->select(['id', 'title'])
-        ->contain(['Users'])
-        ->autoFields(true);
+        ->contain(['Users' => function($q) {
+			return $q->autoFields(true);
+		          }]);
 
 Filtering by Associated Data
 ----------------------------


### PR DESCRIPTION
In the example, the comment says "Select id & title from articles, but all fields off of Users." that's not what the autoFields do if performed on the main entity. autoFields must be specified in the contain().