### PR TITLE
[fr] Update retrieving-data-and-resultsets.rst

### DIFF
--- a/fr/orm/retrieving-data-and-resultsets.rst
+++ b/fr/orm/retrieving-data-and-resultsets.rst
@@ -520,8 +520,9 @@ vous pouvez utiliser ``autoFields()``::
 
     // Select id & title de articles, mais tous les champs de Users.
     $query->select(['id', 'title'])
-        ->contain(['Users'])
-        ->autoFields(true);
+        ->contain(['Users' => function($q) {
+			return $q->autoFields(true);
+		          }]);
 
 Filtrer par les Données Associées
 ---------------------------------


### PR DESCRIPTION
Dans l'example, le commentaire indique "// Select id & title de articles, mais tous les champs de Users." ce n'est pas ce que fait le autoFields(true) si celui-ci est fait sur la main entity. autoFields(true) doit être fait dans le contain().