### PR TITLE
Update global functions

### DIFF
--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -55,7 +55,7 @@ such as debugging and translating content.
     also allows you to specify a context.
 
     The context is a unique identifier for the translations string that makes it
-    unique for in the same domain.
+    unique within the same domain.
 
 .. php:function:: __dxn(string $domain, string $context, string $singular, string $plural, integer $count, mixed $args = null)
 
@@ -66,7 +66,7 @@ such as debugging and translating content.
     for plural messages dependent on the count.
 
     The context is a unique identifier for the translations string that makes it
-    unique for in the same domain.
+    unique within the same domain.
 
 .. php:function:: __n(string $singular, string $plural, integer $count, mixed $args = null)
 
@@ -77,7 +77,7 @@ such as debugging and translating content.
 .. php:function:: __x(string $context, string $msg, mixed $args = null)
 
     The context is a unique identifier for the translations string that makes it
-    unique for in the same domain.
+    unique within the same domain.
 
 .. php:function:: __xn(string $context, string $singular, string $plural, integer $count, mixed $args = null)
 
@@ -87,7 +87,7 @@ such as debugging and translating content.
     messages dependent on the count.
 
     The context is a unique identifier for the translations string that makes it
-    unique for in the same domain.
+    unique within the same domain.
 
 .. php:function:: collection(mixed $items)
 

--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -36,19 +36,6 @@ such as debugging and translating content.
         :doc:`/core-libraries/internationalization-and-localization`
         section for more information.
 
-.. php:function:: __c(string $msg, integer $category, mixed $args = null)
-
-    Note that the category must be specified with an I18n class constant, instead of
-    only the constant name. The values are:
-
-    - I18n::LC_ALL - LC_ALL
-    - I18n::LC_COLLATE - LC_COLLATE
-    - I18n::LC_CTYPE - LC_CTYPE
-    - I18n::LC_MONETARY - LC_MONETARY
-    - I18n::LC_NUMERIC - LC_NUMERIC
-    - I18n::LC_TIME - LC_TIME
-    - I18n::LC_MESSAGES - LC_MESSAGES
-
 .. php:function:: __d(string $domain, string $msg, mixed $args = null)
 
     Allows you to override the current domain for a single message lookup.
@@ -56,51 +43,51 @@ such as debugging and translating content.
     Useful when internationalizing a plugin:
     ``echo __d('PluginName', 'This is my plugin');``
 
-.. php:function:: __dc(string $domain, string $msg, integer $category, mixed $args = null)
-
-    Allows you to override the current domain for a single message lookup. It
-    also allows you to specify a category.
-
-    Note that the category must be specified with an I18n class constant, instead of
-    only the constant name. The values are:
-
-    - I18n::LC_ALL - LC_ALL
-    - I18n::LC_COLLATE - LC_COLLATE
-    - I18n::LC_CTYPE - LC_CTYPE
-    - I18n::LC_MONETARY - LC_MONETARY
-    - I18n::LC_NUMERIC - LC_NUMERIC
-    - I18n::LC_TIME - LC_TIME
-    - I18n::LC_MESSAGES - LC_MESSAGES
-
-.. php:function:: __dcn(string $domain, string $singular, string $plural, integer $count, integer $category, mixed $args = null)
-
-    Allows you to override the current domain for a single plural message
-    lookup. It also allows you to specify a category. Returns correct plural
-    form of message identified by $singular and $plural for count $count from
-    domain $domain.
-
-    Note that the category must be specified with an I18n class constant, instead of
-    only the constant name. The values are:
-
-    - I18n::LC_ALL - LC_ALL
-    - I18n::LC_COLLATE - LC_COLLATE
-    - I18n::LC_CTYPE - LC_CTYPE
-    - I18n::LC_MONETARY - LC_MONETARY
-    - I18n::LC_NUMERIC - LC_NUMERIC
-    - I18n::LC_TIME - LC_TIME
-    - I18n::LC_MESSAGES - LC_MESSAGES
-
 .. php:function:: __dn(string $domain, string $singular, string $plural, integer $count, mixed $args = null)
 
     Allows you to override the current domain for a single plural message
-    lookup. Returns correct plural form of message identified by $singular and
-    $plural for count $count from domain $domain.
+    lookup. Returns correct plural form of message identified by ``$singular``
+    and ``$plural`` for count ``$count`` from domain ``$domain``.
+
+.. php:function:: __dx(string $domain, string $context, string $msg, mixed $args = null)
+
+    Allows you to override the current domain for a single message lookup. It
+    also allows you to specify a context.
+
+    The context is a unique identifier for the translations string that makes it
+    unique for in the same domain.
+
+.. php:function:: __dxn(string $domain, string $context, string $singular, string $plural, integer $count, mixed $args = null)
+
+    Allows you to override the current domain for a single plural message
+    lookup. It also allows you to specify a context. Returns correct plural
+    form of message identified by ``$singular`` and ``$plural`` for count
+    ``$count`` from domain ``$domain``. Some languages have more than one form
+    for plural messages dependent on the count.
+
+    The context is a unique identifier for the translations string that makes it
+    unique for in the same domain.
 
 .. php:function:: __n(string $singular, string $plural, integer $count, mixed $args = null)
 
-    Returns correct plural form of message identified by $singular and $plural
-    for count $count. Some languages have more than one form for plural
+    Returns correct plural form of message identified by ``$singular`` and ``$plural``
+    for count ``$count``. Some languages have more than one form for plural
     messages dependent on the count.
+
+.. php:function:: __x(string $context, string $msg, mixed $args = null)
+
+    The context is a unique identifier for the translations string that makes it
+    unique for in the same domain.
+
+.. php:function:: __xn(string $context, string $singular, string $plural, integer $count, mixed $args = null)
+
+    Returns correct plural form of message identified by ``$singular`` and
+    ``$plural`` for count ``$count`` from domain ``$domain``. It also allows you
+    to specify a context. Some languages have more than one form for plural
+    messages dependent on the count.
+
+    The context is a unique identifier for the translations string that makes it
+    unique for in the same domain.
 
 .. php:function:: collection(mixed $items)
 
@@ -110,7 +97,7 @@ such as debugging and translating content.
 
 .. php:function:: debug(mixed $var, boolean $showHtml = null, $showFrom = true)
 
-    If the core ``$debug`` variable is ``true``, $var is printed out.
+    If the core ``$debug`` variable is ``true``, ``$var`` is printed out.
     If ``$showHTML`` is ``true`` or left as ``null``, the data is rendered to be
     browser-friendly.
     If ``$showFrom`` is not set to ``false``, the debug output will start with the line from
@@ -122,7 +109,7 @@ such as debugging and translating content.
     Gets an environment variable from available sources. Used as a
     backup if ``$_SERVER`` or ``$_ENV`` are disabled.
 
-    This function also emulates PHP\_SELF and DOCUMENT\_ROOT on
+    This function also emulates ``PHP_SELF`` and ``DOCUMENT_ROOT`` on
     unsupporting servers. In fact, it's a good idea to always use
     ``env()`` instead of ``$_SERVER`` or ``getenv()`` (especially if
     you plan to distribute the code), since it's a full emulation
@@ -134,15 +121,15 @@ such as debugging and translating content.
 
 .. php:function:: pluginSplit(string $name, boolean $dotAppend = false, string $plugin = null)
 
-    Splits a dot syntax plugin name into its plugin and class name. If $name
-    does not have a dot, then index 0 will be null.
+    Splits a dot syntax plugin name into its plugin and class name. If ``$name``
+    does not have a dot, then index 0 will be ``null``.
 
     Commonly used like ``list($plugin, $name) = pluginSplit('Users.User');``
 
 .. php:function:: pr(mixed $var)
 
     Convenience wrapper for ``print_r()``, with the addition of
-    wrapping <pre> tags around the output.
+    wrapping ``<pre>`` tags around the output.
 
 Core Definition Constants
 =========================
@@ -176,7 +163,8 @@ Most of the following constants refer to paths in your application.
 
 .. php:const:: DS
 
-    Short for PHP's DIRECTORY\_SEPARATOR, which is / on Linux and \\ on windows.
+    Short for PHP's ``DIRECTORY_SEPARATOR``, which is ``/`` on Linux and ``\\``
+    on Windows.
 
 .. php:const:: LOGS
 

--- a/fr/core-libraries/global-constants-and-functions.rst
+++ b/fr/core-libraries/global-constants-and-functions.rst
@@ -37,19 +37,6 @@ CakePHP, comme le débogage et la traduction de contenu.
         :doc:`/core-libraries/internationalization-and-localization`
         pour plus d'information.
 
-.. php:function:: __c(string $msg, integer $category, mixed $args = null)
-
-    Notez que la catégorie doit être spécifiée avec une constante de classe
-    I18n, au lieu d'un nom de constante. Les valeurs sont:
-
-    - I18n::LC_ALL - LC_ALL
-    - I18n::LC_COLLATE - LC_COLLATE
-    - I18n::LC_CTYPE - LC_CTYPE
-    - I18n::LC_MONETARY - LC_MONETARY
-    - I18n::LC_NUMERIC - LC_NUMERIC
-    - I18n::LC_TIME - LC_TIME
-    - I18n::LC_MESSAGES - LC_MESSAGES
-
 .. php:function:: __d(string $domain, string $msg, mixed $args = null)
 
     Vous permet de remplacer le domaine courant lors de la recherche d'un
@@ -58,53 +45,51 @@ CakePHP, comme le débogage et la traduction de contenu.
     Utile pour internationaliser un plugin:
      ``echo __d('PluginName', 'Ceci est mon plugin');``
 
-.. php:function:: __dc(string $domain, string $msg, integer $category, mixed $args = null)
-
-    Vous permet de remplacer le domaine courant pour la recherche d'un message.
-    Permet également de spécifier une catégorie.
-
-    Notez que la catégorie doit être spécifiée avec une constante de classe I18n
-    au lieu du nom de la constante. Les valeurs sont:
-
-    - I18n::LC_ALL - LC_ALL
-    - I18n::LC_COLLATE - LC_COLLATE
-    - I18n::LC_CTYPE - LC_CTYPE
-    - I18n::LC_MONETARY - LC_MONETARY
-    - I18n::LC_NUMERIC - LC_NUMERIC
-    - I18n::LC_TIME - LC_TIME
-    - I18n::LC_MESSAGES - LC_MESSAGES
-
-.. php:function:: __dcn(string $domain, string $singular, string $plural, integer $count, integer $category, mixed $args = null)
-
-    Vous permet de remplacer le domaine courant pour la recherche simple au
-    pluriel d'un message. Cela permet également de spécifier une catégorie.
-    Retourne la forme correcte d'un message identifié par $singular et $plural
-    pour le compteur $count depuis le domaine $domain. Certaines langues ont
-    plus d'une forme de pluriel dépendant du compteur.
-
-    Notez que la catégorie doit être spécifiée avec des une constante de classe
-    I18n, au lieu des noms de constantes. Les valeurs sont:
-
-    - I18n::LC_ALL - LC_ALL
-    - I18n::LC_COLLATE - LC_COLLATE
-    - I18n::LC_CTYPE - LC_CTYPE
-    - I18n::LC_MONETARY - LC_MONETARY
-    - I18n::LC_NUMERIC - LC_NUMERIC
-    - I18n::LC_TIME - LC_TIME
-    - I18n::LC_MESSAGES - LC_MESSAGES
-
 .. php:function:: __dn(string $domain, string $singular, string $plural, integer $count, mixed $args = null)
 
-    Vous permet de redéfinir le domaine courant pour une recherche simple
-    au pluriel d'un message. Retourne la forme pluriel correcte d'un
-    message identifié par $singular et $plural pour le compteur $count
-    depuis le domaine $domain.
+    Vous permet de redéfinir le domaine courant pour une recherche simple au
+    pluriel d'un message. Retourne la forme pluriel correcte d'un message
+    identifié par ``$singular`` et ``$plural`` pour le compteur ``$count``
+    depuis le domaine ``$domain``.
+
+.. php:function:: __dx(string $domain, string $context, string $msg, mixed $args = null)
+
+    Vous permet de remplacer le domaine courant pour la recherche d'un message.
+    Permet également de spécifier une contexte.
+
+    Le contexte est un identifiant unique pour la chaîne de traductions qui le
+    rend unique dans le même domaine.
+
+.. php:function:: __dxn(string $domain, string $context, string $singular, string $plural, integer $count, mixed $args = null)
+
+    Vous permet de remplacer le domaine courant pour la recherche simple au
+    pluriel d'un message. Cela permet également de spécifier une contexte.
+    Retourne la forme correcte d'un message identifié par ``$singular`` et
+    ``$plural`` pour le compteur ``$count`` depuis le domaine ``$domain``.
+    Certaines langues ont plus d'une forme de pluriel dépendant du compteur.
+
+    Le contexte est un identifiant unique pour la chaîne de traductions qui le
+    rend unique dans le même domaine.
 
 .. php:function:: __n(string $singular, string $plural, integer $count, mixed $args = null)
 
-    Retourne la forme correcte d'un message identifié par $singular et $plural
-    pour le compteur $count. Certaines langues ont plus d'une forme de pluriel
-    dépendant du compteur
+    Retourne la forme correcte d'un message identifié par ``$singular`` et
+    ``$plural`` pour le compteur ``$count``. Certaines langues ont plus d'une forme de pluriel dépendant du compteur.
+
+.. php:function:: __x(string $context, string $msg, mixed $args = null)
+
+    Le contexte est un identifiant unique pour la chaîne de traductions qui le
+    rend unique dans le même domaine.
+
+.. php:function:: __xn(string $context, string $singular, string $plural, integer $count, mixed $args = null)
+
+    Retourne la forme correcte d'un message identifié par ``$singular`` et
+    ``$plural`` pour le compteur ``$count``. Cela permet également de spécifier
+    une contexte. Certaines langues ont plus d'une forme de pluriel dépendant du
+    compteur.
+
+    Le contexte est un identifiant unique pour la chaîne de traductions qui le
+    rend unique dans le même domaine.
 
 .. php:function:: collection(mixed $items)
 
@@ -127,7 +112,7 @@ CakePHP, comme le débogage et la traduction de contenu.
     Récupère une variable d'environnement depuis les sources disponibles.
     Utilisé en secours si ``$_SERVER`` ou ``$_ENV`` sont désactivés.
 
-    Cette fonction émule également PHP\_SELF et DOCUMENT\_ROOT sur
+    Cette fonction émule également ``PHP_SELF`` et ``DOCUMENT_ROOT`` sur
     les serveurs ne les supportant pas. En fait, c'est une bonne idée
     de toujours utiliser ``env()`` plutôt que ``$_SERVER`` ou ``getenv()``
     (notamment si vous prévoyez de distribuer le code), puisque
@@ -140,15 +125,15 @@ CakePHP, comme le débogage et la traduction de contenu.
 .. php:function:: pluginSplit(string $name, boolean $dotAppend = false, string $plugin = null)
 
     Divise le nom d'un plugin en notation par point en plugin et classname
-    (nom de classe). Si $name de contient pas de point, alors l'index 0 sera
-    null.
+    (nom de classe). Si ``$name`` de contient pas de point, alors l'index 0 sera
+    ``null``.
 
     Communément utilisé comme ceci
     ``list($plugin, $name) = pluginSplit('Users.User');``
 
 .. php:function:: pr(mixed $var)
 
-    Raccourci pratique pour ``print_r()``, avec un ajout de balises <pre>
+    Raccourci pratique pour ``print_r()``, avec un ajout de balises ``<pre>``
     autour de la sortie.
 
 Définitions des constantes du noyau
@@ -184,8 +169,8 @@ dans votre application.
 
 .. php:const:: DS
 
-    Raccourci pour la constante PHP DIRECTORY\_SEPARATOR, qui est égale à /
-    pour Linux et \\ pour Windows.
+    Raccourci pour la constante PHP ``DIRECTORY_SEPARATOR``, qui est égale à
+    ``/`` pour Linux et ``\\`` pour Windows.
 
 .. php:const:: LOGS
 

--- a/ja/core-libraries/global-constants-and-functions.rst
+++ b/ja/core-libraries/global-constants-and-functions.rst
@@ -65,22 +65,6 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
         :doc:`/core-libraries/internationalization-and-localization`
         のセクションを確認して下さい。
 
-.. php:function:: __c(string $msg, integer $category, mixed $args = null)
-
-    ..
-        Note that the category must be specified with a numeric value, instead of
-        the constant name. The values are
-
-    カテゴリは定義済みの名前をそのまま使うのではなく、数値で指定されなければなりません。それらの値は以下の通り:
-
-    - 0 - LC_ALL
-    - 1 - LC_COLLATE
-    - 2 - LC_CTYPE
-    - 3 - LC_MONETARY
-    - 4 - LC_NUMERIC
-    - 5 - LC_TIME
-    - 6 - LC_MESSAGES
-
 .. php:function:: __d(string $domain, string $msg, mixed $args = null)
 
     .. Allows you to override the current domain for a single message lookup.
@@ -92,124 +76,121 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
     プラグインを国際化するときに便利です:
     ``echo __d('PluginName', 'This is my plugin');``
 
-.. php:function:: __dc(string $domain, string $msg, integer $category, mixed $args = null)
-
-    ..
-        Allows you to override the current domain for a single message lookup. It
-        also allows you to specify a category.
-
-    メッセージを一つ取得するために、現在のドメインを変更することが可能です。
-    同時に、カテゴリを指定することも出来ます。
-
-    ..
-        Note that the category must be specified with a numeric value, instead of
-        the constant name. The values are:
-
-    カテゴリは定義済みの名前をそのまま使うのではなく、数値で指定されなければなりません。
-    それらの値は以下の通り:
-
-    - 0 - LC_ALL
-    - 1 - LC_COLLATE
-    - 2 - LC_CTYPE
-    - 3 - LC_MONETARY
-    - 4 - LC_NUMERIC
-    - 5 - LC_TIME
-    - 6 - LC_MESSAGES
-
-.. php:function:: __dcn(string $domain, string $singular, string $plural, integer $count, integer $category, mixed $args = null)
-
-    ..
-        Allows you to override the current domain for a single plural message
-        lookup. It also allows you to specify a category. Returns correct plural
-        form of message identified by $singular and $plural for count $count from
-        domain $domain.
-
-    複数形のメッセージを一つ取得するために、現在のドメインを変更することが可能です。
-    同時に、カテゴリを指定することも出来ます。
-    $domain でドメインを指定し、$count の数を数え、 $singular と $plural に基いて複数形を正しく処理したメッセージを返します。
-
-    ..
-        Note that the category must be specified with a numeric value, instead of
-        the constant name. The values are:
-
-    カテゴリは定義済みの名前をそのまま使うのではなく、数値で指定されなければなりません。
-    それらの値は以下の通り:
-
-    - 0 - LC_ALL
-    - 1 - LC_COLLATE
-    - 2 - LC_CTYPE
-    - 3 - LC_MONETARY
-    - 4 - LC_NUMERIC
-    - 5 - LC_TIME
-    - 6 - LC_MESSAGES
-
 .. php:function:: __dn(string $domain, string $singular, string $plural, integer $count, mixed $args = null)
 
     ..
         Allows you to override the current domain for a single plural message
-        lookup. Returns correct plural form of message identified by $singular and
-        $plural for count $count from domain $domain.
+        lookup. Returns correct plural form of message identified by
+        ``$singular`` and ``$plural`` for count ``$count`` from domain
+        ``$domain``.
 
     複数形のメッセージを一つ取得するために、現在のドメインを変更することが可能です。
-    $domain でドメインを指定し、$count の数を数え、 $singular と $plural に基いて複数形を正しく処理したメッセージを返します。
+    ``$domain`` でドメインを指定し、``$count`` の数を数え、 ``$singular`` と
+    ``$plural`` に基いて複数形を正しく処理したメッセージを返します。
+
+.. php:function:: __dx(string $domain, string $context, string $msg, mixed $args = null)
+
+    ..
+        Allows you to override the current domain for a single message lookup. It
+        also allows you to specify a context.
+
+    メッセージを一つ取得するために、現在のドメインを変更することが可能です。
+    また、あなたがコンテキストを指定することができます。
+
+    ..
+        The context is a unique identifier for the translations string that
+        makes it unique for in the same domain.
+
+    コンテキストは、同じドメイン内のため
+    それがユニークな翻訳文字列の一意の識別子です。
+
+.. php:function:: __dxn(string $domain, string $context, string $singular, string $plural, integer $count, mixed $args = null)
+
+    ..
+        Allows you to override the current domain for a single plural message
+        lookup. It also allows you to specify a context. Returns correct plural
+        form of message identified by ``$singular`` and ``$plural`` for count
+        ``$count`` from domain ``$domain``. Some languages have more than one
+        form for plural messages dependent on the count.
+
+    複数形のメッセージを一つ取得するために、現在のドメインを変更することが可能です。
+    また、あなたがコンテキストを指定することができます。
+    ``$domain`` でドメインを指定し、``$count`` の数を数え、 ``$singular`` と
+    ``$plural`` に基いて複数形を正しく処理したメッセージを返します。
+    幾つかの言語が、数に応じた複数形の形式を一つ以上持っています。
+
+    ..
+        The context is a unique identifier for the translations string that
+        makes it unique for in the same domain.
+
+    コンテキストは、同じドメイン内のため
+    それがユニークな翻訳文字列の一意の識別子です。
 
 .. php:function:: __n(string $singular, string $plural, integer $count, mixed $args = null)
 
     ..
-        Returns correct plural form of message identified by $singular and $plural
-        for count $count. Some languages have more than one form for plural
-        messages dependent on the count.
+        Returns correct plural form of message identified by ``$singular`` and
+        ``$plural`` for count ``$count``. Some languages have more than one form
+        for plural messages dependent on the count.
 
-    $count の数を数え、 $singular と $plural に基いて複数形を正しく処理したメッセージを返します。
+    ``$count`` の数を数え、 ``$singular`` と ``$plural`` に基いて複数形を正しく処理したメッセージを返します。
     幾つかの言語が、数に応じた複数形の形式を一つ以上持っています。
 
-.. php:function:: am(array $one, $two, $three...)
+.. php:function:: __x(string $context, string $msg, mixed $args = null)
 
     ..
-        Merges all the arrays passed as parameters and returns the merged
-        array.
+        The context is a unique identifier for the translations string that
+        makes it unique for in the same domain.
 
-    パラメータとして渡されてすべての配列をマージして、その結果の配列を返します。
+    コンテキストは、同じドメイン内のため
+    それがユニークな翻訳文字列の一意の識別子です。
 
-.. php:function:: config()
-
-    ..
-        Can be used to load files from your application ``config``-folder
-        via include\_once. Function checks for existence before include and
-        returns boolean. Takes an optional number of arguments.
-
-    アプリケーション内の ``config`` フォルダから include\_once 経由でファイルをロードするために使用することが出来ます。
-    この関数はインクルードする前にファイルの存在チェックを行い、ブール値を返します。
-    任意の数の引数を取ります。
-
-    .. Example: ``config('some_file', 'myconfig');``
-
-    例: ``config('some_file', 'myconfig');``
-
-.. php:function:: convertSlash(string $string)
+.. php:function:: __xn(string $context, string $singular, string $plural, integer $count, mixed $args = null)
 
     ..
-        Converts forward slashes to underscores and removes the first and
-        last underscores in a string. Returns the converted string.
+        Returns correct plural form of message identified by ``$singular`` and
+        ``$plural`` for count ``$count``. It also allows you to specify a
+        context. Some languages have more than one form for plural messages
+        dependent on the count.
 
-    文字列のスラッシュをアンダースコアに変換し、最初と最後のアンダースコアを削除します。
-    変換した文字列を返します。
+    ``$count`` の数を数え、 ``$singular`` と ``$plural``
+    に基いて複数形を正しく処理したメッセージを返します。
+    また、あなたがコンテキストを指定することができます。
+    幾つかの言語が、数に応じた複数形の形式を一つ以上持っています。
+
+    ..
+        The context is a unique identifier for the translations string that
+        makes it unique for in the same domain.
+
+    コンテキストは、同じドメイン内のため
+    それがユニークな翻訳文字列の一意の識別子です。
+
+.. php:function:: collection(mixed $items)
+
+    ..
+        Convenience wrapper for instantiating a new
+        :php:class:`Cake\Collection\Collection` object, wrapping the passed
+        argument. The ``$items`` parameter takes either a ``Traversable`` object
+        or an array.
+
+    渡された引数をラップする、新しい :php:class:`Cake\Collection\Collection`
+    オブジェクトをインスタンス化するための簡易ラッパー。``$items`` パラメータは
+    ``Traversable`` オブジェクトまたは配列のいずれかを取ります。
 
 .. php:function:: debug(mixed $var, boolean $showHtml = null, $showFrom = true)
 
     ..
-        If the application's DEBUG level is non-zero, $var is printed out.
-        If ``$showHTML`` is true or left as null, the data is rendered to be
-        browser-friendly.
-        If $showFrom is not set to false, the debug output will start with the line from
-        which it was called
+        If the core ``$debug`` variable is ``true``, ``$var`` is printed out.
+        If ``$showHTML`` is ``true`` or left as ``null``, the data is rendered
+        to be browser-friendly.
+        If ``$showFrom`` is not set to ``false``, the debug output will start
+        with the line from which it was called
         Also see :doc:`/development/debugging`
 
-    アプリケーションの DEBUG レベルがゼロ以外の場合に $var が出力されます。
-    ``$showHTML`` が true あるいは null のままであればデータはブラウザ表示に相応しいように描画されます。
-    ``$showFrom`` が false にセットされない場合、それがコールされた行の情報を伴ってデバグ情報の出力が始まります。
+    コア ``$debug`` 変数が ``true`` であれば、 ``$var`` がプリントアウトされる。
+    ``$showHTML`` が ``true`` あるいは ``null`` のままであればデータはブラウザ表示に相応しいように描画されます。
+    ``$showFrom`` が ``false`` にセットされない場合、それがコールされた行の情報を伴ってデバグ情報の出力が始まります。
     :doc:`/development/debugging` も参照して下さい
-
 
 .. php:function:: env(string $key)
 
@@ -218,7 +199,7 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
         backup if ``$_SERVER`` or ``$_ENV`` are disabled.
 
     ..
-        This function also emulates PHP\_SELF and DOCUMENT\_ROOT on
+        This function also emulates ``PHP_SELF`` and ``DOCUMENT_ROOT`` on
         unsupporting servers. In fact, it's a good idea to always use
         ``env()`` instead of ``$_SERVER`` or ``getenv()`` (especially if
         you plan to distribute the code), since it's a full emulation
@@ -226,19 +207,9 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     可能な限りの環境変数を取得します。仮に ``$_SERVER`` か ``$_ENV`` が使用不可の場合にはバックアップとして用いられます。
 
-    この関数はまた、PHP\_SELF と DOCUMENT\_ROOT を、非サポートのサーバー上でエミュレートします。
+    この関数はまた、``PHP_SELF`` と ``DOCUMENT_ROOT`` を、非サポートのサーバー上でエミュレートします。
     これは完全なエミュレーションラッパーなので、``$_SERVER`` や ``getenv()`` の代わりに ``env()`` を常に用いることは、
     （とりわけあなたがコードを配布する予定なら）とても良い考えです。
-
-
-.. php:function:: fileExistsInPath(string $file)
-
-    ..
-        Checks to make sure that the supplied file is within the current
-        PHP include\_path. Returns a boolean result.
-
-    渡されたファイルが、現在の PHP include\_path の中にあるかどうかをチェックします。
-    ブール値の結果を返します。
 
 .. php:function:: h(string $text, boolean $double = true, string $charset = null)
 
@@ -246,20 +217,14 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     ``htmlspecialchars()`` の便利なラッパー。
 
-.. php:function:: LogError(string $message)
-
-    .. Shortcut to :php:meth:`Log::write()`.
-
-    :php:meth:`Log::write()` へのショートカット。
-
 .. php:function:: pluginSplit(string $name, boolean $dotAppend = false, string $plugin = null)
 
     ..
-        Splits a dot syntax plugin name into its plugin and classname. If $name
-        does not have a dot, then index 0 will be null.
+        Splits a dot syntax plugin name into its plugin and classname. If ``$name``
+        does not have a dot, then index 0 will be ``null``.
 
     ドット記法されたプラグイン名をプラグインとクラス名に分離します。
-    $name にドットが含まれない場合、インデクスが 0 の箇所は null になります。
+    ``$name`` にドットが含まれない場合、インデクスが 0 の箇所は ``null`` になります。
 
     .. Commonly used like ``list($plugin, $name) = pluginSplit('Users.User');``
 
@@ -269,24 +234,9 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     ..
         Convenience wrapper for ``print_r()``, with the addition of
-        wrapping <pre> tags around the output.
+        wrapping ``<pre>`` tags around the output.
 
-    出力を <pre> タグでラップする機能を追加した ``print_r()`` の便利なラッパー。
-
-.. php:function:: sortByKey(array &$array, string $sortby, string $order = 'asc', integer $type = SORT_NUMERIC)
-
-    .. Sorts given $array by key $sortby.
-
-    与えられた $array を $sortby キーによってソートします。
-
-.. php:function:: stripslashes_deep(array $value)
-
-    ..
-        Recursively strips slashes from the supplied ``$value``. Returns
-        the modified array.
-
-    与えられた ``$value`` から、再帰的にスラッシュを取り除きます。
-    変換された配列を返します。
+    出力を ``<pre>`` タグでラップする機能を追加した ``print_r()`` の便利なラッパー。
 
 .. Core Definition Constants
 
@@ -343,9 +293,11 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
 .. php:const:: DS
 
-    .. Short for PHP's DIRECTORY\_SEPARATOR, which is / on Linux and \\ on windows.
+    ..
+        Short for PHP's ``DIRECTORY_SEPARATOR``, which is ``/`` on Linux and
+        ``\\`` on Windows.
 
-    PHP の DIRECTORY\_SEPARATOR (Linux の場合は / windows の場合は \\) のショートカット。
+    PHP の ``DIRECTORY_SEPARATOR`` (Linux の場合は ``/`` Windows の場合は ``\\``) のショートカット。
 
 .. php:const:: LOGS
 

--- a/ja/core-libraries/global-constants-and-functions.rst
+++ b/ja/core-libraries/global-constants-and-functions.rst
@@ -99,9 +99,9 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     ..
         The context is a unique identifier for the translations string that
-        makes it unique for in the same domain.
+        makes it unique within the same domain.
 
-    コンテキストは、同じドメイン内のため
+    コンテキストは、同じドメイン内で、
     それがユニークな翻訳文字列の一意の識別子です。
 
 .. php:function:: __dxn(string $domain, string $context, string $singular, string $plural, integer $count, mixed $args = null)
@@ -121,9 +121,9 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     ..
         The context is a unique identifier for the translations string that
-        makes it unique for in the same domain.
+        makes it unique within the same domain.
 
-    コンテキストは、同じドメイン内のため
+    コンテキストは、同じドメイン内で、
     それがユニークな翻訳文字列の一意の識別子です。
 
 .. php:function:: __n(string $singular, string $plural, integer $count, mixed $args = null)
@@ -140,9 +140,9 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     ..
         The context is a unique identifier for the translations string that
-        makes it unique for in the same domain.
+        makes it unique within the same domain.
 
-    コンテキストは、同じドメイン内のため
+    コンテキストは、同じドメイン内で、
     それがユニークな翻訳文字列の一意の識別子です。
 
 .. php:function:: __xn(string $context, string $singular, string $plural, integer $count, mixed $args = null)
@@ -160,9 +160,9 @@ CakePHPを使った皆さんの日常のほとんどの業務ではコアクラ�
 
     ..
         The context is a unique identifier for the translations string that
-        makes it unique for in the same domain.
+        makes it unique within the same domain.
 
-    コンテキストは、同じドメイン内のため
+    コンテキストは、同じドメイン内で、
     それがユニークな翻訳文字列の一意の識別子です。
 
 .. php:function:: collection(mixed $items)


### PR DESCRIPTION
- Remove `__c`, `__dc` and `__dcn` (see cakephp/cakephp#4086)
- Add `__dx`, `__dxn`, ` __x` and `__xn` (see cakephp/cakephp#3703 and cakephp/cakephp#4023)
- Format variables/values/constants with double-ticks
- Remove functions from Japanese version that no longer exist