### PR TITLE
Update part-two.rst

### DIFF
--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -158,10 +158,11 @@ Your ``initialize()`` method should now look like::
                         ]
                     ]
                 ],
-                'unauthorizedRedirect' => [
+                'loginAction' => [
                     'controller' => 'Users',
                     'action' => 'login'
-                ]
+                ],
+                'unauthorizedRedirect' => $this->referer()
             ]);
 
             // Allow the display action so our pages controller


### PR DESCRIPTION
The doc says "Now if you try to view, edit or delete a bookmark that does not belong to you, you should be redirected back to the page you came from.", but it's not, it redirects to users/login. Keeping loginAction and adding unauthorizedRedirect as a referer fallback works better according to the previous description in this tutorial.