### PR TITLE
Follow the recent modifications to the fieldset options

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1528,8 +1528,9 @@ You can customize the generated inputs by defining additional options in the
 When customizing, ``fields``, you can use the ``$options`` parameter to
 control the generated legend/fieldset.
 
-- ``fieldset`` Set to ``false`` to disable the fieldset. If a string is supplied
-  it will be used as the class name for the fieldset element.
+- ``fieldset`` Set to ``false`` to disable the fieldset. You can also pass an
+  array of parameters to be applied as HTML attributes to the fieldset tag. If you
+  pass an empty array, the fieldset will be displayed without attributes.
 - ``legend`` Set to ``false`` to disable the legend for the generated input set.
   Or supply a string to customize the legend text.
 

--- a/fr/views/helpers/form.rst
+++ b/fr/views/helpers/form.rst
@@ -1577,9 +1577,9 @@ additionnelles dans le paramètre ``$fields``::
 Quand vous personnalisez ``fields``, vous pouvez utiliser le paramètre
 ``$options`` pour contrôler les legend/fields générés.
 
-- ``fieldset`` Défini à ``false`` pour désactiver le fieldset. Si une chaîne est
-  fournie, elle sera utilisée comme nom de classe pour l'element fieldset
-
+- ``fieldset`` Défini à ``false`` pour désactiver le fieldset. Vous pouvez également passer
+  un tableau de paramètres qui seront rendus comme attributs HTML sur le tag du fieldset.
+  Si vous passez un tableau vide, le fieldset sera simplement rendu sans attributs.
 - ``legend`` Défini à ``false`` pour désactiver la legend pour l'ensemble d'input
   généré.
   Ou fournir une chaîne pour personnaliser le texte de legend.


### PR DESCRIPTION
Follow cakephp/cakephp#6115.
Corrects a wrong information along the way (saying that if a string is passed, it will be used as the fieldset class).