### PR TITLE
Added missing "array" for configure + Explanation how to set default data for the modelless Form

### DIFF
--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -98,6 +98,42 @@ accordingly. We could have also used the ``validate()`` method to only validate
 the request data::
 
     $isValid = $form->validate($this->request->data);
+    
+Setting Form Values
+===================
+
+In order to set the values for the fields of a modelless form, you can define
+the values in ``$this->request->data``::
+
+    // In a controller
+    namespace App\Controller;
+
+    use App\Controller\AppController;
+    use App\Form\ContactForm;
+
+    class ContactController extends AppController
+    {
+        public function index()
+        {
+            $contact = new ContactForm();
+            if ($this->request->is('post')) {
+                if ($contact->execute($this->request->data)) {
+                    $this->Flash->success('We will get back to you soon.');
+                } else {
+                    $this->Flash->error('There was a problem submitting your form.');
+                }
+            }
+            
+            //Values from the User Model e.g.
+            $this->request->data['name'] = 'John Doe';
+            $this->request->data['email'] = 'john.doe@example.com';
+            
+            $this->set('contact', $contact);
+        }
+    }
+    
+Values should be defined after the processing of the data, otherwise your
+data will override the values from the form.
 
 Getting Form Errors
 ===================

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -102,8 +102,8 @@ the request data::
 Setting Form Values
 ===================
 
-In order to set the values for the fields of a modelless form, you can define
-the values in ``$this->request->data``::
+In order to set the values for the fields of a modelless form, one can define
+the values using ``$this->request->data``, like in all other forms created by the FormHelper::
 
     // In a controller
     namespace App\Controller;
@@ -124,16 +124,19 @@ the values in ``$this->request->data``::
                 }
             }
             
-            //Values from the User Model e.g.
-            $this->request->data['name'] = 'John Doe';
-            $this->request->data['email'] = 'john.doe@example.com';
+            if ($this->request->is('get') {
+                //Values from the User Model e.g.
+                $this->request->data['name'] = 'John Doe';
+                $this->request->data['email'] = 'john.doe@example.com';
+            }
             
             $this->set('contact', $contact);
         }
     }
     
-Values should be defined after the processing of the data, otherwise your
-data will override the values from the form.
+Values should only be defined if the request method is GET, otherwise
+you will overwrite your previous POST Data which might have been incorrect
+and not been saved.
 
 Getting Form Errors
 ===================

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -446,7 +446,7 @@ files, you could create a simple Xml config engine for you application::
             return Xml::toArray($xml);
         }
 
-        public function dump($key, $data)
+        public function dump($key, array $data)
         {
             // Code to dump data to file
         }


### PR DESCRIPTION
The Modelless Form Chapter was missing a part on how to add default data for the modelless Form,
which @dereuromark explained to me in IRC. I tried to add a section which explains how to do so,
I hope its alright regarding write style etc.

The other fix includes the change required in order to inherit the interface for Configure Classes.