### PR TITLE
add -n to cp to avoid overwrites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ DEST = website
 # Clone the en/Makefile everywhere.
 SPHINX_DEPENDENCIES = $(foreach lang, $(LANGS), $(lang)/Makefile)
 
-# Copy-paste the English Makefile everywhere it's needed.
+# Copy-paste the English Makefile everywhere it's needed (if non existing).
 %/Makefile: en/Makefile
-	cp $< $@
+	cp -n $< $@
 
 #
 # The various formats the documentation can be created in.


### PR DESCRIPTION
When runing `make html`, `cp` overwrites all Makefile from all languages with the en Makefile.
It should copy only if the Makefile does not exists.

It's overwritten when runing the command the first time (when `build` folder does not exist)