### PR TITLE
Adds clarifying language around pluralize and singularize

### DIFF
--- a/en/core-libraries/inflector.rst
+++ b/en/core-libraries/inflector.rst
@@ -26,8 +26,16 @@ customize the rules used::
     // Apples
     echo Inflector::pluralize('Apple');
 
+.. note::
+
+    ``pluralize()`` may not always correctly convert a noun that is already in it's plural form.
+
     // Person
     echo Inflector::singularize('People');
+    
+.. note::
+
+    ``singularize()`` may not always correctly convert a noun that is already in it's singular form.
 
 Creating CamelCase and under_scored Forms
 =========================================


### PR DESCRIPTION
Adds a note to clarify that pluralize and singularize while in general will work with most English nouns, it is possible for them to have issues around singularizing a singular noun and same with pluralizing a plural noun.

Related CakePHP Core Issue that brought forth this change: https://github.com/cakephp/cakephp/issues/6236#issuecomment-88313571