### PR TITLE
Adds clarifying language around pluralize and singularize

### DIFF
--- a/en/core-utility-libraries/inflector.rst
+++ b/en/core-utility-libraries/inflector.rst
@@ -15,10 +15,18 @@ You can try out the inflections online at `inflector.cakephp.org <http://inflect
     * **Input:** Apple, Orange, Person, Man
     * **Output:** Apples, Oranges, People, Men
 
+.. note::
+
+    ``pluralize()`` may not always correctly convert a noun that is already in it's plural form.
+
 .. php:staticmethod:: singularize($plural)
 
     * **Input:** Apples, Oranges, People, Men
     * **Output:** Apple, Orange, Person, Man
+
+.. note::
+
+    ``singularize()`` may not always correctly convert a noun that is already in it's singular form.
 
 .. php:staticmethod:: camelize($underscored)
 


### PR DESCRIPTION
Adds a note to clarify that pluralize and singularize while in general will work with most English nouns, it is possible for them to have issues around singularizing a singular noun and same with pluralizing a plural noun.

Related CakePHP Core Issue that brought forth this change: https://github.com/cakephp/cakephp/issues/6236#issuecomment-88313571