### PR TITLE
Moving the Page Contents to the page itself instead of sidebar

### DIFF
--- a/themes/cakephp/layout.html
+++ b/themes/cakephp/layout.html
@@ -147,6 +147,10 @@ window.lang = "{{ language }}";
 			{%- if pagename != 'search' -%}
 				<a class="button pale improve" href="https://github.com/cakephp/docs/edit/{{ branch }}/{{ language }}/{{ pagename }}.rst" target="_blank">Improve this Doc</a>
 			{%- endif -%}
+			<div id="page-contents" class="page-contents">
+				<h3>{{ _('Page Contents') }}</h3>
+				{{ toc }}
+			</div>
 			{% block body %} {% endblock %}
 		</div>
 	</div>

--- a/themes/cakephp/layout.html
+++ b/themes/cakephp/layout.html
@@ -147,10 +147,12 @@ window.lang = "{{ language }}";
 			{%- if pagename != 'search' -%}
 				<a class="button pale improve" href="https://github.com/cakephp/docs/edit/{{ branch }}/{{ language }}/{{ pagename }}.rst" target="_blank">Improve this Doc</a>
 			{%- endif -%}
+			{%- if pagename != 'search' and pagename != 'contents' and pagename != 'index' -%}
 			<div id="page-contents" class="page-contents">
 				<h3>{{ _('Page Contents') }}</h3>
 				{{ toc }}
 			</div>
+			{%- endif -%}
 			{% block body %} {% endblock %}
 		</div>
 	</div>

--- a/themes/cakephp/localtoc.html
+++ b/themes/cakephp/localtoc.html
@@ -8,7 +8,3 @@
     :license: BSD, see LICENSE for details.
 #}
 <a id="back-to-contents" href="#page-contents">&#11014; Back to Contents</a>
-<div id="page-contents" class="page-contents">
-	<h3>{{ _('Page Contents') }}</h3>
-	{{ toc }}
-</div>

--- a/themes/cakephp/static/default.css
+++ b/themes/cakephp/static/default.css
@@ -578,7 +578,6 @@ dt tt {
 }
 
 /* -- Sidebar -- */
-.page-contents > ul,
 #sidebar-navigation > ul {
 	margin-left: 0;
 }
@@ -664,7 +663,10 @@ dt tt {
 	}
 }
 
+.page-contents ul {
+    margin-left:1.5rem;
+}
 
-#back-to-contents {
-	display: none;
+.page-contents ul li {
+    font-size:1.4rem;
 }


### PR DESCRIPTION
It was diffcult, even for myself that I know where the contents were,
to find information on the chapter I was reading. This has also been
the experience from many other users, specially for others comming for
the first time to the docs.