### PR TITLE
Renaming Models chapter to "ORM and Database Access"

### DIFF
--- a/en/orm.rst
+++ b/en/orm.rst
@@ -1,7 +1,7 @@
 ORM and Database Access
 #######################
 
-In CakePHP working with data through the database is done with 2 primary object
+In CakePHP working with data through the database is done with two primary object
 types. The first are **repositories** or **table objects**. These objects
 provide access to collections of data. They allow you to save new records,
 modify/delete existing ones, define relations, and perform bulk operations. The

--- a/en/orm.rst
+++ b/en/orm.rst
@@ -1,17 +1,16 @@
-Models
-######
+ORM and Database Access
+#######################
 
-Models are the classes that sit as the business layer in your application.
-This means that they should be responsible for managing almost everything
-that happens regarding your data, its validity, interactions and evolution
-of the information workflow in your domain of work.
-
-In CakePHP your application's domain model gets split into 2 primary object
+In CakePHP working with data through the database is done with 2 primary object
 types. The first are **repositories** or **table objects**. These objects
 provide access to collections of data. They allow you to save new records,
 modify/delete existing ones, define relations, and perform bulk operations. The
 second type of objects are **entities**. Entities represent individual records
 and allow you to define row/record level behavior & functionality.
+
+These two classes are usually responsible for managing almost everything
+that happens regarding your data, its validity, interactions and evolution
+of the information workflow in your domain of work.
 
 CakePHP's built-in ORM specializes in relational databases, but can be extended
 to support alternative datasources.

--- a/en/orm.rst
+++ b/en/orm.rst
@@ -1,5 +1,5 @@
-ORM and Database Access
-#######################
+Database Access & ORM
+#####################
 
 In CakePHP working with data through the database is done with two primary object
 types. The first are **repositories** or **table objects**. These objects

--- a/fr/orm.rst
+++ b/fr/orm.rst
@@ -1,19 +1,19 @@
-Models (Modèles)
-################
+Accès Base de Données & ORM
+###########################
 
-Les Models sont les classes qui représentent la couche de logique dans votre
-application. Cela signifie qu'ils sont responsables de la gestion de presque
-tout ce qui concerne les données, leur validité, les interactions et
-l'évolution du flux d'informations dans votre domaine de travail.
-
-Dans CakePHP, le domaine d'application du model est séparé en 2 types d'objet
-principaux. Les premiers sont des **repositories** ou **table objects**.
+La manipulation de données de la base de donnés dans CakePHP est réalisée 
+avec deux types d'objets principaux. Les premiers sont des **repositories** ou
+**table objects**.
 Ces objets fournissent un accès aux collections de données. Ils vous permettent
 de sauvegarder de nouveaux enregistrements, de modifier/supprimer des
 enregistrements existants, définir des relations et d'effectuer des opérations
-en masse. Les seconds types d'objet sont des **entities**. Les Entities
+en masse. Les seconds types d'objets sont les **entities**. Les Entities
 représentent des enregistrements individuels et vous permettent de définir
 des comportements et des fonctionnalités au niveau des lignes/enregistrements.
+
+Ces deux classes sont habituellement responsables de la gestion de presque
+tout ce qui concerne les données, leur validité, les interactions et
+l’évolution du flux d’informations dans votre domaine de travail.
 
 L'ORM intégré dans CakePHP se spécialise dans les bases de données
 relationnelles, mais peut être étendu pour supporter des sources de données


### PR DESCRIPTION
Some people have trouble finding the docs for accessing the database
and it is totally unterstandable since it is not easy to associate
Models = ORM. Also we should move away from telling people that the Model
is reserved exclusively for database interaction.