### PR TITLE
Moving the "Parsing Localized Datetime Data" section

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -511,6 +511,59 @@ created translators using the ``translator()`` and ``config()`` methods::
 
     I18n::defaultFormatter('sprintf');
 
+Localizing Dates and Numbers
+============================
+
+When outputting Dates and Numbers in your application, you will often need that
+they are formatted according to the preferred format for the country or region
+that you wish your page to be displayed.
+
+In order to change how dates and numbers are displayed you just need to change
+the current locale setting and use the right classes::
+
+    use Cake\I18n\I18n;
+    use Cake\I18n\Time;
+    use Cake\I18n\Number;
+
+    I18n::locale('fr-FR');
+
+    $date = new Time('2015-04-05 23:00:00');
+
+    echo $date; // Displays 05/04/2015 23:00
+
+    echo Number::format(524.23); // Displays 524,23
+
+Make sure you read the :doc:`/core-libraries/time` and :doc:`/core-libraries/number`
+sections to learn more about formatting options.
+
+By default dates returned for the ORM results use the ``Cake\I18n\Time`` class,
+so displaying them directly in you application will be affected by changing the
+current locale.
+
+.. _parsing-localized-dates:
+
+Parsing Localized Datetime Data
+-------------------------------
+
+When accepting localized data from the request, it is nice to accept datetime
+information in a user's localized format. In a controller, or
+:doc:`/development/dispatch-filters` you can configure the Date, Time, and
+DateTime types to parse localized formats::
+
+    use Cake\Database\Type;
+
+    // Enable default locale format parsing.
+    Type::build('datetime')->useLocaleParser();
+
+    // Configure a custom datetime format parser format.
+    Type::build('datetime')->useLocaleParser()->setLocaleFormat('dd-M-y');
+
+    // You can also use IntlDateFormatter constants.
+    Type::build('datetime')->useLocaleParser()
+        ->setLocaleFormat([IntlDateFormatter::SHORT, -1]);
+
+The default parsing format is the same as the default string format.
+
 .. meta::
     :title lang=en: Internationalization & Localization
     :keywords lang=en: internationalization localization,internationalization and localization,language application,gettext,l10n,pot,i18n,translation,languages

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -315,31 +315,6 @@ CakePHP's database layer will automatically convert our JSON data when creating
 queries. You can use the custom types you've created by mapping the types in
 your Table's :ref:`_initializeSchema() method <saving-complex-types>`.
 
-.. _parsing-localized-dates:
-
-Parsing Localized Datetime Data
--------------------------------
-
-When accepting localized data, it is nice to accept datetime information in
-a user's localized format. In a controller, or
-:doc:`/development/dispatch-filters` you can configure the Date, Time, and
-DateTime types to parse localized formats::
-
-    use Cake\Database\Type;
-
-    // Enable default locale format parsing.
-    Type::build('datetime')->useLocaleParser();
-
-    // Configure a custom datetime format parser format.
-    Type::build('datetime')->useLocaleParser()->setLocaleFormat('dd-M-y');
-
-    // You can also use IntlDateFormatter constants.
-    Type::build('datetime')->useLocaleParser()
-        ->setLocaleFormat([IntlDateFormatter::SHORT, -1]);
-
-The default parsing format is the same as the default string format.
-
-
 Connection Classes
 ==================
 

--- a/fr/core-libraries/internationalization-and-localization.rst
+++ b/fr/core-libraries/internationalization-and-localization.rst
@@ -537,6 +537,59 @@ n'inclut pas les traducteurs créés manuellement en utilisant les méthodes
 
     I18n::defaultFormatter('sprintf');
 
+Localiser les Dates et les Nombres
+==================================
+
+Lorsque vous affichez des dates et des nombres dans votre application, vous
+voudrez souvent qu'elles soient formatées conformément au format du pays ou
+de la région dans lequel vous souhaitez afficher la page.
+
+Pour changer l'affichage des dates et des nombres, vous devez uniquement changer
+la locale et utiliser les bonnes classes::
+
+    use Cake\I18n\I18n;
+    use Cake\I18n\Time;
+    use Cake\I18n\Number;
+
+    I18n::locale('fr-FR');
+
+    $date = new Time('2015-04-05 23:00:00');
+
+    echo $date; // Affiche 05/04/2015 23:00
+
+    echo Number::format(524.23); // Displays 524,23
+
+Assurez vous de lire les sections :doc:`/core-libraries/time` et
+:doc:`/core-libraries/number` pour en apprendre plus sur les options de formatage.
+
+Par défaut, les dates renvoyées par l'ORM utilisent la classe ``Cake\I18n\Time``,
+donc leur l'affichage direct dans votre application sera affecté par le
+changement de la locale.
+
+.. _parsing-localized-dates:
+
+Parser les Données Datetime Localisées
+--------------------------------------
+
+Quand vous acceptez les données localisées, c'est sympa d'accepter les
+informations de type datetime dans un format localisé pour l'utilisateur. Dans
+un controller, ou :doc:`/development/dispatch-filters`, vous pouvez configurer
+les types Date, Time, et DateTime pour parser les formats localisés::
+
+    use Cake\Database\Type;
+
+    // Permet de parser avec le format de locale par défaut.
+    Type::build('datetime')->useLocaleParser();
+
+    // Configure un parser personnalisé du format de datetime.
+    Type::build('datetime')->useLocaleParser()->setLocaleFormat('dd-M-y');
+
+    // Vous pouvez aussi utiliser les constantes IntlDateFormatter.
+    Type::build('datetime')->useLocaleParser()
+        ->setLocaleFormat([IntlDateFormatter::SHORT, -1]);
+
+Le parsing du format par défaut est le même que le format de chaîne par défaut.
+
 .. meta::
     :title lang=fr: Internationalization & Localization
     :keywords lang=fr: internationalization localization,internationalization et localization,localization features,language application,gettext,l10n,daunting task,adaptation,pot,i18n,audience,traduction,languages

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -344,30 +344,6 @@ Vous pouvez utiliser les types personnalisés créés en faisant la correspondan
 des types dans la :ref:`méhode _initializeSchema() <saving-complex-types>` de
 votre Table.
 
-.. _parsing-localized-dates:
-
-Parser les Données Datetime Localisées
---------------------------------------
-
-Quand vous acceptez les données localisées, c'est sympa d'accepter les
-informations de type datetime dans un format localisé pour l'utilisateur. Dans
-un controller, ou :doc:`/development/dispatch-filters`, vous pouvez configurer
-les types Date, Time, et DateTime pour parser les formats localisés::
-
-    use Cake\Database\Type;
-
-    // Permet de parser avec le format de locale par défaut.
-    Type::build('datetime')->useLocaleParser();
-
-    // Configure un parser personnalisé du format de datetime.
-    Type::build('datetime')->useLocaleParser()->setLocaleFormat('dd-M-y');
-
-    // Vous pouvez aussi utiliser les constantes IntlDateFormatter.
-    Type::build('datetime')->useLocaleParser()
-        ->setLocaleFormat([IntlDateFormatter::SHORT, -1]);
-
-Le parsing du format par défaut est le même que le format de chaîne par défaut.
-
 Les Classes de Connection
 =========================
 


### PR DESCRIPTION
The place it was before was very awkward, so putting it now inside
the i18n docs, where people looking to localize their apps would
probably start looking.