### PR TITLE
Update 3-0-migration-guide.rst

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -684,7 +684,7 @@ new ORM.
 ConnectionManager
 -----------------
 
-- ConnectionManager has been moved to the ``Cake\Database`` namespace.
+- ConnectionManager has been moved to the ``Cake\Datasource`` namespace.
 - ConnectionManager has had the following methods removed:
 
   - ``sourceList``


### PR DESCRIPTION
Error in text:
ConnectionManager is part of the Cake\Datasource namespace, not of Cake\Database