### PR TITLE
Match documented optional args in Hash to source code

### DIFF
--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -136,7 +136,7 @@ Attribute Matching Types
         As of 2.5.0 attribute matching expressions work with insert().
 
 
-.. php:staticmethod:: remove(array $data, $path = null)
+.. php:staticmethod:: remove(array $data, $path)
 
     :rtype: array
 
@@ -163,7 +163,7 @@ Attribute Matching Types
     .. versionchanged:: 2.5
         As of 2.5.0 attribute matching expressions work with remove()
 
-.. php:staticmethod:: combine(array $data, $keyPath = null, $valuePath = null, $groupPath = null)
+.. php:staticmethod:: combine(array $data, $keyPath, $valuePath = null, $groupPath = null)
 
     :rtype: array
 


### PR DESCRIPTION
There were a couple arguments documented for Hash as optional (in `combine` and `remove`) that are not optional in the source code