### PR TITLE
Follow cakephp/app#154 for Nginx also

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -422,7 +422,7 @@ addition to www.example.com consult the nginx link above)::
         error_log /var/www/example.com/log/error.log;
 
         location / {
-            try_files $uri $uri/ /index.php?$args;
+            try_files $uri /index.php?$args;
         }
 
         location ~ \.php$ {


### PR DESCRIPTION
Without `autoindex on` (non-default), serving a folder results in a 403 Forbidden error.

This change removes the "don't rewrite dir requests" part of the rule, as has been done for Apache.

Rational explained here: https://github.com/cakephp/app/pull/154