### PR TITLE
Documents the modifications made to Shell::dispatchShell()

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -295,6 +295,38 @@ as var args or as a string::
 The above shows how you can call the schema shell to create the schema for a plugin
 from inside your plugin's shell.
 
+Passing extra parameters to the dispatched Shell
+------------------------------------------------
+
+.. versionadded:: 3.1
+
+It can sometimes be useful to pass on extra parameters (that are not shell arguments)
+to the dispatched Shell. In order to do this, you can now pass an array to
+``dispatchShell()``. The array is expected to have a ``command`` key as well
+as an ``extra`` key::
+
+    // Using a command string
+    $this->dispatchShell([
+       'command' => 'schema create Blog --plugin Blog'
+       'extra' => [
+            'foo' => 'bar'
+        ]
+    ]);
+
+    // Using a command array
+    $this->dispatchShell([
+       'command' => ['schema', 'create', 'Blog', '--plugin', 'Blog']
+       'extra' => [
+            'foo' => 'bar'
+        ]
+    ]);
+
+Parameters passed through ``extra`` will be merged in the ``Shell::$params``
+property and are accessible with the ``Shell::param()`` method.
+By default, a ``requested`` extra param is automatically added when a Shell
+is dispatched using ``dispatchShell()``. This ``requested`` parameter prevents
+the CakePHP console welcome message from being displayed on dispatched shells.
+
 Getting User Input
 ==================
 

--- a/fr/console-and-shells.rst
+++ b/fr/console-and-shells.rst
@@ -316,6 +316,39 @@ chaînes de caractères::
 Ce qui est au-dessus montre comment vous pouvez appeler le shell schema pour un
 plugin à partir du shell de votre plugin.
 
+Passer des paramètres supplémentaires au Shell appelé
+-----------------------------------------------------
+
+.. versionadded:: 3.1
+
+Il peut parfois être utile de passer des paramètres supplémentaires (qui ne
+seraient pas des arguments du Shell) aux Shells appelés.
+Pour ce faire, vous pouvez maintenant passer un tableau à ``dispatchShell()``.
+Le tableau devra avoir une clé ``command`` ainsi qu'une clé ``extra``::
+
+    // En passant la commande via une chaîne
+    $this->dispatchShell([
+       'command' => 'schema create Blog --plugin Blog'
+       'extra' => [
+            'foo' => 'bar'
+        ]
+    ]);
+
+    // En passant la commande via un tableau
+    $this->dispatchShell([
+       'command' => ['schema', 'create', 'Blog', '--plugin', 'Blog']
+       'extra' => [
+            'foo' => 'bar'
+        ]
+    ]);
+
+Les paramètres ajoutés via ``extra`` seront fusionnés dans la propriété
+``Shell::$params`` et accessibles via la méthode ``Shell::param()``.
+Par défaut, un paramètre supplémentaire ``requested`` est automatiquement
+ajouté quand un Shell est appelé via ``dispatchShell()``. Ce paramètre
+empêche la console de CakePHP d'afficher le message de bienvenue à chaque
+Shell appelé via ``dispatchShell()``.
+
 Récupérer les Entrées de l'Utilisateur
 ======================================
 


### PR DESCRIPTION
Documents the new extra parameters that can be passed on the dispatched shell as well as the new ``Shell::dispatchShell()`` argument syntax.

Linked to cakephp/cakephp#6292