### PR TITLE
try to improve search by adding meta

### DIFF
--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -506,3 +506,8 @@ Entities are not intended to contain the logic for serializing and
 unserializing complex data coming from the database. Refer to the
 :ref:`saving-complex-types` section to understand how your application can store
 more complex data types like arrays and objects.
+
+.. meta::
+    :title lang=en: Entities
+    :keywords lang=en: entity, entities, single row, individual record
+    


### PR DESCRIPTION
just a test to see if meta are impacting search result.
Currently, searching `Entity` will end up with the folowing which is not ideal : 
![capture d ecran 2015-04-30 a 22 49 15](https://cloud.githubusercontent.com/assets/4977112/7422212/55cd4f9a-ef8b-11e4-84e0-fa2cb6c5697d.png)

also @markstory do you know what version of elasticsearch is on the server because I don't get the same results in local with latest version ?