### PR TITLE
Fix error option descriptions.

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -453,9 +453,7 @@ HTML attributes. The following will cover the options specific to
     </div>
 
 * ``$options['error']`` Using this key allows you to override the default model
-  error messages and can be used, for example, to set i18n messages. It has a
-  number of suboptions which control the wrapping element, wrapping element
-  class name, and whether HTML in the error message will be escaped.
+  error messages and can be used, for example, to set i18n messages.
 
   To disable error message output & field classes set the error key to ``false``::
 
@@ -1278,9 +1276,6 @@ Options:
 
 -  'escape' bool Whether or not to HTML escape the contents of the
    error.
--  'wrap' mixed Whether or not the error message should be wrapped
-   in a div. If a string, will be used as the HTML tag to use.
--  'class' string The class name for the error message
 
 .. TODO:: Add examples.
 

--- a/fr/views/helpers/form.rst
+++ b/fr/views/helpers/form.rst
@@ -480,9 +480,7 @@ comme les attributs html. Ce qui suit va couvrir les options spécifiques de
 
 * ``$options['error']`` Utiliser cette clé vous permettra de transformer
   les messages de model par défaut et de les utiliser, par exemple, pour
-  définir des messages i18n. Elle comporte un nombre de sous-options qui
-  contrôle l'enveloppe de l'élément (wrapping), le nom de classe de l'élément
-  enveloppé, et si le HTML dans le message d'erreur doit être échappé ou non.
+  définir des messages i18n.
 
   Pour désactiver le rendu des messages d'erreurs définissez la clé error
   ``false``::
@@ -1325,10 +1323,6 @@ Options:
 
 -  'escape' booléen s'il faut ou non que le HTML échappe le contenu de
    l'erreur.
--  'wrap' valeur mixte définissant s'il faut ou pas que le message d'erreur
-   soit enveloppé d'une div. Si c'est une chaîne , sera utilisé comme le
-   tag HTML à utiliser.
--  'class' chaine contenant le nom de classe du message d'erreur.
 
 .. TODO:: Add examples.
 


### PR DESCRIPTION
While it's not true that the `error` option takes any sub-options, it might be nice to have it actually do that, not sure. Until then however, the docs are incorrect about that.