### PR TITLE
Update time.rst to show new formatting

### DIFF
--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -197,7 +197,7 @@ Often it is useful to print times relative to the present::
 
     $now = new Time('Aug 22, 2011');
     echo $now->timeAgoInWords(
-        ['format' => 'F jS, Y', 'end' => '+1 year']
+        ['format' => 'MMM d, YYY', 'end' => '+1 year']
     );
     // On Nov 10th, 2011 this would display: 2 months, 2 weeks, 6 days ago
 


### PR DESCRIPTION
This is the only way I could get formatting to work with `timeAgoInWords`. I can create tests for the core if this behavior is or is not desired.