### PR TITLE
Containing all convenience methods

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -411,9 +411,11 @@ appropriate log level.
 .. php:staticmethod:: emergency($message, $scope = array())
 .. php:staticmethod:: alert($message, $scope = array())
 .. php:staticmethod:: critical($message, $scope = array())
+.. php:staticmethod:: error($message, $scope = array())
+.. php:staticmethod:: warning($message, $scope = array())
 .. php:staticmethod:: notice($message, $scope = array())
-.. php:staticmethod:: debug($message, $scope = array())
 .. php:staticmethod:: info($message, $scope = array())
+.. php:staticmethod:: debug($message, $scope = array())
 
 
 .. meta::


### PR DESCRIPTION
Added non-mentioned CakeLog::error and CakeLog::warning to the list