### PR TITLE
Add carbon docs link

### DIFF
--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -34,6 +34,8 @@ Under the hood, CakePHP uses `Carbon <https://github.com/briannesbitt/Carbon>`_
 to power its Time utility. Anything you can do with ``Carbon`` and
 ``DateTime``, you can do with ``Time``.
 
+For details on Carbon please see `their documentation. <http://carbon.nesbot.com/docs/>`_.
+
 .. start-time
 
 Creating Time Instances

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -34,7 +34,7 @@ Under the hood, CakePHP uses `Carbon <https://github.com/briannesbitt/Carbon>`_
 to power its Time utility. Anything you can do with ``Carbon`` and
 ``DateTime``, you can do with ``Time``.
 
-For details on Carbon please see `their documentation. <http://carbon.nesbot.com/docs/>`_.
+For details on Carbon please see `their documentation <http://carbon.nesbot.com/docs/>`_.
 
 .. start-time
 


### PR DESCRIPTION
vSome people had trouble about finding the functionality underneath Time class, and the existing link goes the project overview, not the documentation. We should provide a direct link to the docs though.