### PR TITLE
New methods in interfaces is a BC-break

### DIFF
--- a/en/contributing/backwards-compatibility.rst
+++ b/en/contributing/backwards-compatibility.rst
@@ -38,8 +38,7 @@ Interfaces
 ----------
 
 Outside of major releases, interfaces provided by CakePHP will **not** have any
-existing methods changed. New methods may be added, but no existing methods will
-be changed.
+existing methods changed. New methods will **not** be added.
 
 Classes
 -------

--- a/en/contributing/backwards-compatibility.rst
+++ b/en/contributing/backwards-compatibility.rst
@@ -38,7 +38,7 @@ Interfaces
 ----------
 
 Outside of major releases, interfaces provided by CakePHP will **not** have any
-existing methods changed. New methods will **not** be added.
+existing methods changed and new methods will **not** be added to any existing interfaces.
 
 Classes
 -------


### PR DESCRIPTION
Adding a method to an interface breaks any existing implementation of that interface. Shouldn't doing this be considered a BC-break?