### PR TITLE
Minor fix to "creating custom auth. objects"

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -261,7 +261,7 @@ you wanted to create an OpenID authentication object. In
 Authentication objects should return ``false`` if they cannot identify the
 user and an array of user information if they can. It's not required
 that you extend ``BaseAuthenticate``, only that your authentication object
-implements an ``authenticate()`` method. The ``BaseAuthenticate`` class
+implements ``Cake\Event\EventListenerInterface``. The ``BaseAuthenticate`` class
 provides a number of helpful methods that are commonly used. You can
 also implement a ``getUser()`` method if your authentication object needs
 to support stateless or cookie-less authentication. See the sections on


### PR DESCRIPTION
Custom authentication objects must implement EventListenerInterface.