### PR TITLE
[3.0] Updated 'Using Custom Authentication Objects'

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -289,8 +289,12 @@ by including them in AuthComponents authenticate array::
 
     $this->Auth->config('authenticate', [
         'Openid', // app authentication object.
-        'AuthBag.Combo', // plugin authentication object.
+        'AuthBag.Openid', // plugin authentication object.
     ]);
+
+> Note that when using plugin notation there's no 'Authenticate' word when
+initiating the authentication object. Instead, if using namespaces, you'll need
+to set the full namespace of the class (including the 'Authenticate' word).
 
 Creating Stateless Authentication Systems
 -----------------------------------------

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -292,9 +292,10 @@ by including them in AuthComponents authenticate array::
         'AuthBag.Openid', // plugin authentication object.
     ]);
 
-> Note that when using plugin notation there's no 'Authenticate' word when
-initiating the authentication object. Instead, if using namespaces, you'll need
-to set the full namespace of the class (including the 'Authenticate' word).
+.. note::
+    Note that when using simple notation there's no 'Authenticate' word when
+    initiating the authentication object. Instead, if using namespaces, you'll need
+    to set the full namespace of the class (including the 'Authenticate' word).
 
 Creating Stateless Authentication Systems
 -----------------------------------------


### PR DESCRIPTION
I've set the same example for both the 'app authentication object' and 'plugin authentication object'. I think that can be better understand in this way, having the 'Creating Custom Authentication Objects' and 'Using Custom Authentication Objects' with the same class name.

Anyway I've also added a note to clarify this.

closes #2746 