### PR TITLE
Fix for plugin path

### DIFF
--- a/en/core-libraries/app.rst
+++ b/en/core-libraries/app.rst
@@ -62,12 +62,12 @@ Used for finding the path to a package inside CakePHP::
 Locating Plugins
 ================
 
-.. php:staticmethod:: pluginPath(string $plugin)
+.. php:staticmethod:: Plugin::path(string $plugin)
 
-Plugins can be located with App as well. Using ``App::pluginPath('DebugKit');``
+Plugins can be located with Plugin. Using ``Plugin::path('DebugKit');``
 for example, will give you the full path to the DebugKit plugin::
 
-    $path = App::pluginPath('DebugKit');
+    $path = Plugin::path('DebugKit');
 
 Locating Themes
 ===============

--- a/fr/core-libraries/app.rst
+++ b/fr/core-libraries/app.rst
@@ -64,13 +64,13 @@ Utilisée pour trouver le chemin vers un package dans CakePHP::
 Localiser les Plugins
 =====================
 
-.. php:staticmethod:: pluginPath(string $plugin)
+.. php:staticmethod:: Plugin::path(string $plugin)
 
-Les plugins peuvent aussi être localisés avec App. En utilisant
-``App::pluginPath('DebugKit');`` par exemple, cela vous donnera le chemin
+Les plugins peuvent être localisés avec Plugin. En utilisant
+``Plugin::path('DebugKit');`` par exemple, cela vous donnera le chemin
 complet vers le plugin DebugKit::
 
-    $path = App::pluginPath('DebugKit');
+    $path = Plugin::path('DebugKit');
 
 Localiser les Themes
 ====================

--- a/ja/core-libraries/app.rst
+++ b/ja/core-libraries/app.rst
@@ -333,18 +333,18 @@ CakePHP が把握しているオブジェクトを探索する
 プラグインの配置
 ================
 
-.. php:staticmethod:: pluginPath(string $plugin)
+.. php:staticmethod:: Plugin::path(string $plugin)
 
     :rtype: string
 
     ..
-        Plugins can be located with App as well. Using ``App::pluginPath('DebugKit');``
+        Plugins can be located with Plugin. Using ``Plugin::path('DebugKit');``
         for example, will give you the full path to the DebugKit plugin
 
     プラグインも同じように App で配置できます。
-    例えば ``App::pluginPath('DebugKit');`` を用いることで DebugKit プラグインへのフルパスをあなたに与えます::
+    例えば ``Plugin::path('DebugKit');`` を用いることで DebugKit プラグインへのフルパスをあなたに与えます::
 
-        $path = App::pluginPath('DebugKit');
+        $path = Plugin::path('DebugKit');
 
 .. Locating themes
 


### PR DESCRIPTION
App::pluginPath() doesn't exist anymore, use Plugin::path() instead.