### PR TITLE
Update tree.rst

### DIFF
--- a/en/orm/behaviors/tree.rst
+++ b/en/orm/behaviors/tree.rst
@@ -24,8 +24,8 @@ Requirements
 This behavior requires the following columns in your table:
 
 - ``parent_id`` (nullable) The column holding the ID of the parent row
-- ``lft`` (integer) Used to maintain the tree structure
-- ``rght`` (integer) Used to maintain the tree structure
+- ``lft`` (integer, signed) Used to maintain the tree structure
+- ``rght`` (integer, signed) Used to maintain the tree structure
 
 You can configure the name of those fields should you need to customize them.
 More information on the meaning of the fields and how they are used can be found


### PR DESCRIPTION
As per comments on StackOverflow here: http://stackoverflow.com/questions/30313081/cakephp-3-tree-behavior-numeric-value-out-of-range-on-save-delete-or-move-fu/30320968#30320968

The structure for this requires that lft and rght be signed rather than unsigned integers due to multiplication by -1 for operation speed.