### PR TITLE
Radio buttons example change

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1540,8 +1540,7 @@ example::
     ]);
 
     // Create a radio set with our custom wrapping div.
-    echo $this->Form->radio('User.email_notifications', [
-        'options' => ['y', 'n'],
+    echo $this->Form->radio('User.email_notifications', ['y', 'n'], [
         'type' => 'radio'
     ]);
 


### PR DESCRIPTION
The options for the radio buttons need to the the second parameter while attributes need to be defined in third parameter.

Ref - 
http://api.cakephp.org/3.0/class-Cake.View.Helper.FormHelper.html#_radio
http://book.cakephp.org/3.0/en/views/helpers/form.html#creating-radio-buttons