### PR TITLE
`dependent` key for belongsToMany association documented

### DIFF
--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -488,6 +488,8 @@ Possible keys for belongsToMany association arrays include:
   conditions on an associated table, you should use a 'through' model, and
   define the necessary belongsTo associations on it.
 - **sort** an array of find() compatible order clauses.
+- **dependent**: When the dependent key is set to ``false``, and an entity is
+  deleted, the data of the join table will not be deleted.
 - **through** Allows you to provide a either the name of the Table instance you
   want used on the join table, or the instance itself. This makes customizing
   the join table keys possible, and allows you to customize the behavior of the

--- a/fr/orm/associations.rst
+++ b/fr/orm/associations.rst
@@ -512,6 +512,9 @@ sont:
   des conditions sur une table associée, vous devriez utiliser un model
   'through' et lui définir les associations belongsTo nécessaires.
 - **sort** un tableau de clauses order compatible avec find().
+- **dependent**: Quand la clé dependent est définie à ``false`` et qu'une entity
+  est supprimée, les enregistrements de la table de jointure ne seront pas
+  supprimés.
 - **through** Vous permet de fournir soit le nom de l'instance de la Table
   que vous voulez utiliser, soit l'instance elle-même. Cela rend possible la
   personnalisation des clés de la table de jointure, et vous permet de


### PR DESCRIPTION
I tried to find how to not delete the join data of a belongsToMany association when deleting an entity, but didn't find anything in the documentation related to this.

I've tried `$this->belongsToMany('Table', ['dependent' => false])`, and it works. So I'm just stating this in the documentation.