### PR TITLE
Add details on debug()ing Query and ResultSet objects.

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -10,6 +10,18 @@ objects, when you query for individual records you get 'entity' objects. While
 this section discusses the different ways you can find and load entities, you
 should read the :doc:`/orm/entities` section for more information on entities.
 
+Debugging Queries and ResultSets
+================================
+
+Since the ORM now returns Collections and Entities, debugging these objects can be more complicated than in previous CakePHP versions. There are now various ways to inspect the data returned by the ORM.
+
+- ``debug($query)`` Shows the SQL and bound params, does not show results.
+- ``debug($query->all())`` Shows the ResultSet properties (not the results).
+- ``debug($query->toArray())`` An easy way to show each of the results.
+- ``debug(json_encode($query, JSON_PRETTY_PRINT))`` More human readable results.
+- ``debug($query->first())`` Show the properties of a single entity.
+- ``debug((string)$query->first())`` Show the properties of a single entity as JSON.
+
 Getting a Single Entity by Primary Key
 ======================================
 


### PR DESCRIPTION
Importing an excellent quick-reference of how to debug information in a Query/ResultSet from @lorenzo's [CakeFest 2015 talk](https://github.com/lorenzo/cakephp3-advanced-examples/blob/1dad4d52e44a7fadca47dc84c355ca31b431c828/slides.pdf) (slide 21). Copying [with permission](https://cakesf.slack.com/archives/general/p1433084148001526).

This change is for the location that @lorenzo recommended ([Retrieving Data & Results Sets](http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#namespace-Cake\ORM)). The alternative proposed by @markstory would be on the [Query Builder](http://book.cakephp.org/3.0/en/orm/query-builder.html) page somewhere. I will happily update the PR if there is a strong preference. Maybe a cross-reference link from the other spot?