### PR TITLE
Update 3-0-migration-guide.rst

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -515,8 +515,7 @@ Controller
   models + controllers were far more intertwined.
 - ``Controller::loadModel()`` now loads table objects.
 - The ``Controller::$scaffold`` property has been removed. Dynamic scaffolding
-  has been removed from CakePHP core, and will be provided as a standalone
-  plugin.
+  has been removed from CakePHP core.  An improved scaffolding plugin, named CRUD, can be found here: https://github.com/FriendsOfCake/crud
 - The ``Controller::$ext`` property has been removed. You now have to extend and
   override the ``View::$_ext`` property if you want to use a non-default view file
   extension.
@@ -543,8 +542,7 @@ Scaffold Removed
 ----------------
 
 The dynamic scaffolding in CakePHP has been removed from CakePHP core. It was
-infrequently used, and never intended for production use. It will be replaced by
-a standalone plugin that people requiring that feature can use.
+infrequently used, and never intended for production use. An improved scaffolding plugin, named CRUD, can be found here: https://github.com/FriendsOfCake/crud
 
 ComponentCollection Replaced
 ----------------------------


### PR DESCRIPTION
CRUD plugin is now available as a solution to scaffolding and seems to support 3.0.