### PR TITLE
Add HTML extension to routing example

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -590,7 +590,7 @@ and then parse what remains. If you want to create a URL such as
 /page/title-of-page.html you would create your route using::
 
     Router::scope('/page', function ($routes) {
-        $routes->extensions(['json', 'xml']);
+        $routes->extensions(['json', 'xml', 'html']);
         $routes->connect(
             '/:title',
             ['controller' => 'Pages', 'action' => 'view'],


### PR DESCRIPTION
One of the routing examples was missing the `html` extension, causing the example to not work as expected.