### PR TITLE
console-and-shells.rst - add needed apostrophe

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -736,7 +736,7 @@ Getting help as XML
 -------------------
 
 When building automated tools or development tools that need to interact
-with CakePHP shells, its nice to have help available in a machine parse-able
+with CakePHP shells, it's nice to have help available in a machine parse-able
 format. The ConsoleOptionParser can provide help in xml by setting an
 additional argument::
 


### PR DESCRIPTION
"it's" as in "it is" needs an apostrophe because it's a contraction