### PR TITLE
console-and-shells.rst - remove bad apostrophe

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -239,7 +239,7 @@ will call this method when the task is invoked. A task class looks like::
         }
     }
 
-A shell can also access it's tasks as properties, which makes tasks great for
+A shell can also access its tasks as properties, which makes tasks great for
 making re-usable chunks of functionality similar to :doc:`/controllers/components`::
 
     // found in Console/Command/SeaShell.php


### PR DESCRIPTION
"A shell can also access it’s tasks" - A possessive belonging to an "it" doesn't need an apostrophe.