### PR TITLE
fix code highlight font size

### DIFF
--- a/themes/cakephp/static/cake.css
+++ b/themes/cakephp/static/cake.css
@@ -166,6 +166,7 @@ a:hover {
 /* Preformatted text */
 pre, code {
     font-family: "Bitstream Vera Sans Mono", "Consolas", "Monaco", monospace;
+    font-size: 1.3rem;
 }
 pre {
     margin-bottom: 18px;


### PR DESCRIPTION
because it's bigger right now when in a `<li>` tag.

before:
![capture d ecran 2015-06-12 a 21 35 36](https://cloud.githubusercontent.com/assets/4977112/8138430/0118aa4e-114b-11e5-8cd5-2e30a3913200.png)
