### PR TITLE
Add a note on migrations about collations

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -226,6 +226,33 @@ adding new tables to the database, you can use the second argument of the
 
 The above will create a ``CHAR(36)`` ``id`` column that is also the primary key.
 
+Collations
+----------
+
+If you need to create a table with a different collation than the database
+default one, you can define it with the ``table()`` method, as an option::
+
+        class CreateCategoriesTable extends AbstractMigration
+        {
+            public function change()
+            {
+                $table = $this
+                    ->table('categories', [
+                        'collation' => 'latin1_german1_ci'
+                    ])
+                    ->addColumn('title', 'string', [
+                        'default' => null,
+                        'limit' => 255,
+                        'null' => false,
+                    ])
+                    ->create();
+            }
+
+Note however this can only be done on table creation : there is currently
+no way of adding a column to an existing table with a different collation than
+the table or the database.
+Only ``MySQL`` and ``SqlServer`` supports this configuration key for the time being.
+
 Applying Migrations
 ===================
 

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -267,8 +267,8 @@ de la méthode ``table()``::
 Notez cependant que ceci ne peut être fait qu'en cas de création de table :
 il n'y a actuellement aucun moyen d'ajouter une colonne avec une ``collation``
 différente de celle de la table ou de la base de données.
-Seul ``MySQL`` et ``SqlServer`` supporte cette option de configuration pour le
-moment.
+Seuls ``MySQL`` et ``SqlServer`` supportent cette option de configuration pour
+le moment.
 
 Appliquer les Migrations
 ========================

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -241,6 +241,35 @@ méthode ``table()``::
 Le code ci-dessus va créer une colonne ``CHAR(36)`` ``id`` également utilisée
 comme clé primaire.
 
+Collations
+----------
+
+Si vous avez besoin de créer une table avec une ``collation`` différente
+de celle par défaut de la base de données, vous pouvez la définir comme option
+de la méthode ``table()``::
+
+        class CreateCategoriesTable extends AbstractMigration
+        {
+            public function change()
+            {
+                $table = $this
+                    ->table('categories', [
+                        'collation' => 'latin1_german1_ci'
+                    ])
+                    ->addColumn('title', 'string', [
+                        'default' => null,
+                        'limit' => 255,
+                        'null' => false,
+                    ])
+                    ->create();
+            }
+
+Notez cependant que ceci ne peut être fait qu'en cas de création de table :
+il n'y a actuellement aucun moyen d'ajouter une colonne avec une ``collation``
+différente de celle de la table ou de la base de données.
+Seul ``MySQL`` et ``SqlServer`` supporte cette option de configuration pour le
+moment.
+
 Appliquer les Migrations
 ========================
 


### PR DESCRIPTION
Follow up on cakephp/migrations#92 where a note was added about dealing with collations with the migrations plugin.