### PR TITLE
Remove incorrect section.

### DIFF
--- a/en/console-and-shells/i18n-shell.rst
+++ b/en/console-and-shells/i18n-shell.rst
@@ -59,21 +59,9 @@ no to set the default behavior::
 
     bin/cake i18n extract --extract-core yes
 
-    or
+    // or
 
     bin/cake i18n extract --extract-core no
-
-
-Create the Tables used by TranslateBehavior
-===========================================
-
-The i18n shell can also be used to initialize the default tables used by the
-:php:class:`TranslateBehavior`::
-
-    bin/cake i18n initdb
-
-This will create the **i18n** table used by translate behavior.
-
 
 .. meta::
     :title lang=en: I18N shell

--- a/fr/console-and-shells/i18n-shell.rst
+++ b/fr/console-and-shells/i18n-shell.rst
@@ -64,19 +64,9 @@ Définissez --extract-core à yes ou no pour définir le comportement par défau
 
     bin/cake i18n extract --extract-core yes
 
-    ou
+    // ou
 
     bin/cake i18n extract --extract-core no
-
-Créer les Tables utilisées par TranslateBehavior
-================================================
-
-Le shell i18n peut aussi être utilisé pour initialiser les tables par défaut
-utilisées par :php:class:`TranslateBehavior`::
-
-    bin/cake i18n initdb
-
-Cela va créer la table **i18n** utilisée par le behavior Translate.
 
 .. meta::
     :title lang=fr: I18N shell


### PR DESCRIPTION
There is no `i18n initdb` command anymore. I didn't add anything as the TranslateBehavior docs already include information on how to create the required schema.

Refs #2921