### PR TITLE
Removing Duplicated Comma In Fallbacks Sample

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -1014,7 +1014,7 @@ Calling fallbacks like so::
 Is equivalent to the following explicit calls::
 
     $routes->connect('/:controller', ['action' => 'index'], ['routeClass' => 'InflectedRoute']);
-    $routes->connect('/:controller/:action/*', [], , ['routeClass' => 'InflectedRoute']);
+    $routes->connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
 
 .. note::
 


### PR DESCRIPTION
Line #1017 had a duplicated comma in the code sample, removed.