### PR TITLE
Remove lie about Scaffold folder

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -783,7 +783,6 @@ The following View folders have been renamed to avoid naming collisions with con
 
 - ``Layouts`` is now ``Layout``
 - ``Elements`` is now ``Element``
-- ``Scaffolds`` is now ``Scaffold``
 - ``Errors`` is now ``Error``
 - ``Emails`` is now ``Email`` (same for ``Email`` inside ``Layout``)
 


### PR DESCRIPTION
This folder does not exist anymore in 3.0.0+

https://github.com/cakephp/app/tree/3.0.0/src/View
https://github.com/cakephp/app/tree/3.0.0/src/Template