### PR TITLE
Fix Bad Apostrophe in views.rst

### DIFF
--- a/en/views.rst
+++ b/en/views.rst
@@ -3,7 +3,7 @@ Views
 
 Views are the **V** in MVC. Views are responsible for generating
 the specific output required for the request. Often this is in the
-form of HTML, XML, or JSON, but streaming files and creating PDF's
+form of HTML, XML, or JSON, but streaming files and creating PDFs
 that users can download are also responsibilities of the View
 Layer.
 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe (even for acronyms). Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!