### PR TITLE
Mention the fact that CakePHP 2.7 new PHP 5.3 and above.

### DIFF
--- a/en/appendices/2-7-migration-guide.rst
+++ b/en/appendices/2-7-migration-guide.rst
@@ -4,6 +4,10 @@
 CakePHP 2.7 is a fully API compatible upgrade from 2.6. This page outlines
 the changes and improvements made in 2.7.
 
+Requirements
+============
+The PHP version requirement for CakePHP 2.7 has been bumped up to PHP 5.3.0.
+
 Console
 =======
 

--- a/en/installation.rst
+++ b/en/installation.rst
@@ -12,7 +12,7 @@ Requirements
 
 -  HTTP Server. For example: Apache. mod\_rewrite is preferred, but
    by no means required.
--  PHP 5.2.8 or greater.
+-  PHP 5.3.0 or greater (CakePHP version 2.6 and below support PHP 5.2.8 and above).
 
 Technically a database engine isn't required, but we imagine that
 most applications will utilize one. CakePHP supports a variety of


### PR DESCRIPTION
It's pretty bad we didn't remember stating this earlier.