### PR TITLE
beforeRules return

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -174,7 +174,7 @@ beforeRules
 .. php:method:: beforeRules(Event $event, Entity $entity, ArrayObject $options, $operation)
 
 The ``Model.beforeRules`` event is fired before an entity has rules applied. By
-stopping this event, you can return the final value of the rules checking
+stopping this event, you can return the value of the rules not checked yet by
 operation.
 
 afterRules

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -174,8 +174,8 @@ beforeRules
 .. php:method:: beforeRules(Event $event, Entity $entity, ArrayObject $options, $operation)
 
 The ``Model.beforeRules`` event is fired before an entity has rules applied. By
-stopping this event, you can return the value of the rules not checked yet by
-operation.
+stopping this event, you can short circuit the rules checking and set the result
+of applying rules'.
 
 afterRules
 --------------


### PR DESCRIPTION
I think beforeRules  can get not checked value by Cake
End of this description is same as after rules.
It is contravertial thing.