### PR TITLE
Add ShellHelpers to the migration guide.

### DIFF
--- a/en/appendices/3-1-migration-guide.rst
+++ b/en/appendices/3-1-migration-guide.rst
@@ -25,6 +25,13 @@ Console
   console. This is very helpful when debugging in test cases, or other CLI
   scripts.
 
+Shell Helpers Added
+-------------------
+
+Console applications can now create helper classes that encapsulate re-usable
+blocks of output logic. See the :doc:`/console-and-shells/helpers` section for
+more information.
+
 Controller
 ==========
 

--- a/fr/appendices/3-1-migration-guide.rst
+++ b/fr/appendices/3-1-migration-guide.rst
@@ -27,6 +27,13 @@ Console
   de code qui peut être utilisé dans un ``eval()`` pour lancer une console
   interactive. C'est très utile pour debugger les tests ou tout script CLI.
 
+Ajout des Shell Helpers
+-----------------------
+
+Les applications de console peuvent maintenant créer des classes Helper qui
+encapsulent des blocs réutilisables de logique de sortie. Consultez la section
+sur :doc:`/console-and-shells/helpers` pour plus d'informations.
+
 Controller
 ==========
 
@@ -52,7 +59,7 @@ RequestHandlerComponent
 - ``RequestHandlerComponent`` now switches the layout and template based on
   the parsed extension or ``Accept-Type`` header in the ``beforeRender()`` callback
   instead of ``startup()``.
-  
+
 Network
 =======
 
@@ -64,7 +71,7 @@ Http\Client
   ``multipart/form-data`` n'est utilisé qu'en cas de transfert de fichiers.
   Lorsqu'il n'y en pas, ``application/x-www-form-urlencoded`` est utilisé à la
   place.
-  
+
 ORM
 ===
 

--- a/fr/views/themes.rst
+++ b/fr/views/themes.rst
@@ -15,9 +15,9 @@ votre callback ``beforeRender()`` ::
     class ExempleController extends AppController
     {
         public function beforeRender(\Cake\Event\Event $event)
-+        {
-+            $this->getView()->theme = 'Modern';
-+        }
+        {
+            $this->getView()->theme = 'Modern';
+        }
     }
 
 Les fichiers de template du theme doivent être dans un plugin avec le même nom.


### PR DESCRIPTION
This was omitted when the docs for shell helpers were written.