### PR TITLE
add #6620, #6800, #6850, #6906 to migration guide

### DIFF
--- a/en/appendices/3-1-migration-guide.rst
+++ b/en/appendices/3-1-migration-guide.rst
@@ -28,9 +28,16 @@ Console
 Shell Helpers Added
 -------------------
 
-Console applications can now create helper classes that encapsulate re-usable
-blocks of output logic. See the :doc:`/console-and-shells/helpers` section for
-more information.
+- Console applications can now create helper classes that encapsulate re-usable
+  blocks of output logic. See the :doc:`/console-and-shells/helpers` section
+  for more information.
+
+RoutesShell
+-----------
+
+- RoutesShell has been added and now provides you a simple to use CLI
+  interface for testing and debugging routes. See the
+  :doc:`/console-and-shells/routes-shell` section for more information.
 
 Controller
 ==========
@@ -128,7 +135,7 @@ FlashHelper
 FormHelper
 ----------
 
-- New option ```templateVars`` has been added. ``templateVars`` allows you to
+- New option ``templateVars`` has been added. ``templateVars`` allows you to
   pass additional variables to your custom form control templates.
 
 Email

--- a/en/appendices/3-1-migration-guide.rst
+++ b/en/appendices/3-1-migration-guide.rst
@@ -18,8 +18,6 @@ Console
 
 - ``Shell::dispatchShell()`` no longer outputs the welcome message from the
   dispatched shell.
-- :doc:`/console-and-shells/helpers` were added. Shell Helpers allow you to
-  package up complex output logic in a reusable way.
 - The ``breakpoint()`` helper function has been added. This function provides
   a snippet of code that can be put into ``eval()`` to trigger an interactive
   console. This is very helpful when debugging in test cases, or other CLI

--- a/en/appendices/3-1-migration-guide.rst
+++ b/en/appendices/3-1-migration-guide.rst
@@ -38,14 +38,15 @@ Controller
 AuthComponent
 -------------
 
-- New config ``storage`` has been added. It contains the storage class name that
+- New config option ``storage`` has been added. It contains the storage class name that
   ``AuthComponent`` uses to store user record. By default ``SessionStorage`` is used.
   If using a stateless authenticator you should configure ``AuthComponent`` to
   use ``MemoryStorage`` instead.
-- New config ``checkAuthIn`` has been added. It contains the name of the event
-  for wich auth checks should be done. By defaults ``Controller.startup`` is
-  used but you can set it to ``Controller.initialize`` if you want the check to
-  be done before controller's ``beforeFilter()`` is run.
+- New config option ``checkAuthIn`` has been added. It contains the name of the
+  event for which auth checks should be done. By default ``Controller.startup``
+  is used, but you can set it to ``Controller.initialize`` if you want
+  authentication to be checked before you controller's ``beforeFilter()`` method
+  is run.
 
 FlashComponent
 --------------
@@ -58,8 +59,9 @@ CsrfComponent
 -------------
 
 - CSRF cookie expiry time can now be set as a ``strtotime()`` compatible value.
-- Invalid CSRF will now throw a ``Cake\Network\Exception\InvalidCsrfTokenException``
-  instead of the ``Cake\Network\Exception\ForbiddenException``.
+- Invalid CSRF tokens will now throw
+  a ``Cake\Network\Exception\InvalidCsrfTokenException`` instead of the
+  ``Cake\Network\Exception\ForbiddenException``.
 
 RequestHandlerComponent
 -----------------------

--- a/en/appendices/3-1-migration-guide.rst
+++ b/en/appendices/3-1-migration-guide.rst
@@ -42,6 +42,10 @@ AuthComponent
   ``AuthComponent`` uses to store user record. By default ``SessionStorage`` is used.
   If using a stateless authenticator you should configure ``AuthComponent`` to
   use ``MemoryStorage`` instead.
+- New config ``checkAuthIn`` has been added. It contains the name of the event
+  for wich auth checks should be done. By defaults ``Controller.startup`` is
+  used but you can set it to ``Controller.initialize`` if you want the check to
+  be done before controller's ``beforeFilter()`` is run.
 
 FlashComponent
 --------------
@@ -54,6 +58,8 @@ CsrfComponent
 -------------
 
 - CSRF cookie expiry time can now be set as a ``strtotime()`` compatible value.
+- Invalid CSRF will now throw a ``Cake\Network\Exception\InvalidCsrfTokenException``
+  instead of the ``Cake\Network\Exception\ForbiddenException``.
 
 RequestHandlerComponent
 -----------------------
@@ -91,6 +97,8 @@ Query
   parameters. These parameter types will select all the columns on the provided
   table or association instance's target table.
 - ``Table::loadInto()`` was added.
+- ``EXTRACT``, ``DATE_ADD`` and ``DAYOFWEEK`` raw SQL functions have been
+  abstracted to ``extract()``, ``dateAdd`` and ``dayOfWeek()``.
 
 
 View
@@ -114,6 +122,12 @@ FlashHelper
 - ``FlashHelper`` can render multiple messages if multiple messages where
   set with the ``FlashComponent``. Each message will be rendered in its own
   element. Messages will be rendered in the order they were set.
+
+FormHelper
+----------
+
+- New option ```templateVars`` has been added. ``templateVars`` allows you to
+  pass additional variables to your custom form control templates.
 
 Email
 =====

--- a/en/appendices/3-1-migration-guide.rst
+++ b/en/appendices/3-1-migration-guide.rst
@@ -152,3 +152,5 @@ Time
 
 - ``Time::fromNow()`` has been added. This method makes it easier to calculate
   differences from 'now'.
+- ``Time::i18nFormat()`` now supports non-gregorian calendars when formatting
+  dates.

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -1001,8 +1001,9 @@ More Topics
     console-and-shells/cron-jobs
     console-and-shells/i18n-shell
     console-and-shells/completion-shell
-    console-and-shells/upgrade-shell
     console-and-shells/plugin-shell
+    console-and-shells/routes-shell
+    console-and-shells/upgrade-shell
 
 .. meta::
     :title lang=en: Console and Shells

--- a/en/console-and-shells/routes-shell.rst
+++ b/en/console-and-shells/routes-shell.rst
@@ -1,0 +1,37 @@
+Routes Shell
+############
+
+.. versionadded:: 3.1
+    The RoutesShell was added in 3.1
+
+The RoutesShell provides a simple to use CLI interface for testing and debugging
+routes. You can use it to test how routes are parsed, and what URLs routing
+parameters will generate.
+
+Getting a List of all Routes
+----------------------------
+
+::
+    bin/cake routes
+
+Testing URL parsing
+-------------------
+
+You can quickly see how a URL will be parsed using the ``check`` method::
+
+    bin/cake routes check /bookmarks/edit/1
+
+If your route contains any query string parameters remember to surround the URL
+in quotes::
+
+    bin/cake routes check "/bookmarks/?page=1&sort=title&direction=desc"
+
+
+Testing URL Generation
+----------------------
+
+You can see how which URL a :term:`routing array` will generate using the
+``generate`` method::
+
+    bin/cake routes generate controller:Bookmarks action:edit 1
+

--- a/en/controllers/components/csrf.rst
+++ b/en/controllers/components/csrf.rst
@@ -12,7 +12,14 @@ are created with the :php:class:`Cake\\View\\Helper\\FormHelper`, a hidden field
 is added containing the CSRF token. During the ``Controller.startup`` event, if
 the request is a POST, PUT, DELETE, PATCH request the component will compare the
 request data & cookie value. If either is missing or the two values mismatch the
-component will throw a :php:class:`Cake\\Network\\Exception\\ForbiddenException`.
+component will throw a
+:php:class:`Cake\\Network\\Exception\\InvalidCsrfTokenException`.
+
+.. versionadded:: 3.1
+
+    The exception type changed from
+    :php:class:`Cake\\Network\\Exception\\ForbiddenException` to
+    :php:class:`Cake\\Network\\Exception\\InvalidCsrfTokenException`.
 
 Using the CsrfComponent
 =======================

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -140,6 +140,23 @@ dates. CakePHP makes this a snap::
     // Outputs '2014-04-20 22:10'
     $now->i18nFormat('YYYY-MM-dd HH:mm:ss');
 
+As of 3.1.0 you can format dates with non-gregorian calendars::
+
+    // Outputs 'Thursday, Dey 24, 1388 at 1:59:28 PM GMT'
+    $result = $now(\IntlDateFormatter::FULL, null, 'en-IR@calendar=persian');
+
+The following calendar types are supported:
+
+* japanese
+* buddhist
+* chinese
+* persian
+* indian
+* islamic
+* hebrew
+* coptic
+* ethiopic
+
 .. php:method:: nice()
 
 Print out a predefined 'nice' format::

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -140,9 +140,9 @@ dates. CakePHP makes this a snap::
     // Outputs '2014-04-20 22:10'
     $now->i18nFormat('YYYY-MM-dd HH:mm:ss');
 
-As of 3.1.0 you can format dates with non-gregorian calendars::
+You can also format dates with non-gregorian calendars::
 
-    // Outputs 'Thursday, Dey 24, 1388 at 1:59:28 PM GMT'
+    // Outputs 'Friday, Aban 9, 1393 AP at 12:00:00 AM GMT'
     $result = $now->i18nFormat(\IntlDateFormatter::FULL, null, 'en-IR@calendar=persian');
 
 The following calendar types are supported:
@@ -156,6 +156,9 @@ The following calendar types are supported:
 * hebrew
 * coptic
 * ethiopic
+
+.. versionadded:: 3.1
+    Non-gregorian calendar support was added in 3.1
 
 .. php:method:: nice()
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -143,7 +143,7 @@ dates. CakePHP makes this a snap::
 As of 3.1.0 you can format dates with non-gregorian calendars::
 
     // Outputs 'Thursday, Dey 24, 1388 at 1:59:28 PM GMT'
-    $result = $now(\IntlDateFormatter::FULL, null, 'en-IR@calendar=persian');
+    $result = $now->i18nFormat(\IntlDateFormatter::FULL, null, 'en-IR@calendar=persian');
 
 The following calendar types are supported:
 

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -144,6 +144,14 @@ exceptions for HTTP methods
 
     Used for doing a 403 Forbidden error.
 
+.. versionadded:: 3.1
+
+    InvalidCsrfTokenException has been added.
+
+.. php:exception:: InvalidCsrfTokenException
+
+    Used for doing a 403 error caused by an invalid CSRF token
+
 .. php:exception:: NotFoundException
 
     Used for doing a 404 Not found error.

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -309,6 +309,14 @@ A number of commonly used functions can be created with the ``func()`` method:
   treated as bound parameters unless marked as literal.
 - ``now()`` Take either 'time' or 'date' as an argument allowing you to get
   either the current time, or current date.
+- ``extract()`` Returns the specified date part from the SQL expression.
+- ``dateAdd()`` Add the time unit to the date expression.
+- ``dayOfWeek()`` Returns a FunctionExpression representing a call to SQL
+  WEEKDAY function.
+
+.. versionadded:: 3.1
+
+    ``extract()``, ``dateAdd()`` and ``dayOfWeek()`` methods have been added.
 
 When providing arguments for SQL functions, there are two kinds of parameters
 you can use, literal arguments and bound parameters. Literal parameters allow

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1610,6 +1610,26 @@ used if it is present. If that template is missing by default each set of label
         'radioFormGroup' => '<div class="radio">{{label}}{{input}}</div>'
     ]);
 
+Adding Additional Template Variables to Templates
+-------------------------------------------------
+
+You can add additional template placeholders in custom templates, and populate
+those placeholders when generating inputs::
+
+    // Add a template with the help placeholder.
+    $this->Form->templates([
+        'inputContainer' => '<div class="input {{type}}{{required}}">
+            {{content}} <span class="help">{{help}}</span></div>'
+    ]);
+
+    // Generate an input and populate the help variable
+    echo $this->Form->input('password', [
+        'templateVars' => ['help' => 'At least 8 characters long.']
+    ]);
+
+.. versionadded:: 3.1
+    Additional template variables were added in 3.1.0
+
 Moving Checkboxes & Radios Outside of a Label
 ---------------------------------------------
 


### PR DESCRIPTION
@markstory in addition to what we spoke earlier, this PR also tries to fill the gap between the implemented features and the docs.

This is all I had the time to do today and obviously, more docs will be needed for cakephp/cakephp#6850 for example but at least it's mentioned in the migration guide.