### PR TITLE
Fix validation providers explanation.

### DIFF
--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -198,7 +198,7 @@ CakePHP sets up a few providers:
    ``default`` provider.
 
 When a validation rule is created you can name the provider of that rule. For
-example, if your entity had a 'isValidRole' method you could use it as
+example, if your table had a ``isValidRole`` method you could use it as
 a validation rule::
 
     use Cake\ORM\Table;
@@ -216,6 +216,11 @@ a validation rule::
                     'provider' => 'table',
                 ]);
             return $validator;
+        }
+
+        public function isValidRole($value, array $context)
+        {
+            return in_array($value, ['admin', 'editor', 'author'], true);
         }
 
     }

--- a/fr/orm/validation.rst
+++ b/fr/orm/validation.rst
@@ -207,7 +207,7 @@ provider connu. Par défaut, CakePHP définit quelques providers:
    configurée avec le provider ``default``.
 
 Quand une règle de validation est créée, vous pouvez nommer le provider de cette
-règle. Par exemple, si votre entity a une méthode 'isValidRole', vous pouvez
+règle. Par exemple, si votre table a une méthode ``isValidRole``, vous pouvez
 l'utiliser comme une règle de validation::
 
     use Cake\ORM\Table;
@@ -225,6 +225,11 @@ l'utiliser comme une règle de validation::
                     'provider' => 'table',
                 ]);
             return $validator;
+        }
+
+        public function isValidRole($value, array $context)
+        {
+            return in_array($value, ['admin', 'editor', 'author'], true);
         }
 
     }


### PR DESCRIPTION
The `table` provider uses tables, not entities.