### PR TITLE
add ","  makes clear

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -27,7 +27,7 @@ routes are parsed. It's generally a good idea to place most frequently
 visited routes at the top of the routes file if possible. This will
 save having to check a number of routes that won't match on each request.
 
-Routes are parsed and matched in the order they are connected in.
+Routes are parsed and matched, in the order they are connected in.
 If you define two similar routes, the first defined route will
 have higher priority over the one defined latter. After connecting routes you
 can manipulate the order of routes using :php:meth:`Router::promote()`.


### PR DESCRIPTION
"," makes   "in the order they are connected in"　clearly related to "matched" and "parsed"  both or not.
In google translation with "," , it outputs good Japanese.