### PR TITLE
Add more information on complex queries.

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -38,6 +38,8 @@ CakePHP supports the following relational database servers:
 You will need the correct PDO extension installed for each of the above database
 drivers. Procedural API's are not supported.
 
+.. _running-select-statements:
+
 Running Select Statements
 -------------------------
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -1188,7 +1188,7 @@ While the query builder makes it easy to build most queries, very complex
 queries can be tedious and complicated to build. You may want to :ref:`execute
 the desired SQL directly <running-select-statements>`.
 
-Directly executing SQL allows you to fine tune the query that will be run.
+Executing SQL directly allows you to fine tune the query that will be run.
 However, doing so doesn't let you use ``contain`` or other higher level ORM
 features.
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -1181,6 +1181,17 @@ subqueries::
 Subqueries are accepted anywhere a query expression can be used. For example, in
 the ``select()`` and ``join()`` methods.
 
+Executing Complex Queries
+-------------------------
+
+While the query builder makes it easy to build most queries, very complex
+queries can be tedious and complicated to build. You may want to :ref:`execute
+the desired SQL directly <running-select-statements>`.
+
+Directly executing SQL allows you to fine tune the query that will be run.
+However, doing so doesn't let you use ``contain`` or other higher level ORM
+features.
+
 .. _format-results:
 
 Adding Calculated Fields

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -42,6 +42,8 @@ CakePHP supporte les serveurs de base de données relationnelles suivants:
 Pour chacun des drivers de base de données ci-dessus, assurez-vous d'avoir
 la bonne extension PDO installée. Les API procédurales ne sont pas supportées.
 
+.. _running-select-statements:
+
 Exécuter des Instructions Select
 --------------------------------
 

--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -1243,6 +1243,18 @@ les requêtes ensemble, vous pouvez faire des sous-requêtes::
 Les sous-requêtes sont acceptées partout où une expression query peut être
 utilisée. Par exemple, dans les méthodes ``select()`` et ``join()``.
 
+Exécuter des Requêtes Complexes
+-------------------------------
+
+Bien que le constructeur de requêtes facilite la construction de la plupart des
+requêtes, les requêtes très complexes peuvent être fastidieuses et compliquées
+à construire. Vous voudrez surement vous référer à :ref:`l'exécution
+directe du SQL souhaité <running-select-statements>`.
+
+Exécuter directement le SQL vous permet d'affiner la requête qui sera utilisée.
+Cependant, cela vous empêchera d'utiliser ``contain`` ou toute autre
+fonctionnalité de plus haut niveau de l'ORM.
+
 .. _format-results:
 
 Ajouter des Champs Calculés


### PR DESCRIPTION
Add links to the query builder docs for running complex queries. Sometimes the query builder just gets in the way, and SQL is the simplest solution.