### PR TITLE
Update form.rst

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1628,7 +1628,7 @@ those placeholders when generating inputs::
     ]);
 
 .. versionadded:: 3.1
-    Additional template variables were added in 3.1.0
+    The templateVars option was added in 3.1.0
 
 Moving Checkboxes & Radios Outside of a Label
 ---------------------------------------------


### PR DESCRIPTION
The templateVars note was confusing and caused us to lose time. The note seemed to imply that templateVars existed in 3.0, but 3.1 introduced new "template variables".