### PR TITLE
lowercased Classname fix

### DIFF
--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -39,7 +39,7 @@ Controller's ``initialize()`` method or via the ``$components`` array::
         {
             parent::initialize();
             $this->loadComponent('Auth', [
-                'authorize' => ['controller'],
+                'authorize' => 'Controller',
                 'loginAction' => ['controller' => 'Users', 'action' => 'login']
             ]);
             $this->loadComponent('Cookie', ['expiry' => '1 day']);


### PR DESCRIPTION
This one was an evil one.
After deployment from OS X (NFS shared to vagrant) to Debian (Host) it did not find the ControllerAuthorize adapter. Reason was I had it in small case as it used to be in 2.x I think. Fixing the documentation here. Also it works with a string only in case you don't supply any configuration options. So I dropped the array brackets here.