### PR TITLE
Update for Cakephp before 3.1

### DIFF
--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -11,6 +11,9 @@ To use themes, set the theme name in your controller's action or ``beforeRender(
 
     class ExamplesController extends AppController
     {
+        // For Cakephp before 3.1
+        public $theme = 'Modern';
+        
         public function beforeRender(\Cake\Event\Event $event)
         {
             $this->viewBuilder()->theme('Modern');


### PR DESCRIPTION
viewBuilder() will throw an exception when being used with Cakephp below 3.1.