### PR TITLE
Update part-three.rst

### DIFF
--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -127,8 +127,7 @@ your tables. We need to change the ``'null' => false`` for the ``parent_id``
 field with ``'null' => true`` because a top-level category has a null
 ``parent_id``.
 
-Once the files fits your envy, you can run the following command to create your
-tables::
+Run the following command to create your tables::
 
     bin/cake migrations migrate
 
@@ -177,9 +176,10 @@ read if you want re-familiarize yourself with how CakePHP works.
 .. note::
     If you are on Windows remember to use \ instead of /.
 
-You'll need to edit the following in **src/Template/Categories/index.ctp**::
+You'll need to edit the following in **src/Template/Categories/add.ctp**
+and **src/Template/Categories/edit.ctp**::
 
-    echo $this->Form->input('parent_id', ['options' => $parentCategories, 'empty' => 'No Parent']);
+    echo $this->Form->input('parent_id', ['options' => $parentCategories, 'empty' => true]);
 
 Attach TreeBehavior to CategoriesTable
 ======================================
@@ -205,6 +205,26 @@ edit template files::
 
     echo $this->Form->input('lft');
     echo $this->Form->input('rght');
+
+And disable or remove any associated validators from your CategoriesTable model:
+
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->add('id', 'valid', ['rule' => 'numeric'])
+            ->allowEmpty('id', 'create');
+
+        // Comment or delete associated validators
+        //  $validator
+        //      ->add('lft', 'valid', ['rule' => 'numeric'])
+        //      ->requirePresence('lft', 'create')
+        //      ->notEmpty('lft');
+        //
+        //  $validator
+        //      ->add('rght', 'valid', ['rule' => 'numeric'])
+        //      ->requirePresence('rght', 'create')
+        //      ->notEmpty('rght');
+    }
 
 These fields are automatically managed by the TreeBehavior when
 a category is saved.

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -206,24 +206,24 @@ edit template files::
     echo $this->Form->input('lft');
     echo $this->Form->input('rght');
 
-And disable or remove any associated validators from your CategoriesTable model:
+In addition you should disable or remove the requirePresence from the validator
+for both lft and rght in your CategoriesTable model:
 
     public function validationDefault(Validator $validator)
     {
         $validator
             ->add('id', 'valid', ['rule' => 'numeric'])
             ->allowEmpty('id', 'create');
-
-        // Comment or delete associated validators
-        //  $validator
-        //      ->add('lft', 'valid', ['rule' => 'numeric'])
-        //      ->requirePresence('lft', 'create')
-        //      ->notEmpty('lft');
-        //
-        //  $validator
-        //      ->add('rght', 'valid', ['rule' => 'numeric'])
-        //      ->requirePresence('rght', 'create')
-        //      ->notEmpty('rght');
+            
+        $validator
+            ->add('lft', 'valid', ['rule' => 'numeric'])
+        //    ->requirePresence('lft', 'create')
+            ->notEmpty('lft');
+            
+        $validator
+            ->add('rght', 'valid', ['rule' => 'numeric'])
+        //    ->requirePresence('rght', 'create')
+            ->notEmpty('rght');
     }
 
 These fields are automatically managed by the TreeBehavior when


### PR DESCRIPTION
I ran into a few issues while working my way through the TreeBehavior portion of the tutorial. There wasn't a mention of removing the validators from the Categories model in addition to the lft and rght input fields from the Categories view.ctp and edit.ctp files.

This of course prevented me from saving my model. I either had to make the form fields hidden (i.e., $this->Form->hidden('lft')) but since the documentation already mentions removing them I presume removing the validators from the model was the best practice.

Please let me know if you have any questions, comments, or observations.