### PR TITLE
Update testing.rst

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -501,6 +501,10 @@ table linked to the model called Article. You can use any model available in
 your application. The statement will only import the Article schema, and  does
 not import records. To import records you can do the following::
 
+.. versionchanged:: 2.7 
+    ``model`` has been replaced by ``table``
+    Now use: public $import => array('table' => 'articles');
+
     class ArticleFixture extends CakeTestFixture {
         public $import = array('model' => 'Article', 'records' => true);
     }


### PR DESCRIPTION
It seems that after 2.7 the 'import' now requires the 3.x method 'table' => 'articles' which changed from 2.x using a 'model'