### PR TITLE
Change PHPUnit install instructions

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -19,15 +19,11 @@ through using either a `PHAR package <http://phpunit.de/#download>`_ or `Compose
 Install PHPUnit with Composer
 -----------------------------
 
-To install PHPUnit with Composer, add the following to you application's
-``require`` section in its ``composer.json``::
+To install PHPUnit with Composer
 
-    "phpunit/phpunit": "*",
-
-After updating your composer.json, run Composer again inside your application
-directory::
-
-    $ php composer.phar install
+    $ php composer.phar require --dev phpunit/phpunit
+    
+This will add the dependency to the ``require-dev`` section of your ``composer.json``, and then install PHPUnit along with any dependencies.
 
 You can now run PHPUnit using::
 


### PR DESCRIPTION
Update the install instructions for PHPUnit to match the recommended method for adding dependencies to composer. Replace the suggestion of editing the composer.json file, with the command line require method