### PR TITLE
Add double colon to correctly format command

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -19,7 +19,7 @@ through using either a `PHAR package <http://phpunit.de/#download>`_ or `Compose
 Install PHPUnit with Composer
 -----------------------------
 
-To install PHPUnit with Composer
+To install PHPUnit with Composer::
 
     $ php composer.phar require --dev phpunit/phpunit
     


### PR DESCRIPTION
As per https://github.com/cakephp/docs/pull/3215#event-399241086 comment, this adds the double colon to the preceding line so that the composer install command is correctly formatted.