### PR TITLE
Upd email.rst - Clearer expl of recepient methods

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -28,8 +28,16 @@ After you've loaded ``Email``, you can send an email with the following::
         ->subject('About')
         ->send('My message');
 
-Since ``Email``'s setter methods return the instance of the class, you are able
-to set its properties with method chaining.
+Since ``Email``'s setter methods return the instance of the class, you are able to set its properties with method chaining.
+
+``Email`` has several methods for defining recepients - ``to()``,``cc()``,``bcc()``, ``addTo()``, ``addCc()`` and ``addBcc()``.  The main difference being that the first three will overwrite what was already set and the later will just add more recepients to their respective field.
+
+    $email = new Email();
+    $email->to('to@example.com', 'To Example');
+    $email->addTo('too@example.com', 'To2 Example');
+    //The email's To recepients are: to@example.com and to2@example.com
+    $email->to('test@example.com', 'ToTest Example');
+    //The email's To recepient is: test@example.com
 
 Choosing the Sender
 -------------------


### PR DESCRIPTION
After discussing a bit in cakephp/cakephp#7348 it turns out that the docs need a bit of tuning.
I added a clearer explanation of the fact that all the recepiend methods (to(), cc(), bcc()) overwrite what is already set.