### PR TITLE
Remove unexpected char in Number which stopped latex build

### DIFF
--- a/en/core-libraries/number.rst
+++ b/en/core-libraries/number.rst
@@ -343,7 +343,7 @@ to various methods.
 Example::
 
     Number::config('en_IN', \NumberFormatter::CURRENCY, [
-        'pattern' => '¤ #,##,##0'
+        'pattern' => '#,##,##0'
     ]);
 
 .. meta::

--- a/fr/core-libraries/number.rst
+++ b/fr/core-libraries/number.rst
@@ -351,7 +351,7 @@ utilisé de façon persistante à travers toutes les méthodes.
 Par exemple::
 
     Number::config('en_IN', \NumberFormatter::CURRENCY, [
-        'pattern' => '¤ #,##,##0'
+        'pattern' => '#,##,##0'
     ]);
 
 .. meta::


### PR DESCRIPTION
It caused a failure for the docs since https://github.com/cakephp/docs/commit/f77c91c6f7cc4693dfb79050f06d3acdb337e108
(jenkins ref http://ci.cakephp.org/job/CakePHP%203.0%20-%20Book/2073/)