### PR TITLE
Correction in rule name

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -153,7 +153,7 @@ the ``provider`` key in your rule::
 
     // Use a rule from the table provider
     $validator->add('title', 'unique', [
-        'rule' => 'uniqueTitle',
+        'rule' => 'validateUnique',
         'provider' => 'table'
     ]);
 


### PR DESCRIPTION
For uniqueness rule 'uniqueTitle' is used which is not in the table provider code, Correct rule is 'validateUnique' as per latest CakePHP code.