### PR TITLE
[all lang] #2068 remove indices & tables in PDF

### DIFF
--- a/config/all.py
+++ b/config/all.py
@@ -201,7 +201,7 @@ latex_show_urls = 'footnote'
 #latex_appendices = []
 
 # If false, no module index is generated.
-# latex_domain_indices = True
+latex_domain_indices = True
 
 
 preamb = ur'''

--- a/en/pdf-contents.rst
+++ b/en/pdf-contents.rst
@@ -54,10 +54,3 @@ Contents
     debug-kit
     migrations
     appendices
-
-
-Indices and Tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/es/pdf-contents.rst
+++ b/es/pdf-contents.rst
@@ -54,9 +54,3 @@ Contents
     debug-kit
     migrations
     appendices
-
-Indices and Tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/fr/pdf-contents.rst
+++ b/fr/pdf-contents.rst
@@ -54,9 +54,3 @@ Contenu
     debug-kit
     migrations
     appendices
-
-Index et tables
-===============
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/ja/pdf-contents.rst
+++ b/ja/pdf-contents.rst
@@ -54,9 +54,3 @@ Contents
     debug-kit
     migrations
     appendices
-
-Indices and Tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/pt/pdf-contents.rst
+++ b/pt/pdf-contents.rst
@@ -54,9 +54,3 @@ Conteúdo
     debug-kit
     migrations
     appendices
-
-Índices e Tabelas
-=================
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/tr/pdf-contents.rst
+++ b/tr/pdf-contents.rst
@@ -54,10 +54,3 @@ Contents
     debug-kit
     migrations
     appendices
-
-
-Indices and Tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/zh/pdf-contents.rst
+++ b/zh/pdf-contents.rst
@@ -54,9 +54,3 @@ Contents
     debug-kit
     migrations
     appendices
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`


### PR DESCRIPTION
This PR refers to #2068.

The option `latex_domain_indices` in config/all.py prints an index at the end of the docs.
The :ref:`genindex` & :ref:`modindex` are useless after this changes.

For the english version of the pdf:
- Before changes: pdf had 844 pages
- Now: pdf has 842 pages (the 2 pages missing are useless)

Here are some screenshots of the end of the pdfs:

![capture d ecran 2015-09-10 a 14 51 49](https://cloud.githubusercontent.com/assets/1652972/9788762/2d5b8ae6-57cc-11e5-852a-cb847f1122f5.png)

![capture d ecran 2015-09-10 a 14 52 10](https://cloud.githubusercontent.com/assets/1652972/9788770/39960b74-57cc-11e5-82ac-0a27221575b9.png)
