### PR TITLE
CakePHP schema columns types

### DIFF
--- a/en/models/model-attributes.rst
+++ b/en/models/model-attributes.rst
@@ -168,7 +168,41 @@ Contains metadata describing the model's database table fields.
 Each field is described by:
 
 -  name
--  type (integer, string, datetime, etc.)
+-  type
+
+The types CakePHP supports are:
+
+string
+    Generally backed by CHAR or VARCHAR columns. In SQL Server, NCHAR and
+    NVARCHAR types are used.
+text
+    Maps to TEXT, MONEY types.
+uuid
+    Maps to the UUID type if a database provides one, otherwise this will
+    generate a CHAR(36) field.
+integer
+    Maps to the INTEGER, SMALLINT types provided by the database.
+biginteger
+    Maps to the BIGINT type provided by the database.
+decimal
+    Maps to the DECIMAL, NUMERIC types.
+float
+    Maps to the REAL, DOUBLE PRECISION types.
+boolean
+    Maps to BOOLEAN except in MySQL, where TINYINT(1) is used to represent
+    booleans.
+binary
+    Maps to the BLOB or BYTEA type provided by the database.
+date
+    Maps to a timezone naive DATE column type.
+datetime
+    Maps to a timezone naive DATETIME column type. In PostgreSQL, and SQL
+    Server this turns into a TIMESTAMP or TIMESTAMPTZ type.
+timestamp
+    Maps to the TIMESTAMP type.
+time
+    Maps to a TIME type in all databases.
+
 -  null
 -  default value
 -  length


### PR DESCRIPTION
Ref to  #885

This is similar to [3.x schema types](http://book.cakephp.org/3.0/en/orm/database-basics.html#data-types)

I created a schema with almost all Postgres types to check the types:

    'smallint' => array('type' => 'integer', 'null' => false, 'default' => null),
    'integer' => array('type' => 'integer', 'null' => false, 'default' => null),
    'bigint' => array('type' => 'biginteger', 'null' => false, 'default' => null),
    'boolean' => array('type' => 'boolean', 'null' => false, 'default' => null),
    'numeric' => array('type' => 'decimal', 'null' => false, 'default' => null),
    'real' => array('type' => 'float', 'null' => false, 'default' => null),
    'double precision' => array('type' => 'float', 'null' => false, 'default' => null),
    'money' => array('type' => 'text', 'null' => false, 'default' => null),
    'date' => array('type' => 'date', 'null' => false, 'default' => null),
    'time' => array('type' => 'time', 'null' => false, 'default' => null),
    'timestamp' => array('type' => 'datetime', 'null' => false, 'default' => null),
    'timestamptz' => array('type' => 'datetime', 'null' => false, 'default' => null),
    'interval' => array('type' => 'text', 'null' => false, 'default' => null),
    'character' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 1),
    'character varying' => array('type' => 'text', 'null' => false, 'default' => null),
    'text' => array('type' => 'text', 'null' => false, 'default' => null, 'length' => 1073741824),
    'tsvector' => array('type' => 'text', 'null' => false, 'default' => null),
    'bit' => array('type' => 'text', 'null' => false, 'default' => null, 'length' => 1),
    'tsquery' => array('type' => 'text', 'null' => false, 'default' => null),
    'xml' => array('type' => 'text', 'null' => false, 'default' => null),
    'bit varying' => array('type' => 'text', 'null' => false, 'default' => null),
    'bytea' => array('type' => 'binary', 'null' => false, 'default' => null),
    'uuid' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 36),

I did not write all types mapping in the PR, but I think it's enough?
We could check with other databases too.