### PR TITLE
[ja] adjust toctree's start-line 10 for original.

### DIFF
--- a/ja/core-libraries/toc-behaviors.rst
+++ b/ja/core-libraries/toc-behaviors.rst
@@ -1,10 +1,12 @@
 ビヘイビア
 ##########
 
-ビヘイビアはモデルに拡張機能を追加します。CakePHP は :php:class:`TreeBehavior` や
-:php:class:`ContainableBehavior` など、いくつかの組込みビヘイビアを備えています。
+ビヘイビアはモデルに拡張機能を追加します。CakePHP は
+:php:class:`TreeBehavior` や :php:class:`ContainableBehavior` など、
+いくつかの組込みビヘイビアを備えています。
 
-ビヘイビアの作成方法と使い方については学ぶには :doc:`/models/behaviors` を読んでください。
+ビヘイビアの作成方法と使い方については学ぶには
+:doc:`/models/behaviors` を読んでください。
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Because toctree is included by /models/behaviors.rst
and it set start-line 10.
