### PR TITLE
Add `addversion` to docs for recoverOrder

### DIFF
--- a/en/orm/behaviors/tree.rst
+++ b/en/orm/behaviors/tree.rst
@@ -217,6 +217,8 @@ as the scope::
 Recovering with custom sort field
 =================================
 
+.. versionadded:: 3.0.14
+
 By default, recover() sorts the items using the primary key. This works great
 if this is a numeric (auto increment) column, but can lead to weird results if you
 use UUIDs.


### PR DESCRIPTION
I thought it would be a good idea to add a note that the recoverOrder feature is available in version 3.0.14 (see cakephp/cakephp#7411 and cakephp/docs#3292).