### PR TITLE
Update session.rst - SQL statement correction.

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -160,7 +160,7 @@ at least these fields::
 
     CREATE TABLE `sessions` (
       `id` varchar(255) NOT NULL DEFAULT '',
-      `data` VARBINARY, -- or BYTEA for PostgreSQL
+      `data` BLOB, -- or BYTEA for PostgreSQL
       `expires` int(11) DEFAULT NULL,
       PRIMARY KEY (`id`)
     );


### PR DESCRIPTION
The wrong Sql statement:
CREATE TABLE `sessions` (
      `id` varchar(255) NOT NULL DEFAULT '',
      `data` VARBINARY, -- or BYTEA for PostgreSQL
      `expires` int(11) DEFAULT NULL,
      PRIMARY KEY (`id`)
    );

The data type for 'data' field is wrong, and it's not working. Bellow is the right Sql statement
 CREATE TABLE `sessions` (
      `id` varchar(255) NOT NULL DEFAULT '',
      `data` BLOB, -- or BYTEA for PostgreSQL
      `expires` int(11) DEFAULT NULL,
      PRIMARY KEY (`id`)
    );