### PR TITLE
Update migrations.rst

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -231,6 +231,13 @@ adding new tables to the database, you can use the second argument of the
 
 The above will create a ``CHAR(36)`` ``id`` column that is also the primary key.
 
+.. note::
+
+        When specifying a custom primary key on the command line, you must note it as the primary key in the id field, otherwise you may get an error regarding duplicate id fields, i.e.::
+
+            bin/cake bake migration CreateProducts id:uuid:primary name:string description:text created modified
+
+
 Additionally, since Migrations 1.3, a new way to deal with primary key was
 introduced. To do so, your migration class should extend the new
 ``Migrations\AbstractMigration`` class.


### PR DESCRIPTION
This is not only my first CakePHP code change, but my first on GitHub as a whole as well, so please be gentle, ha.  

It is not clear via this documentation that, when using the command-line, if ":primary" is not appended to "id:uuid", an error will result.  Without specifying ":primary", the only way to get it to work is to manually modify the resulting migrations file, then proceed.  But this suggested note would have saved me (as a CakePHP newbie) some time searching, and judging by some Google searches, possibly some others as well.  I'm open to the wording, this is just a suggestion.

This was made a bit more clear after digging in the README.md of the cakephp/migrations repo.