### PR TITLE
3.1 add a note to specify from when ``$default`` is availlable in ``env()``

### DIFF
--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -106,6 +106,9 @@ such as debugging and translating content.
 
 .. php:function:: env(string $key, string $default = null)
 
+    .. versionadded:: 3.1.1
+        The ``$default`` parameter has been added.
+
     Gets an environment variable from available sources. Used as a
     backup if ``$_SERVER`` or ``$_ENV`` are disabled.
 
@@ -125,23 +128,23 @@ such as debugging and translating content.
     does not have a dot, then index 0 will be ``null``.
 
     Commonly used like ``list($plugin, $name) = pluginSplit('Users.User');``
- 
-.. php:function:: namespaceSplit(string $class)   
+
+.. php:function:: namespaceSplit(string $class)
 
     Split the namespace from the classname.
-    
+
     Commonly used like ``list($namespace, $className) = namespaceSplit('Cake\Core\App');``
-    
+
 .. php:function:: pr(mixed $var)
 
     Convenience wrapper for ``print_r()``, with the addition of
     wrapping ``<pre>`` tags around the output.
-    
+
 .. php:function:: pj(mixed $var)
 
     JSON pretty print convenience function, with the addition of
     wrapping ``<pre>`` tags around the output.
-    
+
     It is meant for debugging the JSON representation of objects and arrays.
 
 Core Definition Constants

--- a/fr/core-libraries/global-constants-and-functions.rst
+++ b/fr/core-libraries/global-constants-and-functions.rst
@@ -109,6 +109,9 @@ CakePHP, comme le débogage et la traduction de contenu.
 
 .. php:function:: env(string $key, string $default = null)
 
+    .. versionadded:: 3.1.1
+        Le paramètre ``$default`` a été ajouté.
+
     Récupère une variable d'environnement depuis les sources disponibles.
     Utilisé en secours si ``$_SERVER`` ou ``$_ENV`` sont désactivés.
 


### PR DESCRIPTION
to avoid question about non-working functionality