### PR TITLE
repaire Entity class address

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -81,7 +81,7 @@ conventions you can use the ``entityClass()`` method to change things up::
     {
         public function initialize(array $config)
         {
-            $this->entityClass('App\Model\PO');
+            $this->entityClass('App\Model\Entity\PO');
         }
     }
 


### PR DESCRIPTION
with current example must use "namespace App\Model;" instead of "namespace App\Model\Entity;" in Entity class ,It is not recommended
With this change,You do not have to do it.