### PR TITLE
Optimized text added in #3352

### DIFF
--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -101,9 +101,13 @@ manually running the following SQL script in your database:
 
 The schema is also available as sql file in **app/config/schema/i18n.sql**.
 
-A note on language abbreviations: The Translate Behavior doesn't impose any restrictions on the language identifier, the possible values are only restricted by the ``locale`` column type/size. ``locale`` is currently defined as ``varchar(6)`` in case you want to use abbreviations like ``es-419`` (Spanish for Latin America, language abbreviation with area code `UN M.49 <https://en.wikipedia.org/wiki/UN_M.49>`_).
+A note on language abbreviations: The Translate Behavior doesn't impose any restrictions on the language identifier, the possible values are only restricted by the ``locale`` column type/size. ``locale`` is defined as ``varchar(6)`` in case you want to use abbreviations like ``es-419`` (Spanish for Latin America, language abbreviation with area code `UN M.49 <https://en.wikipedia.org/wiki/UN_M.49>`_).
 
-.. tip:: It's recommended to use the same language abbreviations as required for :doc:`Internationalization and Localization </core-libraries/internationalization-and-localization>`: Either the two letter ISO code of the language like ``en``, ``fr``, ``de`` or the full locale name such as ``fr_FR``, ``es_AR``, ``da_DK`` which contains both the language and the country where it is spoken. Thus you are consistent and switching the language works identical for both, the ``Translate Behaviour`` and ``Internationalization and Localization``.
+.. tip::
+
+    It's wise to use the same language abbreviations as required for :doc:`Internationalization and Localization </core-libraries/internationalization-and-localization>`. Thus you are consistent and switching the language works identical for both, the ``Translate Behaviour`` and ``Internationalization and Localization``.
+    
+So it's recommended to use either the two letter ISO code of the language like ``en``, ``fr``, ``de`` or the full locale name such as ``fr_FR``, ``es_AR``, ``da_DK`` which contains both the language and the country where it is spoken.
 
 Attaching the Translate Behavior to Your Tables
 ===============================================

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -99,7 +99,7 @@ manually running the following SQL script in your database:
         INDEX I18N_FIELD(model, foreign_key, field)
     );
 
-The schema is also available as sql file in **app/config/schema/i18n.sql**.
+The schema is also available as sql file in **/config/schema/i18n.sql**.
 
 A note on language abbreviations: The Translate Behavior doesn't impose any restrictions on the language identifier, the possible values are only restricted by the ``locale`` column type/size. ``locale`` is defined as ``varchar(6)`` in case you want to use abbreviations like ``es-419`` (Spanish for Latin America, language abbreviation with area code `UN M.49 <https://en.wikipedia.org/wiki/UN_M.49>`_).
 

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -99,6 +99,11 @@ manually running the following SQL script in your database:
         INDEX I18N_FIELD(model, foreign_key, field)
     );
 
+The schema is also available as sql file in **app/config/schema/i18n.sql**.
+
+A note on language abbreviations: The Translate Behavior doesn't impose any restrictions on the language identifier, the possible values are only restricted by the ``locale`` column type/size. ``locale`` is currently defined as ``varchar(6)`` in case you want to use abbreviations like ``es-419`` (Spanish for Latin America, language abbreviation with area code `UN M.49 <https://en.wikipedia.org/wiki/UN_M.49>`_).
+
+.. tip:: It's recommended to use the same language abbreviations as required for :doc:`Internationalization and Localization </core-libraries/internationalization-and-localization>`: Either the two letter ISO code of the language like ``en``, ``fr``, ``de`` or the full locale name such as ``fr_FR``, ``es_AR``, ``da_DK`` which contains both the language and the country where it is spoken. Thus you are consistent and switching the language works identical for both, the ``Translate Behaviour`` and ``Internationalization and Localization``.
 
 Attaching the Translate Behavior to Your Tables
 ===============================================
@@ -162,8 +167,6 @@ use TranslateBehavior with ``find('list')``::
 
     // Data will contain
     [1 => 'Mi primer artículo', 2 => 'El segundo artículo', 15 => 'Otro articulo' ...]
-
-It's recommended to use the same language abbreviations as required for :doc:`Internationalization and Localization </core-libraries/internationalization-and-localization>`: Either the two letter ISO code of the language like ``en``, ``fr``, ``de`` or the full locale name such as ``fr_FR``, ``es_AR``, ``da_DK`` which contains both the language and the country where it is spoken. Thus you are consistent and switching the language works identical for both, the ``Translate Behaviour`` and ``Internationalization and Localization``.
 
 Retrieve All Translations For An Entity
 ---------------------------------------


### PR DESCRIPTION
I'd like to suggest more optimations in the chapter "Translate Behaviour" (CakePHP 3.x):
- Added info about the location of sql schema file at "Initializing the i18n Database Table"
- Added background info about the column length of the field "locale"
- Moved the note about language abbreviations to the paragraph "Initializing the i18n Database Table"
- Formatted the recommended language abbreviation as tip