### PR TITLE
Fix updateAll example

### DIFF
--- a/en/models/saving-your-data.rst
+++ b/en/models/saving-your-data.rst
@@ -235,8 +235,8 @@ model methods was calling ``updateAll()`` you would do the following::
     $db = $this->getDataSource();
     $value = $db->value($value, 'string');
     $this->updateAll(
-        array('Baker.approved' => true),
-        array('Baker.created <=' => $value)
+        array('Baker.status' => $value),
+        array('Baker.status' => 'old')
     );
 
 .. note::

--- a/fr/models/saving-your-data.rst
+++ b/fr/models/saving-your-data.rst
@@ -249,8 +249,8 @@ vous feriez ce qui suit::
     $db = $this->getDataSource();
     $value = $db->value($value, 'string');
     $this->updateAll(
-        array('Baker.approved' => true),
-        array('Baker.created <=' => $value)
+        array('Baker.status' => $value),
+        array('Baker.status' => 'old')
     );
 
 .. note::

--- a/zh/models/saving-your-data.rst
+++ b/zh/models/saving-your-data.rst
@@ -200,15 +200,15 @@ saveField 方法也有另一种语法::
     );
 
 
-``$fields`` 数组可接受 SQL 表达式。常量(*literal*)值应当使用 
-:php:meth:`DboSource::value()` 手动引用。例如，如果一个模型方法调用 
+``$fields`` 数组可接受 SQL 表达式。常量(*literal*)值应当使用
+:php:meth:`DboSource::value()` 手动引用。例如，如果一个模型方法调用
 ``updateAll()``，应该这样::
 
     $db = $this->getDataSource();
     $value = $db->value($value, 'string');
     $this->updateAll(
-        array('Baker.approved' => true),
-        array('Baker.created <=' => $value)
+        array('Baker.status' => $value),
+        array('Baker.status' => 'old')
     );
 
 .. note::


### PR DESCRIPTION
This is simply wrong, the conditions don't need escaping, the fields do. Doing what the current example shows will generate:

    UPDATE
        bakers as Bakers
    SET
        Bakers.approved = 1
    WHERE
        Bakers.created <= '\'2015-10-14 14:23:55\'' 