### PR TITLE
Escaped back slash in Windows reminder

### DIFF
--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -171,7 +171,7 @@ The bake tool has created all your files in a snap. You can give them a quick
 read if you want re-familiarize yourself with how CakePHP works.
 
 .. note::
-    If you are on Windows remember to use \ instead of /.
+    If you are on Windows remember to use \\ instead of /.
 
 You'll need to edit the following in **src/Template/Categories/add.ctp**
 and **src/Template/Categories/edit.ctp**::


### PR DESCRIPTION
The back slash in the "note" under "Generate skeleton code for categories" was not visible due to it not being escaped.
The sentenced read
"If you are on Windows remember to use instead of /."

Now fixed.