### PR TITLE
add example for bake field length

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -37,6 +37,10 @@ indexes and even insert data into the database.
 
 Here's an example of a migration::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             /**
@@ -55,6 +59,7 @@ Here's an example of a migration::
                       ->addColumn('created', 'datetime')
                       ->create();
             }
+        }
 
 
 This migration adds a table called products with a string column called ``name``, a text
@@ -91,6 +96,10 @@ Let's imagine that you'd like to add a new ``products`` table::
 
 The above line will create a migration file looking like this::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             public function change()
@@ -102,6 +111,7 @@ The above line will create a migration file looking like this::
                       ->addColumn('modified', 'datetime')
                       ->create();
             }
+        }
 
 If the migration name in the command line is of the form "AddXXXToYYY" or "RemoveXXXFromYYY"
 and is followed by a list of column names and types then a migration file
@@ -111,6 +121,10 @@ containing the code for creating or dropping the columns will be generated::
 
 Executing the command line above will generate::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class AddPriceToProducts extends AbstractMigration
         {
             public function change()
@@ -119,12 +133,17 @@ Executing the command line above will generate::
                 $table->addColumn('price', 'decimal')
                       ->update();
             }
+        }
 
 It is also possible to add indexes to columns::
 
         bin/cake bake migration AddNameIndexToProducts name:string:index
 
 will generate::
+
+        <?php
+
+        use Migrations\AbstractMigration;
 
         class AddNameIndexToProducts extends AbstractMigration
         {
@@ -135,7 +154,7 @@ will generate::
                       ->addIndex(['name'])
                       ->update();
             }
-
+        }
 
 When using fields in the command line it may be handy to remember that they
 follow the following pattern::
@@ -157,6 +176,10 @@ command line::
 
 creates the file::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class RemovePriceFromProducts extends AbstractMigration
         {
             public function change()
@@ -164,6 +187,7 @@ creates the file::
                 $table = $this->table('products');
                 $table->removeColumn('price');
             }
+        }
 
 Migration Names can follow any of the following patterns:
 
@@ -217,6 +241,10 @@ If you need to avoid the automatic creation of the ``id`` primary key when
 adding new tables to the database, you can use the second argument of the
 ``table()`` method::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             public function change()
@@ -228,6 +256,7 @@ adding new tables to the database, you can use the second argument of the
                       ->addColumn('description', 'text')
                       ->create();
             }
+        }
 
 The above will create a ``CHAR(36)`` ``id`` column that is also the primary key.
 
@@ -245,6 +274,8 @@ You can specify a ``autoId`` property in the Migration class and set it to
 ``false``, which will turn off the automatic ``id`` column creation. You will
 need to manually create the column that will be used as a primary key and add
 it to the table declaration::
+
+        <?php
 
         use Migrations\AbstractMigration;
 
@@ -266,6 +297,7 @@ it to the table declaration::
                     ->addColumn('description', 'text')
                     ->create();
             }
+        }
 
 Compared to the previous way of dealing with primary key, this method gives you
 the ability to have more control over the primary key column definition :
@@ -284,6 +316,10 @@ Collations
 If you need to create a table with a different collation than the database
 default one, you can define it with the ``table()`` method, as an option::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateCategoriesTable extends AbstractMigration
         {
             public function change()
@@ -299,6 +335,7 @@ default one, you can define it with the ``table()`` method, as an option::
                     ])
                     ->create();
             }
+        }
 
 Note however this can only be done on table creation : there is currently
 no way of adding a column to an existing table with a different collation than

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -135,6 +135,33 @@ Executing the command line above will generate::
             }
         }
 
+.. versionadded:: cakephp/migrations 1.4
+
+If you need to specify a field length, you can do it within brackets in the
+field type, ie::
+
+        bin/cake bake migration AddFullDescriptionToProducts full_description:string[60]
+
+Executing the command line above will generate::
+
+        <?php
+
+        use Migrations\AbstractMigration;
+
+        class AddFullDescriptionToProducts extends AbstractMigration
+        {
+            public function change()
+            {
+                $table = $this->table('products');
+                $table->addColumn('full_description', 'string', [
+                        'default' => null,
+                        'limit' => 60,
+                        'null' => false,
+                     ])
+                      ->update();
+            }
+        }
+
 It is also possible to add indexes to columns::
 
         bin/cake bake migration AddNameIndexToProducts name:string:index

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -34,7 +34,7 @@ A migration file will be generated in the **/config/Migrations** folder with the
 
     <?php
 
-    use Phinx\Migration\AbstractMigration;
+    use Migrations\AbstractMigration;
 
     class CreateArticlesTable extends AbstractMigration
     {
@@ -67,15 +67,16 @@ A migration file will be generated in the **/config/Migrations** folder with the
         }
     }
 
-Run another command to create a ``categories`` table::
+Run another command to create a ``categories`` table. If you need to specify
+a field length, you can do it within brackets in the field type, ie::
 
-    bin/cake bake migration CreateCategories parent_id:integer lft:integer rght:integer name:string description:string created modified
+    bin/cake bake migration CreateCategories parent_id:integer lft:integer[10] rght:integer[10] name:string[100] description:string created modified
 
 This will generate the following file in **config/Migrations**::
 
     <?php
 
-    use Phinx\Migration\AbstractMigration;
+    use Migrations\AbstractMigration;
 
     class CreateCategoriesTable extends AbstractMigration
     {
@@ -89,17 +90,17 @@ This will generate the following file in **config/Migrations**::
             ]);
             $table->addColumn('lft', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ]);
             $table->addColumn('rght', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ]);
             $table->addColumn('name', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => false,
             ]);
             $table->addColumn('description', 'string', [

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -42,6 +42,10 @@ de données.
 
 Ci-dessous un exemple de migration::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             /**
@@ -60,6 +64,7 @@ Ci-dessous un exemple de migration::
                       ->addColumn('created', 'datetime')
                       ->create();
             }
+        }
 
 
 Cette migration ajoute une table appelée ``products`` avec une colonne de type
@@ -101,6 +106,10 @@ commande. Imaginons que vous souhaitez ajouter une nouvelle table ``products``::
 
 La ligne ci-dessus va créer un fichier de migration qui ressemble à ceci::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             public function change()
@@ -112,6 +121,7 @@ La ligne ci-dessus va créer un fichier de migration qui ressemble à ceci::
                       ->addColumn('modified', 'datetime')
                       ->create();
             }
+        }
 
 Si le nom de la migration dans la ligne de commande est de la forme
 "AddXXXToYYY" ou "RemoveXXXFromYYY" et est suivie d'une liste de noms de
@@ -122,6 +132,10 @@ création ou le retrait des colonnes sera généré::
 
 L'exécution de la ligne de commande ci-dessus va générer::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class AddPriceToProducts extends AbstractMigration
         {
             public function change()
@@ -130,12 +144,17 @@ L'exécution de la ligne de commande ci-dessus va générer::
                 $table->addColumn('price', 'decimal')
                       ->update();
             }
+        }
 
 Il est également possible d'ajouter des indexes de colonnes::
 
         bin/cake bake migration AddNameIndexToProducts name:string:index
 
 va générer::
+
+        <?php
+
+        use Migrations\AbstractMigration;
 
         class AddNameIndexToProducts extends AbstractMigration
         {
@@ -146,6 +165,7 @@ va générer::
                       ->addIndex(['name'])
                       ->update();
             }
+        }
 
 
 Lors de l'utilisation des champs dans la ligne de commande, il est utile de se
@@ -169,6 +189,10 @@ colonne en utilisant la ligne de commande::
 
 crée le fichier::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class RemovePriceFromProducts extends AbstractMigration
         {
             public function change()
@@ -176,8 +200,9 @@ crée le fichier::
                 $table = $this->table('products');
                 $table->removeColumn('price');
             }
+        }
 
-Les noms des migration peuvent suivre l'un des motifs suivants:
+Les noms des migrations peuvent suivre l'un des motifs suivants:
 
 * Créer une table: (``/^(Create)(.*)/``) Crée la table spécifiée.
 * Supprimer une table: (``/^(Drop)(.*)/``) Supprime la table spécifiée. Ignore les arguments de champ spécifié.
@@ -232,6 +257,10 @@ Pour personnaliser la création automatique de la clé primaire ``id`` lors
 de l'ajout de nouvelles tables, vous pouvez utiliser le deuxième argument de la
 méthode ``table()``::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             public function change()
@@ -243,6 +272,7 @@ méthode ``table()``::
                       ->addColumn('description', 'text')
                       ->create();
             }
+        }
 
 Le code ci-dessus va créer une colonne ``CHAR(36)`` ``id`` également utilisée
 comme clé primaire.
@@ -262,6 +292,8 @@ Vous pouvez définir la propriété ``autoId`` à ``false`` dans la classe de
 Migration, ce qui désactivera la création automatique de la colonne ``id``.
 Vous aurez cependant besoin de manuellement créer la colonne qui servira de clé
 primaire et devrez l'ajouter à la déclaration de la table::
+
+        <?php
 
         use Migrations\AbstractMigration;
 
@@ -283,6 +315,7 @@ primaire et devrez l'ajouter à la déclaration de la table::
                     ->addColumn('description', 'text')
                     ->create();
             }
+        }
 
 Comparée à la méthode précédente de gestion des clés primaires, cette méthode
 vous donne un plus grand contrôle sur la définition de la colonne de la clé
@@ -304,6 +337,10 @@ Si vous avez besoin de créer une table avec une ``collation`` différente
 de celle par défaut de la base de données, vous pouvez la définir comme option
 de la méthode ``table()``::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateCategoriesTable extends AbstractMigration
         {
             public function change()
@@ -319,6 +356,7 @@ de la méthode ``table()``::
                     ])
                     ->create();
             }
+        }
 
 Notez cependant que ceci ne peut être fait qu'en cas de création de table :
 il n'y a actuellement aucun moyen d'ajouter une colonne avec une ``collation``

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -146,6 +146,33 @@ L'exécution de la ligne de commande ci-dessus va générer::
             }
         }
 
+.. versionadded:: cakephp/migrations 1.4
+
+Si vous voulez spécifier une longueur de champ, vous pouvez le faire entre
+crochets dans le type du champ, par exemple::
+
+        bin/cake bake migration AddFullDescriptionToProducts full_description:string[60]
+
+L'exécution de la ligne de commande ci-dessus va générer::
+
+        <?php
+
+        use Migrations\AbstractMigration;
+
+        class AddFullDescriptionToProducts extends AbstractMigration
+        {
+            public function change()
+            {
+                $table = $this->table('products');
+                $table->addColumn('full_description', 'string', [
+                        'default' => null,
+                        'limit' => 60,
+                        'null' => false,
+                     ])
+                      ->update();
+            }
+        }
+
 Il est également possible d'ajouter des indexes de colonnes::
 
         bin/cake bake migration AddNameIndexToProducts name:string:index

--- a/fr/tutorials-and-examples/blog/part-three.rst
+++ b/fr/tutorials-and-examples/blog/part-three.rst
@@ -39,7 +39,7 @@ ce qui suit::
 
     <?php
 
-    use Phinx\Migration\AbstractMigration;
+    use Migrations\AbstractMigration;
 
     class CreateArticlesTable extends AbstractMigration
     {
@@ -72,15 +72,17 @@ ce qui suit::
         }
     }
 
-Exécutez une autre commande pour créer une table ``categories``::
+Exécutez une autre commande pour créer une table ``categories``. Si vous voulez
+spécifier une longueur de champ, vous pouvez le faire entre crochets dans le
+type du champ, par exemple::
 
-    bin/cake bake migration CreateCategories parent_id:integer lft:integer rght:integer name:string description:string created modified
+    bin/cake bake migration CreateCategories parent_id:integer lft:integer[10] rght:integer[10] name:string[100] description:string created modified
 
 Ceci va générer le fichier suivant dans **config/Migrations**::
 
     <?php
 
-    use Phinx\Migration\AbstractMigration;
+    use Migrations\AbstractMigration;
 
     class CreateCategoriesTable extends AbstractMigration
     {
@@ -94,17 +96,17 @@ Ceci va générer le fichier suivant dans **config/Migrations**::
             ]);
             $table->addColumn('lft', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ]);
             $table->addColumn('rght', 'integer', [
                 'default' => null,
-                'limit' => 11,
+                'limit' => 10,
                 'null' => false,
             ]);
             $table->addColumn('name', 'string', [
                 'default' => null,
-                'limit' => 255,
+                'limit' => 100,
                 'null' => false,
             ]);
             $table->addColumn('description', 'string', [

--- a/ja/migrations.rst
+++ b/ja/migrations.rst
@@ -9,7 +9,7 @@ Migrations
 スキーマ変更のSQLを書く代わりに、このプラグインでは、直観的にデータベースの変更を
 実現するための手段を使用することができます。
 
-このプラグインは、データベースマイグレーションライブラリの 
+このプラグインは、データベースマイグレーションライブラリの
 `Phinx <https://phinx.org/>`_ のラッパーです。
 
 インストール
@@ -38,6 +38,10 @@ migration は、基本的にはデータベースに「バージョン」を記�
 
 ここにマイグレーションの例があります。::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             /**
@@ -55,8 +59,9 @@ migration は、基本的にはデータベースに「バージョン」を記�
                       ->addColumn('created', 'datetime')
                       ->create();
             }
+        }
 
-このマイグレーションは products というテーブルに、 ``name`` という string 項目と 
+このマイグレーションは products というテーブルに、 ``name`` という string 項目と
 ``description`` という text 項目と ``created`` という datetime 形式の項目を
 作成します。プライマリキーの ``id`` という項目は、暗黙のうちに作成されます。
 
@@ -72,9 +77,9 @@ migration は、基本的にはデータベースに「バージョン」を記�
 マイグレーションファイルの作成
 ==============================
 
-マイグレーションファイルは、あなたのアプリケーションの **config/Migration** 
+マイグレーションファイルは、あなたのアプリケーションの **config/Migration**
 ディレクトリに配置します。
-マイグレーションファイルの名前には、先頭に **YYYYMMDDHHMMSS_my_new_migration.php** 
+マイグレーションファイルの名前には、先頭に **YYYYMMDDHHMMSS_my_new_migration.php**
 というように作成した日付を付けます。
 
 移行ファイルを作成する最も簡単な方法は、コマンドラインを使用することです。
@@ -90,6 +95,10 @@ migration は、基本的にはデータベースに「バージョン」を記�
 
 上の行は、下記のようなマイグレーションファイルを作成します::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             public function change()
@@ -101,6 +110,7 @@ migration は、基本的にはデータベースに「バージョン」を記�
                       ->addColumn('modified', 'datetime')
                       ->create();
             }
+        }
 
 もしコマンドラインのマイグレーション名が "AddXXXToYYY" や "RemoveXXXFromYYY" といった
 書式で、その後にカラム名と型が続けば、項目の追加・削除を行うコードを含んだ
@@ -110,6 +120,10 @@ migration は、基本的にはデータベースに「バージョン」を記�
 
 コマンドラインを実行すると下記のようなファイルが生成されます。::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class AddPriceToProducts extends AbstractMigration
         {
             public function change()
@@ -118,12 +132,17 @@ migration は、基本的にはデータベースに「バージョン」を記�
                 $table->addColumn('price', 'decimal')
                       ->update();
             }
+        }
 
 インデックスに項目を追加することも可能です。::
 
         bin/cake bake migration AddNameIndexToProducts name:string:index
 
 このようなファイルが生成されます。::
+
+        <?php
+
+        use Migrations\AbstractMigration;
 
         class AddNameIndexToProducts extends AbstractMigration
         {
@@ -134,7 +153,7 @@ migration は、基本的にはデータベースに「バージョン」を記�
                       ->addIndex(['name'])
                       ->update();
             }
-
+        }
 
 コマンドラインのフィールドを使用する場合には、下記のようなパターンに従っている事を
 覚えておくと便利かもしれません::
@@ -156,6 +175,10 @@ migration は、基本的にはデータベースに「バージョン」を記�
 
 このようなファイルが生成されます。::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class RemovePriceFromProducts extends AbstractMigration
         {
             public function change()
@@ -163,6 +186,7 @@ migration は、基本的にはデータベースに「バージョン」を記�
                 $table = $this->table('products');
                 $table->removeColumn('price');
             }
+        }
 
 マイグレーション名は下記のパターンに従うことができます。:
 
@@ -193,8 +217,8 @@ migration は、基本的にはデータベースに「バージョン」を記�
 
         bin/cake migrations create MyCustomMigration
 
-マイグレーションファイルに記述可能なメソッドの一覧については、オフィシャルの 
-`Phinx ドキュメント <http://docs.phinx.org/en/latest/migrations.html>`_ 
+マイグレーションファイルに記述可能なメソッドの一覧については、オフィシャルの
+`Phinx ドキュメント <http://docs.phinx.org/en/latest/migrations.html>`_
 をご覧ください。
 
 既存のデータベースからマイグレーションファイルを作成する
@@ -215,6 +239,10 @@ migration は、基本的にはデータベースに「バージョン」を記�
 あなたがデータベースに新しいテーブルを作成する時、 ``id`` を主キーとして
 自動生成したくない場合、 ``table()`` メソッドの第２引数を使うことができます。::
 
+        <?php
+
+        use Migrations\AbstractMigration;
+
         class CreateProductsTable extends AbstractMigration
         {
             public function change()
@@ -226,15 +254,18 @@ migration は、基本的にはデータベースに「バージョン」を記�
                       ->addColumn('description', 'text')
                       ->create();
             }
+        }
 
 上記の例では、 ``CHAR(36)`` ``id`` というカラムを主キーとして作成します。
 
 さらに、Migrations 1.3 以降では 主キーに対処するための新しい方法が導入されました。
-これを行うには、あなたのマイグレーションクラスは新しい ``Migrations\AbstractMigration`` 
+これを行うには、あなたのマイグレーションクラスは新しい ``Migrations\AbstractMigration``
 クラスを継承する必要があります。
 あなたは Migration クラスの ``autoId`` プロパティに ``false`` を設定することで、
 自動的な ``id`` 項目の生成をオフにすることができます。
 あなたは手動で主キー項目を作成し、テーブル宣言に追加する必要があります。::
+
+        <?php
 
         use Migrations\AbstractMigration;
 
@@ -256,6 +287,7 @@ migration は、基本的にはデータベースに「バージョン」を記�
                     ->addColumn('description', 'text')
                     ->create();
             }
+        }
 
 主キーを扱うこれまでの方法と比較すると、この方法は、unsigned や not や limit や comment など
 さらに多くの主キーの定義を操作することができるようになっています。
@@ -271,8 +303,12 @@ Bake で生成されたマイグレーションファイルとスナップショ
 照合順序
 ----------
 
-もしデータベースのデフォルトとは別の照合順序を持つテーブルを作成する必要がある場合は、 
+もしデータベースのデフォルトとは別の照合順序を持つテーブルを作成する必要がある場合は、
 ``table()`` メソッドのオプションとして定義することができます。::
+
+        <?php
+
+        use Migrations\AbstractMigration;
 
         class CreateCategoriesTable extends AbstractMigration
         {
@@ -289,6 +325,7 @@ Bake で生成されたマイグレーションファイルとスナップショ
                     ])
                     ->create();
             }
+        }
 
 ですが、これはテーブル作成時にしかできず、既存のテーブルに対して項目を追加する時に
 テーブルやデータベースと異なる照合順序を指定する方法がないことに注意してください。
@@ -297,7 +334,7 @@ Bake で生成されたマイグレーションファイルとスナップショ
 マイグレーションを適用する
 ==========================
 
-マイグレーションファイルを生成したり記述したら、下記のコマンドを実行して 
+マイグレーションファイルを生成したり記述したら、下記のコマンドを実行して
 変更をデータベースに適用しましょう。::
 
         bin/cake migrations migrate
@@ -350,7 +387,7 @@ Statusコマンドは、現在の状況とすべてのマイグレーション�
 
 プラグインはマイグレーションファイルも提供することができます。
 これはプラグインの移植性とインストールの容易さを高め、配布しやすくなるように意図されています。
-Migrations プラグインの全てのコマンドは、プラグイン関連のマイグレーションを行うための 
+Migrations プラグインの全てのコマンドは、プラグイン関連のマイグレーションを行うための
 ``--plugin`` か ``-p`` オプションをサポートしています。::
 
         bin/cake migrations status -p PluginName
@@ -363,9 +400,9 @@ Migrations プラグインの全てのコマンドは、プラグイン関連の
 
 .. versionadded:: cakephp/migrations 1.2.0
 
-migrations プラグインのバージョン 1.2 から、非シェル環境でも app から直接 
+migrations プラグインのバージョン 1.2 から、非シェル環境でも app から直接
 ``Migrations`` クラスを使ってマイグレーションを実行できるようになりました。
-これは CMS のプラグインインストーラを作る時などに便利です。 
+これは CMS のプラグインインストーラを作る時などに便利です。
 ``Migrations`` クラスを使用すると、マイグレーションシェルから下記のコマンドを
 実行することができます。:
 

--- a/ja/migrations.rst
+++ b/ja/migrations.rst
@@ -134,6 +134,33 @@ migration は、基本的にはデータベースに「バージョン」を記�
             }
         }
 
+.. versionadded:: cakephp/migrations 1.4
+
+If you need to specify a field length, you can do it within brackets in the
+field type, ie::
+
+        bin/cake bake migration AddFullDescriptionToProducts full_description:string[60]
+
+Executing the command line above will generate::
+
+        <?php
+
+        use Migrations\AbstractMigration;
+
+        class AddFullDescriptionToProducts extends AbstractMigration
+        {
+            public function change()
+            {
+                $table = $this->table('products');
+                $table->addColumn('full_description', 'string', [
+                        'default' => null,
+                        'limit' => 60,
+                        'null' => false,
+                     ])
+                      ->update();
+            }
+        }
+        
 インデックスに項目を追加することも可能です。::
 
         bin/cake bake migration AddNameIndexToProducts name:string:index


### PR DESCRIPTION
- ref to migrations change in https://github.com/cakephp/migrations/pull/140
- add `use Migrations\AbstractMigration;` to be consistent