### PR TITLE
Update the migrations plugin book with the recent changes

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -408,23 +408,48 @@ You can use this command to determine which migrations have been run::
 Marking a migration as migrated
 ===============================
 
-.. versionadded:: cakephp/migrations 1.1.0
+.. versionadded:: 1.4.0
 
-It can sometimes be useful to mark a migration as migrated without actually
-running it.
-In order to do this, you can use the ``mark_migrated`` command. This command
-expects the migration version number as argument::
+It can sometimes be useful to mark a set of migrations as migrated without
+actually running them.
+In order to do this, you can use the ``mark_migrated`` command.
+The command works seamlessly as the other commands.
+
+You can mark all migrations as migrated using this command::
+
+    bin/cake migrations mark_migrated
+
+You can also mark all migrations up to a specific version as migrated using
+the ``--target`` option::
+
+    bin/cake migrations mark_migrated --target=20151016204000
+
+If you do not want the targeted migration to be marked as migrated during the
+process, you can use the ``--exclude`` flag with it::
+
+    bin/cake migrations mark_migrated --target=20151016204000 --exclude
+
+Finally, if you wish to mark only the targeted migration as migrated, you can
+use the ``--only`` flag::
+
+    bin/cake migrations mark_migrated --target=20151016204000 --only
+
+.. note::
+
+    When you bake a snapshot with the ``cake bake migration_snapshot``
+    command, the created migration will automatically be marked as migrated.
+
+.. deprecated:: 1.4.0
+
+    The following way of using the command has been deprecated. Use it only
+    if you are using a version of the plugin < 1.4.0.
+
+This command expects the migration version number as argument::
 
     bin/cake migrations mark_migrated 20150420082532
 
-Note that when you bake a snapshot with the ``cake bake migration_snapshot``
-command, the created migration will automatically be marked as migrated.
-
-.. versionadded:: cakephp/migrations 1.3.1
-
-A new ``all`` special value was added to the version argument of the
-``mark_migrated`` command. If you use it, it will mark all found migrations as
-migrated::
+If you wish to mark all migrations as migrated, you can use the ``all`` special
+value. If you use it, it will mark all found migrations as migrated::
 
     bin/cake migrations mark_migrated all
 

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -436,23 +436,50 @@ migrations qui ont été exécutées::
 Marqué une migration comme "migrée"
 ===================================
 
-.. versionadded:: cakephp/migrations 1.1.0
+.. versionadded:: 1.4.0
 
-Il peut parfois être utile de marquer une migration comme "migrée" sans avoir
-à exécuter la migration.
-Pour ce faire, vous pouvez utiliser la commande ``mark_migrated``. Cette commande
-attend le numéro de version de la migration comme argument::
+Il peut parfois être utile de marquer une série de migrations comme "migrées"
+sans avoir à les exécuter.
+Pour ce faire, vous pouvez utiliser la commande ``mark_migrated``.
+Cette commande fonctionne de la même manière que les autres commandes.
+
+Vous pouvez marquer toutes les migrations comme migrées en utilisant cette
+commande::
+
+    bin/cake migrations mark_migrated
+
+Vous pouvez également marquer toutes les migrations jusqu'à une version
+spécifique en utilisant l'option ``--target``
+
+    bin/cake migrations mark_migrated --target=20151016204000
+
+Si vous ne souhaitez pas que la migration "cible" soit marquée, vous pouvez
+utiliser le _flag_ ``--exclude``::
+
+    bin/cake migrations mark_migrated --target=20151016204000 --exclude
+
+Enfin, si vous souhaitez marquer seulement une migration, vous pouvez utiliser
+le _flag_ ``--only``::
+
+    bin/cake migrations mark_migrated --target=20151016204000 --only
+
+.. note::
+
+    Lorsque vous créez un snapshot avec la commande
+    ``cake bake migration_snapshot``, la migration créée sera automatiquement
+    marquée comme "migrée".
+
+.. deprecated:: 1.4.0
+
+    Les instructions suivantes ont été dépréciées. Utilisez les seulement si
+    vous utilisez une version du plugin inférieure à 1.4.0.
+
+La commande attend le numéro de version de la migration comme argument::
 
     bin/cake migrations mark_migrated 20150420082532
 
-Notez que lorsque vous faites un snapshot avec la commande
-``cake bake migration_snapshot``, la migration créée sera automatiquement marquée
-comme "migrée".
-
-.. versionadded:: cakephp/migrations 1.3.1
-
-Une nouvelle valeur spéciale ``all`` a été ajoutée pour l'argument version de
-la commande ``mark_migrated``. Si vous l'utilisez, toutes les migrations
+Si vous souhaitez marquer toutes les migrations comme "migrées", vous pouvez
+utiliser la valeur spéciale ``all``. Si vous l'utilisez, toutes les migrations
 trouvées seront marquées comme "migrées"::
 
     bin/cake migrations mark_migrated all


### PR DESCRIPTION
Update the migrations plugin book with the recent changes made to the ``mark_migrated`` command.

I decided to leave the old way of doing things given the old behavior is still here for backward compatibility.

Refs https://github.com/cakephp/migrations/pull/137 and https://github.com/cakephp/migrations/pull/142