### PR TITLE
Rephrase a sentence to avoid ambiguity

### DIFF
--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -52,7 +52,8 @@ already enabled for all requests; let's take a look at how they are added::
     // Use options to set priority
     DispatcherFactory::add('Asset', ['priority' => 1]);
 
-Dispatcher filters with higher priority will be executed first. Priority defaults to ``10``.
+Dispatcher filters with lower ``priority`` values will be executed first.
+Priority defaults to ``10``.
 
 While using the string name is convenient, you can also pass instances into
 ``add()``::


### PR DESCRIPTION
I found the sentence ambiguous (higher as in priority order, like 1 is higher in term of priority than 10 ? or higher as a numerical value ?), as opposed to the one from the Event system doc : 
http://book.cakephp.org/3.0/en/core-libraries/events.html#establishing-priorities