### PR TITLE
3.0 dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:latest
+
+ENV DEBIAN_FRONTEND noninteractive
+
+LABEL Description="This image is used to create an environment to contribute to the cakephp/docs"
+
+RUN apt-get update && apt-get install -y \
+  python-pip \
+  texlive-full
+
+RUN pip install sphinx==1.2.3
+RUN pip install sphinxcontrib-phpdomain
+
+VOLUME ["/data"]
+
+WORKDIR ["/data"]
+
+CMD ["make", "html"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ LABEL Description="This image is used to create an environment to contribute to 
 
 RUN apt-get update && apt-get install -y \
   python-pip \
-  texlive-full
+  texlive-latex-recommended \
+  texlive-latex-extra \
+  texlive-fonts-recommended
 
-RUN pip install sphinx==1.2.3
-RUN pip install sphinxcontrib-phpdomain
+ADD ./requirements.txt /tmp/requirements.txt
+RUN pip install -qr /tmp/requirements.txt
 
-VOLUME ["/data"]
+WORKDIR /data
 
-WORKDIR ["/data"]
-
-CMD ["make", "html"]
+CMD ["/bin/bash"]

--- a/README.mdown
+++ b/README.mdown
@@ -12,17 +12,14 @@ cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for
 help. You can read all of the documentation within as its just in plain text
 files, marked up with ReST text formatting.
 
-Tools required to Build the Documentation
------------------------------------------
+There are two ways for building the documentation: with Docker, or by installing
+the packages directly on your OS.
 
-You can either use docker to create a container with all packages needed to
-build the docs, or you can manually install the packages depending on your
-OS. We'll explain both methods in the next sub-parts.
+Build the Documentation with Docker
+-----------------------------------
 
-With Docker
-~~~~~~~~~~~
-
-You need to have docker installed, see the [official docs of
+Docker will let you create a container with all packages needed to build the
+docs. You need to have docker installed, see the [official docs of
 docker](http://docs.docker.com/mac/started/) for more information.
 
 There is a Dockerfile included at the root of this repository. You can build
@@ -30,21 +27,39 @@ an image using::
 
 	docker build -t cakephp/docs .
 
-Now that the image is build, you can run::
+This can take a little while, because all packages needs to be downloaded, but
+you'll only need to do this once.
 
-	docker run -t -i cakephp/docs
+Now that the image is build, you can run all the commands to build the docs::
 
-With Manual Installation
-~~~~~~~~~~~~~~~~~~~~~~~~
+	# To build the html
+	docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make html
 
-To build the documentation you'll need the following:
+	# To build the epub
+	docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make epub
+
+	# To build the latex
+	docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make latex
+
+	# To build the pdf
+	docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make pdf
+
+All the commands below will create and start containers and build the docs in
+the `build` folder. Be aware that each time you run a command, a container is
+created.
+
+Build the Documentation Manually
+--------------------------------
+
+Installing the needed Packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To build the documentation you'll need the following for linux/OS X:
 
 * Make
 * Python
 * Sphinx 1.2.* (currently the make commands will not work with 1.3.* versions and up)
 * PhpDomain for sphinx
-
-- On linux/OS X
 
 You can install sphinx using:
 
@@ -57,7 +72,7 @@ You can install the phpdomain using:
 *To run the pip command, python-pip package must be previously installed.*
 
 Building the Documentation
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After installing the required packages, you can build the documentation using `make`.
 
@@ -82,7 +97,7 @@ This will generate all the documentation in an HTML form.  Other output such as
 After making changes to the documentation, you can build the HTML version of the docs by using `make html` again.  This will build only the HTML files that have had changes made to them.
 
 Building the PDF
-----------------
+~~~~~~~~~~~~~~~~
 
 Building the PDF is a non-trivial task.
 

--- a/README.mdown
+++ b/README.mdown
@@ -6,25 +6,55 @@ CakePHP Documentation
 
 This is the official documentation for the CakePHP project. It is available online in HTML, PDF and EPUB formats at http://book.cakephp.org.
 
-Requirements
-------------
+Contributing to the documentation is pretty simple. Please read the
+documentation on contributing to the documentation over on [the
+cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for
+help. You can read all of the documentation within as its just in plain text
+files, marked up with ReST text formatting.
 
-You can read all of the documentation within as its just in plain text files, marked up with ReST text formatting.  To build the documentation you'll need the following:
+Tools required to Build the Documentation
+-----------------------------------------
+
+You can either use docker to create a container with all packages needed to
+build the docs, or you can manually install the packages depending on your
+OS. We'll explain both methods in the next sub-parts.
+
+With Docker
+~~~~~~~~~~~
+
+You need to have docker installed, see the [official docs of
+docker](http://docs.docker.com/mac/started/) for more information.
+
+There is a Dockerfile included at the root of this repository. You can build
+an image using::
+
+	docker build -t cakephp/docs .
+
+Now that the image is build, you can run::
+
+	docker run -t -i cakephp/docs
+
+With Manual Installation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To build the documentation you'll need the following:
 
 * Make
 * Python
 * Sphinx 1.2.* (currently the make commands will not work with 1.3.* versions and up)
 * PhpDomain for sphinx
 
+- On linux/OS X
+
 You can install sphinx using:
 
-	easy_install sphinx==1.2.3
+	pip install sphinx==1.2.3
 
 You can install the phpdomain using:
 
-	easy_install sphinxcontrib-phpdomain
+	pip install sphinxcontrib-phpdomain
 
-*To run the easy_install command, the setuptools package must be previously installed.*
+*To run the pip command, python-pip package must be previously installed.*
 
 Building the Documentation
 --------------------------
@@ -46,7 +76,8 @@ After installing the required packages, you can build the documentation using `m
 	# Populate the search index
 	make populate-index
 
-This will generate all the documentation in an HTML form.  Other output such as 'htmlhelp' are not fully complete at this time.
+This will generate all the documentation in an HTML form.  Other output such as
+'htmlhelp' are not fully complete at this time.
 
 After making changes to the documentation, you can build the HTML version of the docs by using `make html` again.  This will build only the HTML files that have had changes made to them.
 
@@ -61,11 +92,8 @@ Building the PDF is a non-trivial task.
 
 At this point the completed PDF should be in build/latex/en/CakePHPCookbook.pdf.
 
-
 Contributing
 ------------
-
-Contributing to the documentation is pretty simple. Please read the documentation on contributing to the documentation over on [the cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for help.
 
 There are currently a number of outstanding issues that need to be addressed.  We've tried to flag these with `.. todo::` where possible.  To see all the outstanding todo's add the following to your `config/all.py`
 
@@ -78,7 +106,7 @@ You are also welcome to make and suggestions for new content as commits in a Git
 Translations
 ------------
 
-Contributing translations requires that you make a new directory using the two letter name for your language.  As content is translated, directories mirroring the english content should be created with localized content.
+Contributing translations requires that you make a new directory using the two letter name for your language. As content is translated, directories mirroring the english content should be created with localized content.
 
 Making Search Work Locally
 --------------------------


### PR DESCRIPTION
I added a `Dockerfile` to the docs. I think this can ease the installation process as more and more people use docker.
We could also create an image in the [DockerHub](https://hub.docker.com/), allowing people to just run a command to run the docs building process, something like:

    docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make html

With no need to build an image.
