### PR TITLE
Appears to be incorrect or missing a step

### DIFF
--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -232,7 +232,7 @@ shell run the following::
 
     ./Console/cake schema create DbAcl
 
-This schema may prompt you to drop and create the tables. Say yes
+This schema will prompt you to drop and create the tables. Say yes
 to dropping and creating the tables.
 
 If you don't have shell access, or are having trouble using the

--- a/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
+++ b/en/tutorials-and-examples/simple-acl-controlled-application/simple-acl-controlled-application.rst
@@ -225,14 +225,14 @@ Initialize the Db Acl tables
 
 Before we create any users or groups we will want to connect them
 to the Acl. However, we do not at this time have any Acl tables and
-if you try to view any pages right now, you will get a missing
+if you try to view any pages right now, you may get a missing
 table error ("Error: Database table acos for model Aco was not
 found."). To remove these errors we need to run a schema file. In a
 shell run the following::
 
     ./Console/cake schema create DbAcl
 
-This schema will prompt you to drop and create the tables. Say yes
+This schema may prompt you to drop and create the tables. Say yes
 to dropping and creating the tables.
 
 If you don't have shell access, or are having trouble using the


### PR DESCRIPTION
Initialize the Db Acl tables
============================

Before we create any users or groups we will want to connect them
to the Acl. However, we do not at this time have any Acl tables and
if you try to view any pages right now, you will get a missing
table error ("Error: Database table acos for model Aco was not
found."). To remove these errors we need to run a schema file. In a
shell run the following::

I followed this step a few times in 2.6 and 

"However, we do not at this time have any Acl tables and
if you try to view any pages right now, you will get a missing
table error" 

Does not give me an error, I suspect that either 

1. A step is missing between line 115 "Preparing to Add Auth" and  line 223 "Initialize the Db Acl tables" OR

2. The cake bake all command builds scaffolding by default (I do not know how to check for this, per I do not have anything to check against.  ) OR

3. This is simply incorrect and you will not always get the error depending on the version of cake you are executing this tutorial in  thus I have changed the "will" to "may" (Sorry if this is a mistake on my part it may very well be)

NOTE: Do you prefer that I modify a document in small modifications as I am doing now or would you prefer that I summit all my changes in a large pull request ? Should I be asking questions about the document someplace else ?