### PR TITLE
add a --rm flag to rm container after run

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -59,19 +59,23 @@ Run the following command (with your image id of course):
 Now that the image is built, you can run all the commands to build the docs:
 
     # To build the html
-    docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make html
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make html
 
     # To build the epub
-    docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make epub
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make epub
 
     # To build the latex
-    docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make latex
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make latex
 
     # To build the pdf
-    docker run -i -t -v /full-path-to-your-local-docs-cakephp/:/data cakephp/docs make pdf
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make pdf
 
 All the commands below will create and start containers and build the docs in
-the `build` folder. Be aware that each time you run a command, a container is
+the `build` folder. The `--rm` flag will delete the container after run.
 created.
 
 Build the Documentation Manually

--- a/README.mdown
+++ b/README.mdown
@@ -76,7 +76,6 @@ Now that the image is built, you can run all the commands to build the docs:
 
 All the commands below will create and start containers and build the docs in
 the `build` folder. The `--rm` flag will delete the container after run.
-created.
 
 Build the Documentation Manually
 --------------------------------


### PR DESCRIPTION
To ease the use of docker, the best would be to create an official image on Dockerhub (from the Dockerfile of this repo). This would avoid the issues when building the image. For now, you can use my image without having to build an image:

    docker run -it --rm -v $(pwd):/data cake17/cakephp:cakephp-docs make html

