### PR TITLE
Small readability improvement concerning --target parameter

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -377,7 +377,7 @@ following command to apply the changes to your database::
 
         bin/cake migrations migrate
 
-To migrate to a specific version then use the --target parameter or -t for short::
+To migrate to a specific version then use the \-\-target parameter or -t for short::
 
         bin/cake migrations migrate -t 20150103081132
 


### PR DESCRIPTION
The double dash had been converted to a single "m"-width-dash thus I escaped the two dashes so that they are displayed properly.