### PR TITLE
Add details about baking test files with custom bake command options

### DIFF
--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -212,7 +212,7 @@ FooTask.php file should look like::
 
         public function name()
         {
-            return 'shell';
+            return 'foo';
         }
 
         public function fileName($name)
@@ -246,6 +246,32 @@ You should now see your new task in the output of ``bin/cake bake``. You can
 run your new task by running ``bin/cake bake foo Example``.
 This will generate a new ``ExampleFoo`` class in **src/Foo/ExampleFoo.php**
 for your application to use.
+
+If you want the ``bake`` call to also create a test file for your
+``ExampleFoo`` class, you need to overwrite the ``bakeTest()`` method in the
+``FooTask`` class to register the class suffix and namespace for your custom
+command name:
+
+  public function bakeTest($className)
+  {
+      if (!isset($this->Test->classSuffixes[$this->name()])) {
+          $this->Test->classSuffixes[$this->name()] = 'Foo';
+      }
+
+      $name = ucfirst($this->name());
+      if (!isset($this->Test->classTypes[$name])) {
+          $this->Test->classTypes[$name] = 'Foo';
+      }
+
+      return parent::bakeTest($className);
+  }
+
+- The **class suffix** will be appened to the name provided in your ``bake``
+call. In the previous example, it would create a ``ExampleFooTest.php`` file.
+- The **class type** will be the sub-namespace used that will lead to your
+file (relative to the app or the plugin you are baking into). In the previous
+example, it would create your test with the namespace ``App\Test\TestCase\Foo``
+.
 
 .. meta::
     :title lang=en: Extending Bake

--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -266,12 +266,12 @@ command name::
         return parent::bakeTest($className);
     }
 
-- The **class suffix** will be appened to the name provided in your ``bake``
-call. In the previous example, it would create a ``ExampleFooTest.php`` file.
-- The **class type** will be the sub-namespace used that will lead to your
-file (relative to the app or the plugin you are baking into). In the previous
-example, it would create your test with the namespace ``App\Test\TestCase\Foo``
-.
+* The **class suffix** will be appened to the name provided in your ``bake``
+  call. In the previous example, it would create a ``ExampleFooTest.php`` file.
+* The **class type** will be the sub-namespace used that will lead to your
+  file (relative to the app or the plugin you are baking into). In the previous
+  example, it would create your test with the namespace ``App\Test\TestCase\Foo``
+  .
 
 .. meta::
     :title lang=en: Extending Bake

--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -250,21 +250,21 @@ for your application to use.
 If you want the ``bake`` call to also create a test file for your
 ``ExampleFoo`` class, you need to overwrite the ``bakeTest()`` method in the
 ``FooTask`` class to register the class suffix and namespace for your custom
-command name:
+command name::
 
-  public function bakeTest($className)
-  {
-      if (!isset($this->Test->classSuffixes[$this->name()])) {
+    public function bakeTest($className)
+    {
+        if (!isset($this->Test->classSuffixes[$this->name()])) {
           $this->Test->classSuffixes[$this->name()] = 'Foo';
-      }
+        }
 
-      $name = ucfirst($this->name());
-      if (!isset($this->Test->classTypes[$name])) {
+        $name = ucfirst($this->name());
+        if (!isset($this->Test->classTypes[$name])) {
           $this->Test->classTypes[$name] = 'Foo';
-      }
+        }
 
-      return parent::bakeTest($className);
-  }
+        return parent::bakeTest($className);
+    }
 
 - The **class suffix** will be appened to the name provided in your ``bake``
 call. In the previous example, it would create a ``ExampleFooTest.php`` file.

--- a/fr/bake/development.rst
+++ b/fr/bake/development.rst
@@ -266,19 +266,19 @@ pour la classe ``ExampleFoo``, vous devrez surcharger la méthode ``bakeTest()``
 dans la classe ``FooTask`` pour y définir le suffixe et le namespace de la
 classe de votre nom de commande personnalisée::
 
-  public function bakeTest($className)
-  {
-      if (!isset($this->Test->classSuffixes[$this->name()])) {
+    public function bakeTest($className)
+    {
+        if (!isset($this->Test->classSuffixes[$this->name()])) {
           $this->Test->classSuffixes[$this->name()] = 'Foo';
-      }
+        }
 
-      $name = ucfirst($this->name());
-      if (!isset($this->Test->classTypes[$name])) {
+        $name = ucfirst($this->name());
+        if (!isset($this->Test->classTypes[$name])) {
           $this->Test->classTypes[$name] = 'Foo';
-      }
+        }
 
-      return parent::bakeTest($className);
-  }
+        return parent::bakeTest($className);
+    }
 
 - Le **suffixe de classe** sera ajouté après le nom passé à ``bake``. Dans le
 cadre de l'exemple ci-dessus, cela créerait un fichier ``ExampleFooTest.php``.

--- a/fr/bake/development.rst
+++ b/fr/bake/development.rst
@@ -223,7 +223,7 @@ FooTask.php devra ressembler à ceci::
 
         public function name()
         {
-            return 'shell';
+            return 'foo';
         }
 
         public function fileName($name)
@@ -260,6 +260,32 @@ Vous devriez maintenant voir votre nouvelle tâche dans l'affichage de
 Cela va générer une nouvelle classe ``ExampleFoo`` dans
 **src/Foo/ExampleFoo.php** que votre application va
 pouvoir utiliser.
+
+Si vous souhaitez que votre appel à ``bake`` crée également un fichier de test
+pour la classe ``ExampleFoo``, vous devrez surcharger la méthode ``bakeTest()``
+dans la classe ``FooTask`` pour y définir le suffixe et le namespace de la
+classe de votre nom de commande personnalisée::
+
+  public function bakeTest($className)
+  {
+      if (!isset($this->Test->classSuffixes[$this->name()])) {
+          $this->Test->classSuffixes[$this->name()] = 'Foo';
+      }
+
+      $name = ucfirst($this->name());
+      if (!isset($this->Test->classTypes[$name])) {
+          $this->Test->classTypes[$name] = 'Foo';
+      }
+
+      return parent::bakeTest($className);
+  }
+
+- Le **suffixe de classe** sera ajouté après le nom passé à ``bake``. Dans le
+cadre de l'exemple ci-dessus, cela créerait un fichier ``ExampleFooTest.php``.
+- Le **type de classe** sera le sous-namespace utilisé pour atteindre votre
+fichier (relatif à l'application ou au plugin dans lequel vous faites le
+``bake``). Dans le cadre de l'exemple ci-dessus, cela créerait le test avec le
+namespace ``App\Test\TestCase\Foo``.
 
 .. meta::
     :title lang=fr: Etendre Bake

--- a/fr/bake/development.rst
+++ b/fr/bake/development.rst
@@ -280,12 +280,12 @@ classe de votre nom de commande personnalisée::
         return parent::bakeTest($className);
     }
 
-- Le **suffixe de classe** sera ajouté après le nom passé à ``bake``. Dans le
-cadre de l'exemple ci-dessus, cela créerait un fichier ``ExampleFooTest.php``.
-- Le **type de classe** sera le sous-namespace utilisé pour atteindre votre
-fichier (relatif à l'application ou au plugin dans lequel vous faites le
-``bake``). Dans le cadre de l'exemple ci-dessus, cela créerait le test avec le
-namespace ``App\Test\TestCase\Foo``.
+* Le **suffixe de classe** sera ajouté après le nom passé à ``bake``. Dans le
+  cadre de l'exemple ci-dessus, cela créerait un fichier ``ExampleFooTest.php``.
+* Le **type de classe** sera le sous-namespace utilisé pour atteindre votre
+  fichier (relatif à l'application ou au plugin dans lequel vous faites le
+  ``bake``). Dans le cadre de l'exemple ci-dessus, cela créerait le test avec le
+  namespace ``App\Test\TestCase\Foo``.
 
 .. meta::
     :title lang=fr: Etendre Bake


### PR DESCRIPTION
When baking a custom type class, tests files should only be created if the class type has been declared.
This gives an example of how to do it.

Refs to #3435
Linked to https://github.com/cakephp/bake/pull/170