### PR TITLE
miss leading note to start internal server

### DIFF
--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -84,7 +84,7 @@ home page. Before you can do that, you'll need to start the development server::
 
 .. note::
 
-    For Windows, the command needs to be ``bin\cake`` (note the backslash).
+    For Windows, the command needs to be ``bin\cake server`` (note the backslash).
 
 This will start PHP's built-in webserver on port 8765. Open up
 **http://localhost:8765** in your web browser to see the welcome page. All the


### PR DESCRIPTION
just went true and recognized this note for windows, to start the internal server is missleading. The server arg is needed on windows too.