### PR TITLE
Fix Flash component usage in Auth component login example.

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -219,12 +219,9 @@ working with a login form could look like::
                 $this->Auth->setUser($user);
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
-                $this->Flash->error(
-                    __('Username or password is incorrect'),
-                    'default',
-                    [],
-                    'auth'
-                );
+                $this->Flash->error(__('Username or password is incorrect'), [
+                    'key' => 'auth'
+                ]);
             }
         }
     }

--- a/fr/controllers/components/authentication.rst
+++ b/fr/controllers/components/authentication.rst
@@ -237,12 +237,9 @@ connexion pourrait ressembler à cela::
                 $this->Auth->setUser($user);
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
-                $this->Flash->error(
-                    __("Nom d'utilisateur ou mot de passe incorrect"),
-                    'default',
-                    [],
-                    'auth'
-                );
+                $this->Flash->error(__('Nom d'utilisateur ou mot de passe incorrect'), [
+                    'key' => 'auth'
+                ]);
             }
         }
     }


### PR DESCRIPTION
Not sure whether the example should really use the `key` option, but if it should, then it should look more like this.