### PR TITLE
Remove easily.

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -22,9 +22,9 @@ Upgrade Tool
 ============
 
 While this document covers all the breaking changes and improvements made in
-CakePHP 3.0, we've also created a console application to help you easily
-complete some of the time consuming mechanical changes. You can `get the upgrade
-tool from github <https://github.com/cakephp/upgrade>`_.
+CakePHP 3.0, we've also created a console application to help you complete some
+of the time consuming mechanical changes. You can `get the upgrade tool from
+github <https://github.com/cakephp/upgrade>`_.
 
 Application Directory Layout
 ============================
@@ -37,7 +37,7 @@ when updating your application.
 CakePHP should be installed with Composer
 =========================================
 
-Since CakePHP can no longer easily be installed via PEAR, or in a shared
+Since CakePHP can no longer be installed via PEAR, or in a shared
 directory, those options are no longer supported. Instead you should use
 `Composer <http://getcomposer.org>`_ to install CakePHP into your application.
 
@@ -405,7 +405,7 @@ Filter\AssetFilter
   of issues with JavaScript libraries like TinyMCE and environments with
   short_tags enabled.
 * Support for the ``Asset.filter`` configuration and hooks were removed. This
-  feature can easily be replaced with a plugin or dispatcher filter.
+  feature should be replaced with a plugin or dispatcher filter.
 
 
 Network
@@ -457,7 +457,7 @@ for using the session object.
 * The session cookie timeout is automatically updated in tandem with the timeout
   in the session data.
 * The path for session cookie now defaults to app's base path instead of "/".
-  Also new config variable ``Session.cookiePath`` has been added to easily
+  A new configuration variable ``Session.cookiePath`` has been added to
   customize the cookie path.
 * A new convenience method :php:meth:`Cake\\Network\\Session::consume()` has been added
   to allow reading and deleting session data in a single step.
@@ -485,7 +485,7 @@ Network\\Email
   removal of email configuration.
 * :php:meth:`Cake\\Network\\Email\\Email::configTransport()` has been added to allow the
   definition of transport configurations. This change removes transport options
-  from delivery profiles and allows you to easily re-use transports across email
+  from delivery profiles and allows you to re-use transports across email
   profiles.
 * :php:meth:`Cake\\Network\\Email\\Email::dropTransport()` has been added to allow the
   removal of transport configuration.
@@ -648,7 +648,7 @@ SecurityComponent
 - ``SecurityComponent::$disabledFields()`` has been removed, use
   ``SecurityComponent::$unlockedFields()``.
 - The CSRF related features in SecurityComponent have been extracted and moved
-  into a separate CsrfComponent. This allows you more easily use CSRF protection
+  into a separate CsrfComponent. This allows you to use CSRF protection
   without having to use form tampering prevention.
 - Configuration options are no longer set as public properties.
 - The methods ``requireAuth()`` and ``requireSecure()`` no longer accept "var args".
@@ -902,7 +902,7 @@ FormHelper has been entirely rewritten for 3.0. It features a few large changes:
 * FormHelper works with the new ORM. But has an extensible system for
   integrating with other ORMs or datasources.
 * FormHelper features an extensible widget system that allows you to create new
-  custom input widgets and easily augment the built-in ones.
+  custom input widgets and augment the built-in ones.
 * String templates are the foundation of the helper. Instead of munging arrays
   together everywhere, most of the HTML FormHelper generates can be customized
   in one central place using template sets.

--- a/en/appendices/orm-migration.rst
+++ b/en/appendices/orm-migration.rst
@@ -541,7 +541,7 @@ differences from behaviors in CakePHP 2.x:
 - The method signatures for mixin methods have changed.
 - The method signatures for callback methods have changed.
 - The base class for behaviors have changed.
-- Behaviors can easily add finder methods.
+- Behaviors can add finder methods.
 
 New Base Class
 --------------

--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -2,7 +2,7 @@ Extending Bake
 ##############
 
 Bake features an extensible architecture that allows your application or plugins
-to easily modify or add-to the base functionality. Bake makes use of a dedicated
+to modify or add-to the base functionality. Bake makes use of a dedicated
 view class which does not use standard PHP syntax.
 
 Bake Events

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -581,7 +581,7 @@ configure the OptionParser to define the expected inputs of your shell.
 You can also configure subcommand option parsers, which allow you to
 have different option parsers for subcommands and tasks.
 The ConsoleOptionParser implements a fluent interface and includes
-methods for easily setting multiple options/arguments at once::
+methods for setting multiple options/arguments at once::
 
     public function getOptionParser()
     {
@@ -819,7 +819,7 @@ The above is an example of how you could provide help and a specialized
 option parser for a shell's task. By calling the Task's ``getOptionParser()``
 we don't have to duplicate the option parser generation, or mix concerns
 in our shell. Adding subcommands in this way has two advantages.
-First it lets your shell easily document its subcommands in the
+First, it lets your shell document its subcommands in the
 generated help. It also gives easy access to the subcommand
 help. With the above subcommand created you could call
 ``cake myshell --help`` and see the list of subcommands, and

--- a/en/console-and-shells/helpers.rst
+++ b/en/console-and-shells/helpers.rst
@@ -4,7 +4,7 @@ Shell Helpers
 .. versionadded:: 3.1
     Shell Helpers were added in 3.1.0
 
-Shell Helpers let you easily package up complex output generation code. Shell
+Shell Helpers let you package up complex output generation code. Shell
 Helpers can be accessed and used from any shell or task::
 
     // Output some data as a table.

--- a/en/console-and-shells/i18n-shell.rst
+++ b/en/console-and-shells/i18n-shell.rst
@@ -2,8 +2,8 @@ I18N Shell
 ##########
 
 The i18n features of CakePHP use `po files <http://en.wikipedia.org/wiki/GNU_gettext>`_
-as their translation source. This makes them easily to integrate with tools
-like `poedit <http://www.poedit.net/>`_ and other common translation tools.
+as their translation source. PO files integrate with commonly used translation tools
+like `poedit <http://www.poedit.net/>`_.
 
 The i18n shell provides a quick and easy way to generate po template files.
 These templates files can then be given to translators so they can translate the

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -10,7 +10,7 @@ controller has been found, your controller's action is called. Your controller
 should handle interpreting the request data, making sure the correct models
 are called, and the right response or view is rendered. Controllers can be
 thought of as middle man between the Model and View. You want to keep your
-controllers thin, and your models fat. This will help you more easily reuse
+controllers thin, and your models fat. This will help you reuse
 your code and makes your code easier to test.
 
 Commonly, a controller is used to manage the logic around a single model. For

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -282,7 +282,7 @@ registry::
 
     $controller = $this->_registry->getController();
 
-You can also easily access the controller in any callback method from the event
+You can access the controller in any callback method from the event
 object::
 
     $controller = $event->subject();

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -4,7 +4,7 @@ Request & Response Objects
 .. php:namespace:: Cake\Network
 
 The request and response objects provide an abstraction around HTTP requests and
-responses. The request object in CakePHP allows you to easily introspect an
+responses. The request object in CakePHP allows you to introspect an
 incoming request, while the response object allows you to effortlessly create
 HTTP responses from your controllers.
 
@@ -186,7 +186,7 @@ conditions, as well as inspect other application specific request criteria::
 
     $this->request->is('post');
 
-You can also easily extend the request detectors that are available, by using
+You can also extend the request detectors that are available, by using
 :php:meth:`Cake\\Network\\Request::addDetector()` to create new kinds of
 detectors. There are four different types of detectors that you can create:
 
@@ -503,7 +503,7 @@ a pdf or an ics generated on the fly from a string::
 Streaming Resources
 -------------------
 
-You can use a callable with ``body()`` to easily convert resource streams into
+You can use a callable with ``body()`` to convert resource streams into
 responses::
 
     $file = fopen('/some/file.png', 'r');

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -7,7 +7,7 @@ Caching
 
 Caching is frequently used to reduce the time it takes to create or read from
 other resources. Caching is often used to make reading from expensive
-resources less expensive. You can easily store the results of expensive queries,
+resources less expensive. You can store the results of expensive queries,
 or remote webservice access that doesn't frequently change in a cache. Once
 in the cache, re-reading the stored resource from the cache is much cheaper
 than accessing the remote resource.
@@ -38,8 +38,8 @@ to implement your own caching systems. The built-in caching engines are:
   Memcached, also provides atomic operations.
 
 Regardless of the CacheEngine you choose to use, your application interacts with
-:php:class:`Cake\\Cache\\Cache` in a consistent manner.  This means you can
-easily swap cache engines as your application grows.
+:php:class:`Cake\\Cache\\Cache` in a consistent manner. You can swap cache
+engines as your application grows.
 
 .. _cache-configuration:
 
@@ -158,7 +158,7 @@ model finds::
         Cache::write('posts', $posts);
     }
 
-Using ``Cache::write()`` and ``Cache::read()`` to easily reduce the number
+Using ``Cache::write()`` and ``Cache::read()`` to reduce the number
 of trips made to the database to fetch posts.
 
 .. note::
@@ -315,12 +315,12 @@ Using Cache to Store Counters
 
 .. php:staticmethod:: decrement($key, $offset = 1, $config = 'default')
 
-Counters for various things are easily stored in a cache. For example, a simple
-countdown for remaining 'slots' in a contest could be stored in Cache. The
-Cache class exposes atomic ways to increment/decrement counter values in an easy
-way. Atomic operations are important for these values as it reduces the risk of
-contention, and ability for two users to simultaneously lower the value by one,
-resulting in an incorrect value.
+Counters in your application are good candidates for storage in a cache.  As an
+example, a simple countdown for remaining 'slots' in a contest could be stored
+in Cache. The Cache class exposes atomic ways to increment/decrement counter
+values in an easy way. Atomic operations are important for these values as it
+reduces the risk of contention, and ability for two users to simultaneously
+lower the value by one, resulting in an incorrect value.
 
 After setting an integer value you can manipulate it using ``increment()`` and
 ``decrement()``::

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -72,7 +72,7 @@ created. To keep your Orders model clean you could use events::
         }
     }
 
-The above code allows you to easily notify the other parts of the application
+The above code allows you to notify the other parts of the application
 that an order has been created. You can then do tasks like send email
 notifications, update stock, log relevant statistics and other tasks in separate
 objects that focus on those concerns.

--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -5,7 +5,7 @@ Http Client
 
 .. php:class:: Client(mixed $config = [])
 
-CakePHP includes a basic but powerful HTTP client which can be easily used for
+CakePHP includes a basic but powerful HTTP client which can be used for
 making requests. It is a great way to communicate with webservices, and
 remote APIs.
 

--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -274,7 +274,7 @@ an increasing level of severity:
 
 You can refer to these levels by name when configuring loggers, and when writing
 log messages. Alternatively, you can use convenience methods like
-:php:meth:`Cake\\Log\\Log::error()` to clearly and easily indicate the logging
+:php:meth:`Cake\\Log\\Log::error()` to clearly indicate the logging
 level. Using a level that is not in the above levels will result in an
 exception.
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -67,7 +67,7 @@ The ``Time`` class constructor can take any parameter that the internal ``DateTi
 PHP class can. When passing a number or numeric string, it will be interpreted
 as a UNIX timestamp.
 
-In test cases you can easily mock out ``now()`` using ``setTestNow()``::
+In test cases you can mock out ``now()`` using ``setTestNow()``::
 
     // Fixate time.
     $now = new Time('2014-04-12 12:22:30');

--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -301,7 +301,7 @@ Creating Reusable Validators
 ----------------------------
 
 While defining validators inline where they are used makes for good example
-code, it doesn't lead to easily maintainable applications. Instead, you should
+code, it doesn't lead to maintainable applications. Instead, you should
 create ``Validator`` sub-classes for your reusable validation logic::
 
     // In src/Model/Validation/ContactValidator.php

--- a/en/core-libraries/xml.rst
+++ b/en/core-libraries/xml.rst
@@ -5,7 +5,7 @@ Xml
 
 .. php:class:: Xml
 
-The Xml class allows you to easily transform arrays into SimpleXMLElement or
+The Xml class allows you to transform arrays into SimpleXMLElement or
 DOMDocument objects, and back into arrays again.
 
 

--- a/en/deployment.rst
+++ b/en/deployment.rst
@@ -77,7 +77,7 @@ directory being executed.
 Improve Your Application's Performance
 ======================================
 
-Class loading can easily take a big share of your application's processing time.
+Class loading can take a big share of your application's processing time.
 In order to avoid this problem, it is recommended that you run this command in
 your production server once the application is deployed::
 
@@ -85,7 +85,7 @@ your production server once the application is deployed::
 
 Since handling static assets, such as images, JavaScript and CSS files of
 plugins, through the ``Dispatcher`` is incredibly inefficient, it is strongly
-recommended to symlink them for production. This can be done easily using 
+recommended to symlink them for production. This can be done by using 
 the ``plugin`` shell::
 
     bin/cake plugin assets symlink

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -38,7 +38,7 @@ Using Filters
 =============
 
 Filters are usually enabled in your application's **bootstrap.php** file, but
-you could easily load them any time before the request is dispatched.  Adding
+you could load them any time before the request is dispatched.  Adding
 and removing filters is done through :php:class:`Cake\\Routing\\DispatcherFactory`. By
 default, the CakePHP application template comes with a couple filter classes
 already enabled for all requests; let's take a look at how they are added::

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -399,7 +399,7 @@ which allows the native ``__toString()`` methods to work as normal::
 When caught by the built in exception handler, you would get a ``$widget``
 variable in your error view template. In addition if you cast the exception
 as a string or use its ``getMessage()`` method you will get
-``Seems that Pointy is missing.``. This allows you easily and quickly create
+``Seems that Pointy is missing.``. This allows you to quickly create
 your own rich development errors, just like CakePHP uses internally.
 
 

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -100,7 +100,7 @@ this::
 
 RESTful controllers often use parsed extensions to serve up different views
 based on different kinds of requests. Since we're dealing with REST requests,
-we'll be making XML views. You can also easily make JSON views using CakePHP's
+we'll be making XML views. You can make JSON views using CakePHP's
 built-in :doc:`/views/json-and-xml-views`. By using the built in
 :php:class:`XmlView` we can define a ``_serialize`` view variable. This special
 view variable is used to define which view variables ``XmlView`` should

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -11,7 +11,7 @@ are structured.
 
 Routing in CakePHP also encompasses the idea of reverse routing,
 where an array of parameters can be transformed into a URL string.
-By using reverse routing, you can more easily re-factor your application's
+By using reverse routing, you can re-factor your application's
 URL structure without having to update all your code.
 
 .. index:: routes.php
@@ -188,7 +188,7 @@ allows you link to ``/government`` rather than ``/pages/display/5``.
 Another common use for the Router is to define an "alias" for a
 controller. Let's say that instead of accessing our regular URL at
 ``/users/some_action/5``, we'd like to be able to access it by
-``/cooks/some_action/5``. The following route easily takes care of
+``/cooks/some_action/5``. The following route takes care of
 that::
 
     $routes->connect(
@@ -557,7 +557,7 @@ Plugin Routing
 
 .. php:staticmethod:: plugin($name, $options = [], $callback)
 
-Routes for :doc:`/plugins` are most easily created using the ``plugin()``
+Routes for :doc:`/plugins` should be created using the ``plugin()``
 method. This method creates a new routing scope for the plugin's routes::
 
     Router::plugin('DebugKit', function ($routes) {
@@ -724,7 +724,7 @@ preference:
 #. The REQUEST\_METHOD header
 
 The \_method POST variable is helpful in using a browser as a
-REST client (or anything else that can do POST easily). Just set
+REST client (or anything else that can do POST). Just set
 the value of \_method to the name of the HTTP request method you
 wish to emulate.
 
@@ -923,7 +923,7 @@ Generating URLs
 .. php:staticmethod:: url($url = null, $full = false)
 
 Generating URLs or Reverse routing is a feature in CakePHP that is used to
-allow you to easily change your URL structure without having to modify all your
+allow you to change your URL structure without having to modify all your
 code. By using :term:`routing arrays <routing array>` to define your URLs, you
 can later configure routes and the generated URLs will automatically update.
 
@@ -1101,7 +1101,7 @@ Callback filter functions should expect the following parameters:
 
 The URL filter function should *always* return the params even if unmodified.
 
-URL filters allow you to easily implement features like persistent parameters::
+URL filters allow you to implement features like persistent parameters::
 
     Router::addUrlFilter(function ($params, $request) {
         if (isset($request->params['lang']) && !isset($params['lang'])) {

--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -315,7 +315,7 @@ Accessing the Session Object
 ============================
 
 You can access the session data any place you have access to a request object.
-This means the session is easily accessible from:
+This means the session is accessible from:
 
 * Controllers
 * Views

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -201,9 +201,9 @@ string that contains the content we expect. If the result did not contain the
 expected content the test would fail, and we would know that our code is
 incorrect.
 
-By using test cases you can easily describe the relationship between a set of
+By using test cases you can describe the relationship between a set of
 known inputs and their expected output. This helps you be more confident of the
-code you're writing as you can easily check that the code you wrote fulfills the
+code you're writing as you can ensure that the code you wrote fulfills the
 expectations and assertions your tests make. Additionally because tests are
 code, they are easy to re-run whenever you make a change. This helps prevent
 the creation of new bugs.
@@ -463,7 +463,7 @@ to have a ``null`` value, just specify the value of that key as ``null``.
 Dynamic Data and Fixtures
 -------------------------
 
-Since records for a fixture are declared as a class property, you cannot easily
+Since records for a fixture are declared as a class property, you cannot
 use functions or other dynamic data to define fixtures. To solve this problem,
 you can define ``$records`` in the ``init()`` function of your fixture. For
 example if you wanted all the created and modified timestamps to reflect today's
@@ -509,11 +509,11 @@ Importing Table Information
 ---------------------------
 
 Defining the schema in fixture files can be really handy when creating plugins
-or libraries or if you are creating an application that needs to easily be
-portable. Redefining the schema in fixtures can become difficult to maintain in
-larger applications. Because of this CakePHP provides the ability to import the
-schema from an existing connection and use the reflected table definition to
-create the table definition used in the test suite.
+or libraries or if you are creating an application that needs to be portable
+between database vendors. Redefining the schema in fixtures can become difficult
+to maintain in larger applications. Because of this CakePHP provides the ability
+to import the schema from an existing connection and use the reflected table
+definition to create the table definition used in the test suite.
 
 Let's start with an example. Assuming you have a table named articles available
 in your application, change the example fixture given in the previous section
@@ -740,7 +740,7 @@ Controller Integration Testing
 While you can test controller classes in a similar fashion to Helpers, Models,
 and Components, CakePHP offers a specialized ``IntegrationTestCase`` class.
 Using this class as the base class for your controller test cases allows you to
-more easily do integration testing with your controllers.
+test controllers from a high level.
 
 If you are unfamiliar with integration testing, it is a testing approach that
 makes it easy to test multiple units in concert. The integration testing
@@ -1256,7 +1256,7 @@ would be
       </testsuite>
     </testsuites>
 
-``CakeTestSuite`` offers several methods for easily creating test suites based
+``CakeTestSuite`` offers several methods for creating test suites based
 on the file system. It allows you to run any code you want to prepare your test
 suite. If we wanted to create a test suite for all our model tests we could
 would create **tests/TestCase/AllModelTest.php**. Put the following in it::

--- a/en/index.rst
+++ b/en/index.rst
@@ -8,7 +8,7 @@ Welcome
 The CakePHP cookbook is an openly developed and community editable documentation
 project. Notice the "Improve this Doc" button in the upper right-hand
 corner; it will direct you to the GitHub online editor of the active page,
-allowing you to easily contribute any additions, deletions, or corrections to
+allowing you to contribute any additions, deletions, or corrections to
 the documentation.
 
 .. container:: offline-download

--- a/en/intro.rst
+++ b/en/intro.rst
@@ -75,7 +75,7 @@ or a XML formatted result for others to consume::
     <?php endforeach; ?>
 
 The View layer provides a number of extension points like :ref:`view-elements`
-and :doc:`/views/cells` to let you easily re-use your presentation logic.
+and :doc:`/views/cells` to let you re-use your presentation logic.
 
 The View layer is not only limited to HTML or text representation of the data.
 It can be used to deliver common data formats like JSON, XML, and through

--- a/en/intro/conventions.rst
+++ b/en/intro/conventions.rst
@@ -6,7 +6,7 @@ bit of time to learn CakePHP's conventions, you save time in the
 long run. By following conventions, you get free functionality, and
 you liberate yourself from the maintenance nightmare of tracking config
 files. Conventions also make for a very uniform development experience,
-allowing other developers to jump in and help more easily.
+allowing other developers to jump in and help.
 
 Controller Conventions
 ======================
@@ -24,7 +24,7 @@ cannot be accessed with routing.
 URL Considerations for Controller Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As you've just seen, single word controllers map easily to a simple
+As you've just seen, single word controllers map to a simple
 lower case URL path. For example, ``ApplesController`` (which would
 be defined in the file name 'ApplesController.php') is accessed
 from http://example.com/apples.

--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -144,7 +144,7 @@ Doctors hasOne Mentors mentors.doctor\_id
 
 .. note::
 
-    It is not mandatory to follow CakePHP conventions, you can easily override
+    It is not mandatory to follow CakePHP conventions, you can override
     the use of any foreignKey in your associations definitions. Nevertheless sticking
     to conventions will make your code less repetitive, easier to read and to maintain.
 

--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -198,7 +198,7 @@ Defining Finders
 ----------------
 
 Now that we are able to save articles with slug values, we should implement
-a finder method so we can easily fetch articles by their slug. Behavior finder
+a finder method so we can fetch articles by their slug. Behavior finder
 methods, use the same conventions as :ref:`custom-find-methods` do. Our
 ``find('slug')`` method would look like::
 

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -51,7 +51,7 @@ You can try now getting your entity again::
     $article = $this->Articles->get(12);
     echo $article->title; // Echoes 'Un Artículo', yay piece of cake!
 
-Working with multiple translations can be done easily by using a special trait
+Working with multiple translations can be done by using a special trait
 in your Entity class::
 
     use Cake\ORM\Behavior\Translate\TranslateTrait;
@@ -386,7 +386,7 @@ Saving Multiple Translations
 ============================
 
 It is a common requirement to be able to add or edit multiple translations to
-any database record at the same time. This can be easily done using the
+any database record at the same time. This can be done using the
 ``TranslateTrait``::
 
     use Cake\ORM\Behavior\Translate\TranslateTrait;

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -145,7 +145,7 @@ Mutator methods should always return the value that should be stored in the
 property. As you can see above, you can also use mutators to set other
 calculated properties. When doing this, be careful to not introduce any loops,
 as CakePHP will not prevent infinitely looping mutator methods. Mutators allow
-you easily convert properties as they are set, or create calculated data.
+you to convert properties as they are set, or create calculated data.
 Mutators and accessors are applied when properties are read using object
 notation, or using get() and set().
 
@@ -402,7 +402,7 @@ Creating Re-usable Code with Traits
 You may find yourself needing the same logic in multiple entity classes. PHP's
 traits are a great fit for this. You can put your application's traits in
 **src/Model/Entity**. By convention traits in CakePHP are suffixed with
-``Trait`` so they are easily discernible from classes or interfaces. Traits are
+``Trait`` so they can be discernible from classes or interfaces. Traits are
 often a good compliment to behaviors, allowing you to provide functionality for
 the table and entity objects.
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -532,7 +532,7 @@ The above generates SQL similar to::
     ))
 
 By using functions as the parameters to ``orWhere()`` and ``andWhere()``,
-you can easily compose conditions together with the expression objects::
+you can compose conditions together with the expression objects::
 
     $query = $articles->find()
         ->where(['title LIKE' => '%First%'])
@@ -1244,7 +1244,7 @@ a few calculated fields or derived data, you can use the ``formatResults()``
 method. This is a lightweight way to map over the result sets. If you need more
 control over the process, or want to reduce results you should use
 the :ref:`Map/Reduce <map-reduce>` feature instead. If you were querying a list
-of people, you could easily calculate their age with a result formatter::
+of people, you could calculate their age with a result formatter::
 
     // Assuming we have built the fields, conditions and containments.
     $query->formatResults(function (\Cake\Datasource\ResultSetInterface $results) {

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -30,7 +30,7 @@ Getting a Single Entity by Primary Key
 .. php:method:: get($id, $options = [])
 
 It is often convenient to load a single entity from the database when editing or
-view entities and their related data. You can do this easily by using
+view entities and their related data. You can do this by using
 ``get()``::
 
     // In a controller or table method.
@@ -155,9 +155,9 @@ The list of options supported by find() are:
 Any options that are not in this list will be passed to beforeFind listeners
 where they can be used to modify the query object. You can use the
 ``getOptions()`` method on a query object to retrieve the options used. While you
-can very easily pass query objects to your controllers, we recommend that you
+can pass query objects to your controllers, we recommend that you
 package your queries up as :ref:`custom-find-methods` instead. Using custom
-finder methods will let you re-use your queries more easily and make testing
+finder methods will let you re-use your queries and make testing
 easier.
 
 By default queries and result sets will return :doc:`/orm/entities` objects. You
@@ -283,7 +283,7 @@ Finding Threaded Data
 
 The ``find('threaded')`` finder returns nested entities that are threaded
 together through a key field. By default this field is ``parent_id``. This
-finder allows you to easily access data stored in an 'adjacency list' style
+finder allows you to access data stored in an 'adjacency list' style
 table. All entities matching a given ``parent_id`` are placed under the
 ``children`` attribute::
 
@@ -365,7 +365,7 @@ Dynamic Finders
 ===============
 
 CakePHP's ORM provides dynamically constructed finder methods which allow you to
-easily express simple queries with no additional code. For example if you wanted
+express simple queries with no additional code. For example if you wanted
 to find a user by username you could do::
 
     // In a controller
@@ -867,7 +867,7 @@ Turning buffering off has a few caveats:
     Streaming results will still allocate memory for the entire results when
     using PostgreSQL and SQL Server. This is due to limitations in PDO.
 
-Result sets allow you to easily cache/serialize or JSON encode results for API
+Result sets allow you to cache/serialize or JSON encode results for API
 results::
 
     // In a controller or table method.
@@ -887,7 +887,7 @@ within a result set.
 In addition to making serialization easy, result sets are a 'Collection' object and
 support the same methods that :doc:`collection objects </core-libraries/collections>`
 do. For example, you can extract a list of unique tags on a collection of
-articles quite easily::
+articles by running::
 
     // In a controller or table method.
     $articles = TableRegistry::get('Articles');
@@ -1188,7 +1188,7 @@ Removing All Stacked Map-reduce Operations
 ------------------------------------------
 
 Under some circumstances you may want to modify a ``Query`` object so that no
-``mapReduce`` operations are executed at all. This can be easily done by
+``mapReduce`` operations are executed at all. This can be done by
 calling the method with both parameters as null and the third parameter
 (overwrite) as ``true``::
 

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -346,7 +346,7 @@ Creating Unique Field Rules
 ---------------------------
 
 Because unique rules are quite common, CakePHP includes a simple Rule class that
-allows you to easily define unique field sets::
+allows you to define unique field sets::
 
     use Cake\ORM\Rule\IsUnique;
 

--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -501,7 +501,7 @@ Components, Helpers and Behaviors
 A plugin can have Components, Helpers and Behaviors just like a regular CakePHP
 application. You can even create plugins that consist only of Components,
 Helpers or Behaviors which can be a great way to build reusable components that
-can easily be dropped into any project.
+can be dropped into any project.
 
 Building these components is exactly the same as building it within a regular
 application, with no special naming convention.

--- a/en/tutorials-and-examples/blog/blog.rst
+++ b/en/tutorials-and-examples/blog/blog.rst
@@ -188,7 +188,7 @@ in security hashes.
 The security salt is used for generating hashes. If you used Composer this too is taken
 care of for you during the install. Else you'd need to change the default salt value
 by editing **config/app.php**. It doesn't matter much what the new value is, as long as
-it's not easily guessed::
+it's not guessable::
 
     'Security' => [
         'salt' => 'something long and containing lots of different values.',

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -386,7 +386,7 @@ to **src/Model/Table/BookmarksTable.php**::
     }
 
 While this code is a bit more complicated than what we've done so far, it helps
-to showcase how powerful the ORM in CakePHP is. You can easily manipulate query
+to showcase how powerful the ORM in CakePHP is. You can manipulate query
 results using the :doc:`/core-libraries/collections` methods, and handle
 scenarios where you are creating entities on the fly with ease.
 

--- a/en/upgrade-tool.rst
+++ b/en/upgrade-tool.rst
@@ -2,7 +2,7 @@ Upgrade Tool
 ############
 
 Upgrading to CakePHP 3 from CakePHP 2.x requires a number of transformations
-that can easily be automated, such as adding namespaces. To assist in making
+that can be automated, such as adding namespaces. To assist in making
 these mechanical changes easier, CakePHP provides a CLI based upgrade tool.
 
 Installation

--- a/en/views.rst
+++ b/en/views.rst
@@ -295,7 +295,7 @@ want to conditionally show headings or other markup:
     <?php endif; ?>
 
 You can also provide a default value for a block should it not have
-any content. This allows you to easily add placeholder content for empty
+any content. This allows you to add placeholder content for empty
 states. You can provide a default value using the second argument:
 
 .. code-block:: php

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -46,10 +46,9 @@ build forms.
 
 Once a form has been created with a context, all inputs you create will use the
 active context. In the case of an ORM backed form, FormHelper can access
-associated data, validation errors and schema metadata easily making building
-forms simple.  You can close the active context using the ``end()`` method, or
-by calling ``create()`` again. To create a form for an entity, do the
-following::
+associated data, validation errors and schema metadata. You can close the active
+context using the ``end()`` method, or by calling ``create()`` again. To create
+a form for an entity, do the following::
 
     // If you are on /articles/add
     // $article should be an empty Article entity.
@@ -234,7 +233,7 @@ Creating Form Inputs
 
 .. php:method:: input(string $fieldName, array $options = [])
 
-The ``input()`` method lets you easily generate complete form inputs. These
+The ``input()`` method lets you to generate complete form inputs. These
 inputs will include a wrapping div, label, input widget, and validation error if
 necessary. By using the metadata in the form context, this method will choose an
 appropriate input type for each field. Internally ``input()`` uses the other
@@ -1798,7 +1797,7 @@ Adding Custom Widgets
 
 CakePHP makes it easy to add custom input widgets in your application, and use
 them like any other input type. All of the core input types are implemented as
-wigets, which means you can easily override any core widget with your own
+wigets, which means you can override any core widget with your own
 implemenation as well.
 
 Building a Widget Class

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -28,7 +28,7 @@ Loading Templates from a File
 -----------------------------
 
 When adding the PaginatorHelper in your controller, you can define the
-'templates' setting to define a template file to load. This allows you easily
+'templates' setting to define a template file to load. This allows you to
 customize multiple templates and keep your code DRY::
 
     // In a controller.
@@ -415,7 +415,7 @@ doesn't always need to be restricted as such.
 See the details on
 `PaginatorHelper <http://api.cakephp.org/3.0/class-Cake.View.Helper.PaginatorHelper.html>`_
 in the API. As mentioned, the PaginatorHelper also offers sorting features
-which can be easily integrated into your table column headers:
+which can be integrated into your table column headers:
 
 .. code-block:: php
 

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -2,7 +2,7 @@ JSON and XML views
 ##################
 
 The ``JsonView`` and ``XmlView``
-let you easily create JSON and XML responses, and integrate with the
+let you create JSON and XML responses, and integrate with the
 :php:class:`Cake\\Controller\\Component\\RequestHandlerComponent`.
 
 By enabling ``RequestHandlerComponent`` in your application, and enabling

--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -2,7 +2,7 @@ Themes
 ######
 
 You can take advantage of themes, making it easy to switch the look and feel of
-your page quickly and easily. Themes in CakePHP are simply plugins that focus on
+your page quickly. Themes in CakePHP are simply plugins that focus on
 providing template files. In addition to template files, they can also provide
 helpers and cells if your theming requires that. When using cells and helpers from your
 theme, you will need to continue using the :term:`plugin syntax`.


### PR DESCRIPTION
Easily is a filler word that add little to no value. Hat tip to @schmalliso on why easily is bad.