### PR TITLE
Fix Hash::remove sample code results

### DIFF
--- a/en/core-libraries/hash.rst
+++ b/en/core-libraries/hash.rst
@@ -173,6 +173,7 @@ Attribute Matching Types
                 ['clear' => true, 'Item' => ['id' => 1, 'title' => 'first']],
                 ['Item' => ['id' => 2, 'title' => 'second']],
                 ['Item' => ['id' => 3, 'title' => 'third']],
+                ['clear' => true],
                 ['Item' => ['id' => 5, 'title' => 'fifth']],
             ]
         */


### PR DESCRIPTION
Hash::remove sample code is wrong.

Code:
```php
$data = [
    0 => ['clear' => true, 'Item' => ['id' => 1, 'title' => 'first']],
    1 => ['Item' => ['id' => 2, 'title' => 'second']],
    2 => ['Item' => ['id' => 3, 'title' => 'third']],
    3 => ['clear' => true, 'Item' => ['id' => 4, 'title' => 'fourth']],
    4 => ['Item' => ['id' => 5, 'title' => 'fifth']],
];
$result = Hash::remove($data, '{n}[clear].Item[id=4]');
print_r($result);
```

Result:
```
Array
(
    [0] => Array
        (
            [clear] => 1
            [Item] => Array
                (
                    [id] => 1
                    [title] => first
                )

        )

    [1] => Array
        (
            [Item] => Array
                (
                    [id] => 2
                    [title] => second
                )

        )

    [2] => Array
        (
            [Item] => Array
                (
                    [id] => 3
                    [title] => third
                )

        )

    [3] => Array
        (
            [clear] => 1
        )

    [4] => Array
        (
            [Item] => Array
                (
                    [id] => 5
                    [title] => fifth
                )

        )

)
```