### PR TITLE
Fix example in validation.rst

### DIFF
--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -179,7 +179,7 @@ construction process into multiple reusable steps::
     {
         $validator = $this->validateDefault($validator);
 
-        $validator->add('password', 'length', ['rule' => 'between', 8, 100]);
+        $validator->add('password', 'length', ['rule' => ['lengthBetween', 8, 100]]);
         return $validator;
     }
 


### PR DESCRIPTION
The example for field length validation in "Combining Validators" is not valid code. The rule name is incorrect and the rule and its parameters need to be provided contained in an array.