### PR TITLE
Update string.rst

### DIFF
--- a/en/core-utility-libraries/string.rst
+++ b/en/core-utility-libraries/string.rst
@@ -7,6 +7,10 @@ The String class includes convenience methods for creating and
 manipulating strings and is normally accessed statically. Example:
 ``String::uuid()``.
 
+.. deprecated:: 2.7
+    The String class has been deprecated in 2.7 in favour of the :php:class:`CakeText`
+    class. It offers a more consistent interface and API.
+    
 If you need :php:class:`TextHelper` functionalities outside of a ``View``,
 use the ``String`` class::
 


### PR DESCRIPTION
Added deprecation notice. Not sure if this is the right way. There is no CakeText section in the docs. As String is just a wrapper for CakeText, perhaps the file can can be duplicated and have the class name replaced.
