### PR TITLE
Improve autocompletion setup instructions

### DIFF
--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -54,7 +54,12 @@ For example::
 
 Returns::
 
-    --help -h --verbose -v --quiet -q --connection -c --template -t
+    --help -h --verbose -v --quiet -q --everything --connection -c --force -f --plugin -p --prefix --theme -t
+Vous pouvez passer un autre argument représentant une sous-commande du shell :
+cela vous retournera les options spécifiques à cette sous-commande.
+
+You can also pass an additional argument being the shell sub-command : it will
+output the specific options of this sub-command.
 
 How to enable Bash autocompletion for the CakePHP Console
 =========================================================

--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -62,6 +62,7 @@ How to enable Bash autocompletion for the CakePHP Console
 Using a Debian distribution
 ---------------------------
 
+First, make sure the **bash-completion** library is installed.
 Create a file named **cake** in **/etc/bash_completion.d/** and put the
 following content inside it::
 
@@ -100,17 +101,16 @@ following content inside it::
             opts=$(${cake} Completion subcommands $prev)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             if [[ $COMPREPLY = "" ]] ; then
-                COMPREPLY=( $(compgen -df -- ${cur}) )
+                _filedir
                 return 0
             fi
             return 0
         fi
 
-
         opts=$(${cake} Completion fuzzy "${COMP_WORDS[@]:1}")
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         if [[ $COMPREPLY = "" ]] ; then
-            COMPREPLY=( $(compgen -df -- ${cur}) )
+            _filedir
             return 0
         fi
         return 0;

--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -134,14 +134,14 @@ Three type of autocompletion are provided. The following output are from a fresh
 
 #### Commands::
 
-	$ bin/cake <tab>
-	bake        i18n        orm_cache   routes
+    $ bin/cake <tab>
+    bake        i18n        orm_cache   routes
     console     migrations  plugin      server
 
 #### Subcommands::
 
-	$ bin/cake bake <tab>
-	behavior            helper              shell
+    $ bin/cake bake <tab>
+    behavior            helper              shell
     cell                mailer              shell_helper
     component           migration           template
     controller          migration_snapshot  test
@@ -150,6 +150,6 @@ Three type of autocompletion are provided. The following output are from a fresh
 
 #### Options::
 
-	$ bin/cake bake -<tab>
-	-c            --everything  --force       --help        --plugin      -q            -t            -v
+    $ bin/cake bake -<tab>
+    -c            --everything  --force       --help        --plugin      -q            -t            -v
     --connection  -f            -h            -p            --prefix      --quiet       --theme       --verbose

--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -56,12 +56,18 @@ Returns::
 
     --help -h --verbose -v --quiet -q --connection -c --template -t
 
-Bash Example
-============
+How to enable Bash autocompletion for the CakePHP Console
+=========================================================
 
-The following bash example comes from the original author::
+Using a Debian distribution
+---------------------------
 
-    # bash completion for CakePHP console
+Create a file named **cake** in **/etc/bash_completion.d/** and put the
+following content inside it::
+
+    #
+    # Bash completion file for CakePHP console
+    #
 
     _cake()
     {
@@ -111,3 +117,34 @@ The following bash example comes from the original author::
     }
 
     complete -F _cake cake bin/cake
+
+Save the file, then restart your console.
+
+Using autocompletion
+====================
+
+Once enabled, the autocompletion can be used the same way than for other
+built-in commands, using the **TAB** key.
+Three type of autocompletion are provided. The following output are from a fresh CakePHP install.
+
+#### Commands::
+
+	$ bin/cake <tab>
+	bake        i18n        orm_cache   routes
+    console     migrations  plugin      server
+
+#### Subcommands::
+
+	$ bin/cake bake <tab>
+	behavior            helper              shell
+    cell                mailer              shell_helper
+    component           migration           template
+    controller          migration_snapshot  test
+    fixture             model
+    form                plugin
+
+#### Options::
+
+	$ bin/cake bake -<tab>
+	-c            --everything  --force       --help        --plugin      -q            -t            -v
+    --connection  -f            -h            -p            --prefix      --quiet       --theme       --verbose

--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -55,8 +55,6 @@ For example::
 Returns::
 
     --help -h --verbose -v --quiet -q --everything --connection -c --force -f --plugin -p --prefix --theme -t
-Vous pouvez passer un autre argument représentant une sous-commande du shell :
-cela vous retournera les options spécifiques à cette sous-commande.
 
 You can also pass an additional argument being the shell sub-command : it will
 output the specific options of this sub-command.
@@ -64,12 +62,30 @@ output the specific options of this sub-command.
 How to enable Bash autocompletion for the CakePHP Console
 =========================================================
 
-Using a Debian distribution
----------------------------
+First, make sure the **bash-completion** library is installed. If not, you do it
+with the following command::
 
-First, make sure the **bash-completion** library is installed.
+    apt-get install bash-completion
+
 Create a file named **cake** in **/etc/bash_completion.d/** and put the
-following content inside it::
+:ref:`bash-completion-file-content` inside it.
+
+Save the file, then restart your console.
+
+.. note::
+
+    If you are using MacOS X, you can install the **bash-completion** library
+    using **homebrew** with the command ``brew install bash-completion``.
+    The target directory for the **cake** file will be
+    **/usr/local/etc/bash_completion.d/**.
+
+.. _bash-completion-file-content:
+
+Bash Completion file content
+----------------------------
+
+This is the code you need to put inside the **cake** file in the correct location
+in order to get autocompletion when using the CakePHP console::
 
     #
     # Bash completion file for CakePHP console
@@ -123,7 +139,6 @@ following content inside it::
 
     complete -F _cake cake bin/cake
 
-Save the file, then restart your console.
 
 Using autocompletion
 ====================
@@ -132,13 +147,19 @@ Once enabled, the autocompletion can be used the same way than for other
 built-in commands, using the **TAB** key.
 Three type of autocompletion are provided. The following output are from a fresh CakePHP install.
 
-#### Commands::
+Commands
+--------
+
+Sample output for commands autocompletion::
 
     $ bin/cake <tab>
     bake        i18n        orm_cache   routes
     console     migrations  plugin      server
 
-#### Subcommands::
+Subcommands
+-----------
+
+Sample output for subcommands autocompletion::
 
     $ bin/cake bake <tab>
     behavior            helper              shell
@@ -148,7 +169,10 @@ Three type of autocompletion are provided. The following output are from a fresh
     fixture             model
     form                plugin
 
-#### Options::
+Options
+-------
+
+Sample output for subcommands options autocompletion::
 
     $ bin/cake bake -<tab>
     -c            --everything  --force       --help        --plugin      -q            -t            -v

--- a/fr/console-and-shells/completion-shell.rst
+++ b/fr/console-and-shells/completion-shell.rst
@@ -57,7 +57,10 @@ Par exemple::
 
 Retourne::
 
-    --help -h --verbose -v --quiet -q --connection -c --template -t
+    --help -h --verbose -v --quiet -q --everything --connection -c --force -f --plugin -p --prefix --theme -t
+
+Vous pouvez passer un autre argument représentant une sous-commande du shell :
+cela vous retournera les options spécifiques à cette sous-commande.
 
 Activer l'autocompletion Bash pour la console CakePHP
 =====================================================

--- a/fr/console-and-shells/completion-shell.rst
+++ b/fr/console-and-shells/completion-shell.rst
@@ -59,12 +59,18 @@ Retourne::
 
     --help -h --verbose -v --quiet -q --connection -c --template -t
 
-Exemple de Bash
-===============
+Activer l'autocompletion Bash pour la console CakePHP
+=====================================================
 
-L'exemple de bash suivant provient de l'auteur original::
+Avec une distribution Debian
+----------------------------
 
-    # bash completion for CakePHP console
+Créez un fichier **cake** dans **/etc/bash_completion.d/** et placez-y le
+contenu suivant::
+
+    #
+    # Fichier completion Bash pour la console CakePHP
+    #
 
     _cake()
     {
@@ -114,3 +120,35 @@ L'exemple de bash suivant provient de l'auteur original::
     }
 
     complete -F _cake cake bin/cake
+
+Sauvegardez le fichier et rédémarrer la console.
+
+Utilisez l'autocompletion
+=========================
+
+Une fois activée, l'autocompletion peut être utilisée de la même manière que
+pour les autres commandes natives du système, en utilisant la touche **TAB**.
+Trois types d'autocompletion sont fournis. Les examples de retour qui suivent
+proviennent d'une installation fraîche de CakePHP.
+
+#### Commandes::
+
+	$ bin/cake <tab>
+	bake        i18n        orm_cache   routes
+    console     migrations  plugin      server
+
+#### Sous-commandes::
+
+	$ bin/cake bake <tab>
+	behavior            helper              shell
+    cell                mailer              shell_helper
+    component           migration           template
+    controller          migration_snapshot  test
+    fixture             model
+    form                plugin
+
+#### Options::
+
+	$ bin/cake bake -<tab>
+	-c            --everything  --force       --help        --plugin      -q            -t            -v
+    --connection  -f            -h            -p            --prefix      --quiet       --theme       --verbose

--- a/fr/console-and-shells/completion-shell.rst
+++ b/fr/console-and-shells/completion-shell.rst
@@ -136,14 +136,14 @@ proviennent d'une installation fraîche de CakePHP.
 
 #### Commandes::
 
-	$ bin/cake <tab>
-	bake        i18n        orm_cache   routes
+    $ bin/cake <tab>
+    bake        i18n        orm_cache   routes
     console     migrations  plugin      server
 
-#### Sous-commandes::
+#### Subcommands::
 
-	$ bin/cake bake <tab>
-	behavior            helper              shell
+    $ bin/cake bake <tab>
+    behavior            helper              shell
     cell                mailer              shell_helper
     component           migration           template
     controller          migration_snapshot  test
@@ -152,6 +152,6 @@ proviennent d'une installation fraîche de CakePHP.
 
 #### Options::
 
-	$ bin/cake bake -<tab>
-	-c            --everything  --force       --help        --plugin      -q            -t            -v
+    $ bin/cake bake -<tab>
+    -c            --everything  --force       --help        --plugin      -q            -t            -v
     --connection  -f            -h            -p            --prefix      --quiet       --theme       --verbose

--- a/fr/console-and-shells/completion-shell.rst
+++ b/fr/console-and-shells/completion-shell.rst
@@ -65,11 +65,12 @@ Activer l'autocompletion Bash pour la console CakePHP
 Avec une distribution Debian
 ----------------------------
 
+Tout d'abord, assurez-vous que la librairie **bash-completion** est installée.
 Créez un fichier **cake** dans **/etc/bash_completion.d/** et placez-y le
 contenu suivant::
 
     #
-    # Fichier completion Bash pour la console CakePHP
+    # Fichier de completion Bash pour la console CakePHP
     #
 
     _cake()
@@ -103,17 +104,16 @@ contenu suivant::
             opts=$(${cake} Completion subcommands $prev)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             if [[ $COMPREPLY = "" ]] ; then
-                COMPREPLY=( $(compgen -df -- ${cur}) )
+                _filedir
                 return 0
             fi
             return 0
         fi
 
-
         opts=$(${cake} Completion fuzzy "${COMP_WORDS[@]:1}")
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         if [[ $COMPREPLY = "" ]] ; then
-            COMPREPLY=( $(compgen -df -- ${cur}) )
+            _filedir
             return 0
         fi
         return 0;

--- a/fr/console-and-shells/completion-shell.rst
+++ b/fr/console-and-shells/completion-shell.rst
@@ -62,15 +62,34 @@ Retourne::
 Vous pouvez passer un autre argument représentant une sous-commande du shell :
 cela vous retournera les options spécifiques à cette sous-commande.
 
-Activer l'autocompletion Bash pour la console CakePHP
+Activer l'autocomplétion Bash pour la console CakePHP
 =====================================================
 
-Avec une distribution Debian
-----------------------------
-
 Tout d'abord, assurez-vous que la librairie **bash-completion** est installée.
+Si elle ne l'est pas, vous pouvez le faire en exécutant la commande suivante::
+
+    apt-get install bash-completion
+
 Créez un fichier **cake** dans **/etc/bash_completion.d/** et placez-y le
-contenu suivant::
+:ref:`bash-completion-file-content`.
+
+Sauvegardez le fichier et rédémarrez la console.
+
+.. note::
+
+    Si vous utilisez MacOS X, vous pouvez installer la librairie
+    **bash-completion** en utilisant **homebrew** avec la commande suivante :
+    ``brew install bash-completion``. Le répertoire cible du fichier **cake**
+    devra être **/usr/local/etc/bash_completion.d/**.
+
+.. _bash-completion-file-content:
+
+Contenu du fichier bash d'autocomplétion
+----------------------------------------
+
+Voici le code que vous devez saisir dans le fichier **cake** (préalablement créé
+au bon emplacement pour bénéficier de l'autocomplétion quand vous utilisez la
+console CakePHP::
 
     #
     # Fichier de completion Bash pour la console CakePHP
@@ -124,8 +143,6 @@ contenu suivant::
 
     complete -F _cake cake bin/cake
 
-Sauvegardez le fichier et rédémarrer la console.
-
 Utilisez l'autocompletion
 =========================
 
@@ -134,13 +151,19 @@ pour les autres commandes natives du système, en utilisant la touche **TAB**.
 Trois types d'autocompletion sont fournis. Les examples de retour qui suivent
 proviennent d'une installation fraîche de CakePHP.
 
-#### Commandes::
+Commandes
+---------
+
+Exemple de rendu pour l'autocomplétion des commandes::
 
     $ bin/cake <tab>
     bake        i18n        orm_cache   routes
     console     migrations  plugin      server
 
-#### Subcommands::
+Sous-commandes
+--------------
+
+Exemple de rendu pour l'autocomplétion des sous-commandes::
 
     $ bin/cake bake <tab>
     behavior            helper              shell
@@ -150,7 +173,10 @@ proviennent d'une installation fraîche de CakePHP.
     fixture             model
     form                plugin
 
-#### Options::
+Options
+-------
+
+Exemple de rendu pour l'autocomplétion des options d'une sous-commande::
 
     $ bin/cake bake -<tab>
     -c            --everything  --force       --help        --plugin      -q            -t            -v


### PR DESCRIPTION
Improves the documentation on how to setup autocompletion for the CakePHP Console.
Can someone using MacOS tell me if the bash script is good as well for MacOS ?
Because I replaced the filesystem browsing part of the bash autocompletion script by the _filedir function that is bundled with the bash-completion lib, but I don't know if it's available on MacOS.

Linked to https://github.com/cakephp/cakephp/pull/7800 and https://github.com/cakephp/cakephp/pull/7784