### PR TITLE
3.0 dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ before_install:
 
 script:
     - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make html SPHINXOPTS='-W'
+    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make epub
+    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make latex
+    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make pdf
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 sudo: required
 
 services:
-  - docker
+    - docker
 
 before_install:
-  - docker pull cakephpfr/docs
+    - docker pull cakephpfr/docs
 
 script:
-    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make html SPHINXOPTS='-W'
-    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make epub
-    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make latex
-    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make pdf
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs:light make html SPHINXOPTS='-W'
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make pdf
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
-language: python
+sudo: required
 
-python:
- - "2.7"
+services:
+  - docker
 
-install:
-    - pip install -r requirements.txt
-    - sudo apt-get install texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+before_install:
+  - docker pull cakephpfr/docs
 
 script:
-    - 'make html SPHINXOPTS="-W"'
-    - 'make latex'
-    - 'make epub'
-    - 'make pdf'
+    - docker run -it --rm -v $(pwd):/data -p 127.0.0.1:80:4567 cakephpfr/docs make html SPHINXOPTS='-W'
 
 notifications:
     email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     texlive-latex-recommended \
     texlive-latex-extra \
     texlive-fonts-recommended \
+    texlive-lang-all \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Instead of rebuilding the environment, we can use the docker image from https://hub.docker.com/r/cakephpfr/docs/.

This PR reduces time for travis builds:
- about 11-15 mins with previous travis config (install tools directly) : ie https://travis-ci.org/cakephp/docs/builds/95535464
- about 6-7 mins with new travis config (docker image) : ie: https://travis-ci.org/cakephp/docs/builds/95364968

Note : Instead of pulling from cakephpfr/docs in the `before_install` script, we could create the image with a `docker build -t cakephpfr/docs`.