### PR TITLE
[2.x] Fix the argument name of TextHelper.

### DIFF
--- a/en/core-libraries/helpers/text.rst
+++ b/en/core-libraries/helpers/text.rst
@@ -22,7 +22,7 @@ truncating long stretches of text.
     :param array $options: An array of :term:`html attributes` for the generated links.
 
     Adds links to the well-formed email addresses in $text, according
-    to any options defined in ``$htmlOptions`` (see
+    to any options defined in ``$options`` (see
     :php:meth:`HtmlHelper::link()`). ::
 
         $myText = 'For more information regarding our world-famous ' .
@@ -38,10 +38,10 @@ truncating long stretches of text.
         In 2.1 this method automatically escapes its input. Use the ``escape``
         option to disable this if necessary.
 
-.. php:method:: autoLinkUrls(string $text, array $htmlOptions=array())
+.. php:method:: autoLinkUrls(string $text, array $options=array())
 
     :param string $text: The text to convert.
-    :param array $htmlOptions: An array :term:`html attributes` for the generated links
+    :param array $options: An array :term:`html attributes` for the generated links
 
     Same as ``autoLinkEmails()``, only this method searches for
     strings that start with https, http, ftp, or nntp and links them
@@ -51,14 +51,14 @@ truncating long stretches of text.
         In 2.1 this method automatically escapes its input. Use the ``escape``
         option to disable this if necessary.
 
-.. php:method:: autoLink(string $text, array $htmlOptions=array())
+.. php:method:: autoLink(string $text, array $options=array())
 
     :param string $text: The text to autolink.
-    :param array $htmlOptions: An array :term:`html attributes` for the generated links
+    :param array $options: An array :term:`html attributes` for the generated links
 
     Performs the functionality in both ``autoLinkUrls()`` and
     ``autoLinkEmails()`` on the supplied ``$text``. All URLs and emails
-    are linked appropriately given the supplied ``$htmlOptions``.
+    are linked appropriately given the supplied ``$options``.
 
     .. versionchanged:: 2.1
         As of 2.1, this method automatically escapes its input. Use the ``escape``


### PR DESCRIPTION
Rename $htmlOptions to $options.