### PR TITLE
Reorganize the migration guide.

### DIFF
--- a/en/appendices/3-2-migration-guide.rst
+++ b/en/appendices/3-2-migration-guide.rst
@@ -29,7 +29,7 @@ replaced with better solutions. Deprecated features will not be removed until
 * ``Cake\\ORM\\ResultSet::_calculateTypeMap()`` is now unused and deprecated.
 * ``Cake\\ORM\\ResultSet::_castValues()`` is now unused and deprecated.
 * The ``action`` key for ``FormHelper::create()`` has been deprecated. You
-  should be use the ``url`` key directly.
+  should use the ``url`` key directly.
 
 Disabling Deprecation Warnings
 ------------------------------

--- a/en/appendices/3-2-migration-guide.rst
+++ b/en/appendices/3-2-migration-guide.rst
@@ -21,7 +21,7 @@ replaced with better solutions. Deprecated features will not be removed until
 * ``Shell::error()`` is deprecated because its name does not clearly indicate
   that it both outputs a message and stops execution. Use ``Shell::abort()``
   instead.
-* ``Cake\\Database\\Type::type()`` is deprecated. Use ``tieWith()`` instead.
+* ``Cake\\Database\\Expression\QueryExpression::type()`` is deprecated. Use ``tieWith()`` instead.
 * ``Cake\\Database\\Type\\DateTimeType::$dateTimeClass`` is deprecated.  Use
   DateTimeType::useMutable() or DateTimeType::useImmutable() instead.
 * ``Cake\\Database\\Type\\DateType::$dateTimeClass`` is deprecated.  Use

--- a/en/appendices/3-2-migration-guide.rst
+++ b/en/appendices/3-2-migration-guide.rst
@@ -11,8 +11,28 @@ CakePHP 3.2 requires at least PHP 5.5.10. By adopting PHP 5.5 we can provide bet
 Date and Time libraries and remove dependencies on password compatibility
 libraries.
 
+Deprecations
+============
+
+As we continue to improve CakePHP, certain features are deprecated as they are
+replaced with better solutions. Deprecated features will not be removed until
+4.0:
+
+* ``Shell::error()`` is deprecated because its name does not clearly indicate
+  that it both outputs a message and stops execution. Use ``Shell::abort()``
+  instead.
+* ``Cake\\Database\\Type::type()`` is deprecated. Use ``tieWith()`` instead.
+* ``Cake\\Database\\Type\\DateTimeType::$dateTimeClass`` is deprecated.  Use
+  DateTimeType::useMutable() or DateTimeType::useImmutable() instead.
+* ``Cake\\Database\\Type\\DateType::$dateTimeClass`` is deprecated.  Use
+  ``DateTimeType::useMutable()`` or ``DateType::useImmutable()`` instead.
+* ``Cake\\ORM\\ResultSet::_calculateTypeMap()`` is now unused and deprecated.
+* ``Cake\\ORM\\ResultSet::_castValues()`` is now unused and deprecated.
+* The ``action`` key for ``FormHelper::create()`` has been deprecated. You
+  should be use the ``url`` key directly.
+
 Disabling Deprecation Warnings
-==============================
+------------------------------
 
 Upon upgrading you may encounter several deprecation warnings. These warnings
 are emitted by methods, options and functionality that will be removed in
@@ -27,8 +47,11 @@ disable them in your **config/app.php**::
 
 The above error level will suppress deprecation warnings from CakePHP.
 
+New Enhancements
+================
+
 Carbon Replaced with Chronos
-============================
+----------------------------
 
 The Carbon library has been replaced with :doc:`cakephp/chronos </chronos>`. This
 new library is a fork of Carbon with no additional dependencies. It also offer
@@ -36,14 +59,14 @@ a calendar date object, and immutable versions of both date and datetime
 objects.
 
 New Date Object
-===============
+---------------
 
 The ``Date`` class allows you to cleanly map ``DATE`` columns into PHP objects.
 Date instances will always fix their time to ``00:00:00 UTC``. By default the
 ORM creates instances of ``Date`` when mapping ``DATE`` columns now.
 
 New Immutable Date and Time Objects
-===================================
+-----------------------------------
 
 The ``FrozenTime``, and ``FrozenDate`` classes were added. These classes offer
 the same API as the ``Time`` object has. The frozen classes provide immutable
@@ -63,33 +86,29 @@ the ORM can map date/datetime columns into immutable objects. See the
 :ref:`immutable-datetime-mapping` section for more information.
 
 CorsBuilder Added
-=================
+-----------------
 
 In order to make setting headers related to Cross Origin Requests (CORS) easier,
 a new ``CorsBuilder`` has been added. This class lets you define CORS related
 headers with a fluent interface. See :ref:`cors-headers` for more information.
 
 ORM
-===
+---
 
 * Containing the same association multiple times now works as expected, and the
   query builder functions are now stacked.
 
 
 Shell
-=====
+-----
 
 * ``Shell::info()``, ``Shell::warn()`` and ``Shell::success()`` were added.
   These helper methods make using commonly used styling simpler.
 * ``Cake\\Console\\Exception\\StopException`` was added.
 * ``Shell::abort()`` was added to replace ``error()``.
-* ``Shell::error()`` is deprecated because its name does not clearly indicate
-  that it both outputs a message and stops execution. Use ``Shell::abort()``
-  instead.
-
 
 exit() no longer called by _stop() and error()
-----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``Shell::_stop()`` and ``Shell::error()`` no longer call ``exit()``. Instead
 they raise ``Cake\\Console\\Exception\\StopException``. If your shells/tasks are
@@ -97,23 +116,14 @@ catching ``\Exception`` where these methods would have been called, those catch
 blocks will need to be updated so they don't catch the ``StopException``. By not
 calling ``exit()`` testing shells should be easier and require fewer mocks.
 
-View
-====
-
-Helpers
--------
+Helper initialize() added
+-------------------------
 
 Helpers can now implement an ``initialize(array $config)`` hook method like other
 class types.
 
-FormHelper
-----------
-
-The ``action`` key for ``FormHelper::create()`` has been deprecated. You should be use
-the ``url`` key directly.
-
 Fatal Error Memory Limit Handling
-=================================
+---------------------------------
 
 A new configuration option ``Error.extraFatalErrorMemory`` can be set to the
 number of megabytes to increase the memory limit by when a fatal error is


### PR DESCRIPTION
Consolidate deprecations into one place to make it easier to find.