### PR TITLE
3.2 moves the migration guide to separate page

### DIFF
--- a/en/appendices.rst
+++ b/en/appendices.rst
@@ -4,31 +4,13 @@ Appendices
 Appendices contain information regarding the new features
 introduced in each version and the migration path between versions.
 
-3.2 Migration Guide
+3.x Migration Guide
 ===================
 
 .. toctree::
     :maxdepth: 1
 
-    appendices/3-2-migration-guide
-
-
-3.1 Migration Guide
-===================
-
-.. toctree::
-    :maxdepth: 1
-
-    appendices/3-1-migration-guide
-
-3.0 Migration Guide
-===================
-
-.. toctree::
-    :maxdepth: 1
-
-    appendices/3-0-migration-guide
-    appendices/orm-migration
+    appendices/3-x-migration-guide
 
 General Information
 ===================

--- a/en/appendices/3-x-migration-guide.rst
+++ b/en/appendices/3-x-migration-guide.rst
@@ -1,0 +1,33 @@
+3.x Migration Guide
+###################
+
+.. toctree::
+   :hidden:
+
+Migration guides contain information regarding the new features introduced in
+each version and the migration path between versions.
+
+3.2 Migration Guide
+===================
+
+.. toctree::
+    :maxdepth: 1
+
+    3-2-migration-guide
+
+3.1 Migration Guide
+===================
+
+.. toctree::
+    :maxdepth: 1
+
+    3-1-migration-guide
+
+3.0 Migration Guide
+===================
+
+.. toctree::
+    :maxdepth: 1
+
+    3-0-migration-guide
+    orm-migration

--- a/en/contents.rst
+++ b/en/contents.rst
@@ -12,7 +12,7 @@ Contents
 
     intro
     quickstart
-    appendices/3-0-migration-guide
+    appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
 


### PR DESCRIPTION
to help people that are not familiar with the appendices to find the migration guide faster.
Then the top link in the menu will ink to all 3.x migration guides.

Comes in addition of #3621 

it will shows up like that:
<img width="995" alt="capture d ecran 2016-01-03 a 09 59 50" src="https://cloud.githubusercontent.com/assets/4977112/12078025/c5358126-b200-11e5-9be9-189cea680bfa.png">


<img width="1022" alt="capture d ecran 2016-01-03 a 09 59 07" src="https://cloud.githubusercontent.com/assets/4977112/12078023/abf321be-b200-11e5-8e32-b5d1d7381150.png">

and will still be available from appendices. I didn't move any pages so it won't break the search result and/or the google references.