### PR TITLE
default in second argument of fetch()

### DIFF
--- a/en/views.rst
+++ b/en/views.rst
@@ -294,8 +294,8 @@ want to conditionally show headings or other markup:
     </div>
     <?php endif; ?>
 
-You can also provide a default value for a block should it not have
-any content. This allows you to add placeholder content for empty
+You can also provide a default value for a block does not exist.
+This allows you to add placeholder content for not exist
 states. You can provide a default value using the second argument:
 
 .. code-block:: php


### PR DESCRIPTION
second argument : return default The block content or $default if the block does not exist.