### PR TITLE
Added information about less secure apps

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -139,6 +139,10 @@ enable TLS SMTP using the ``tls`` option::
 
 The above configuration would enable TLS communication for email messages.
 
+.. warning::
+    You will need to have access for less secure apps enabled in you google account for this to work:
+    `Allowing less secure apps to access your account <https://support.google.com/accounts/answer/6010255?hl=ne>`__.
+
 .. note::
 
     To use SSL + SMTP, you will need to have the SSL configured in your PHP


### PR DESCRIPTION
Google has introduced a setting called "access for less secure apps" that needs to be enabled to be able to use SMTP/IMAP on gmail now.
People keep on asking on about password errors origination from this requirent.