### PR TITLE
Added information about less secure apps

### DIFF
--- a/en/core-utility-libraries/email.rst
+++ b/en/core-utility-libraries/email.rst
@@ -110,6 +110,10 @@ You can configure SSL SMTP servers such as Gmail. To do so, prefix the host with
 
 You can also use ``tls://`` to prefer TLS for connection level encryption.
 
+.. warning::
+    You will need to have access for less secure apps enabled in you google account for this to work:
+    `Allowing less secure apps to access your account <https://support.google.com/accounts/answer/6010255?hl=ne>`__.
+
 .. note::
 
     To use either the ssl:// or tls:// feature, you will need to have the SSL


### PR DESCRIPTION
Google has introduced a setting called "access for less secure apps" that needs to be enabled to be able to use SMTP/IMAP on gmail now.
People keep on asking on about password errors origination from this requirent.