### PR TITLE
Delete link's query string.

### DIFF
--- a/en/core-utility-libraries/email.rst
+++ b/en/core-utility-libraries/email.rst
@@ -112,7 +112,7 @@ You can also use ``tls://`` to prefer TLS for connection level encryption.
 
 .. warning::
     You will need to have access for less secure apps enabled in you google account for this to work:
-    `Allowing less secure apps to access your account <https://support.google.com/accounts/answer/6010255?hl=ne>`__.
+    `Allowing less secure apps to access your account <https://support.google.com/accounts/answer/6010255>`__.
 
 .. note::
 


### PR DESCRIPTION
Avoiding to display error message.