### PR TITLE
Explain that master is not for 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ CakePHP Documentation
 This is the official documentation for the CakePHP project. It is available
 online in HTML, PDF and EPUB formats at http://book.cakephp.org.
 
+This `master` branch is the documentation for **CakePHP 2.x**.
+For **CakePHP 3.x** please see `3.0` branch.
+
 Contributing to the documentation is pretty simple. Please read the
 documentation on contributing to the documentation over on [the
 cookbook](http://book.cakephp.org/2.0/en/contributing/documentation.html) for

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the official documentation for the CakePHP project. It is available
 online in HTML, PDF and EPUB formats at http://book.cakephp.org.
 
 This `master` branch is the documentation for **CakePHP 2.x**.
-For **CakePHP 3.x** please see `3.0` branch.
+For **CakePHP 3.x** please see the `3.0` branch.
 
 Contributing to the documentation is pretty simple. Please read the
 documentation on contributing to the documentation over on [the


### PR DESCRIPTION
We should do the same for 3.0 branch then.
This should clarify some beginners confusion on why cakephp/cakephp master does not match the docs one.