### PR TITLE
Exceptions

### DIFF
--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -213,12 +213,12 @@ pages for items that have not been found::
     
     public function view($id = null)
     {
-        $post = $this->Posts->findById($id)->first();
-        if (empty($post)) {
-            throw new NotFoundException(__('Post not found'));
+        $article = $this->Articles->findById($id)->first();
+        if (empty($article)) {
+            throw new NotFoundException(__('Article not found'));
         }
-        $this->set('post', $post);
-        $this->set('_serialize', ['post']);
+        $this->set('article', $article);
+        $this->set('_serialize', ['article']);
     }
 
 By using exceptions for HTTP errors, you can keep your code both clean, and give
@@ -369,12 +369,12 @@ to indicate failure states. For example::
     
     public function view($id = null)
     {
-        $post = $this->Posts->findById($id)->first();
-        if (empty($post)) {
-            throw new NotFoundException(__('Post not found'));
+        $article = $this->Articles->findById($id)->first();
+        if (empty($article)) {
+            throw new NotFoundException(__('Article not found'));
         }
-        $this->set('post', $post);
-        $this->set('_serialize', ['post']);
+        $this->set('article', 'article);
+        $this->set('_serialize', ['article']);
     }
 
 The above would cause the configured exception handler to catch and

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -131,6 +131,9 @@ Internal Server Error.
 Built in Exceptions for CakePHP
 ===============================
 
+HTTP Exceptions
+---------------
+
 There are several built-in exceptions inside CakePHP, outside of the
 internal framework exceptions, there are several
 exceptions for HTTP methods
@@ -223,6 +226,9 @@ pages for items that have not been found::
 
 By using exceptions for HTTP errors, you can keep your code both clean, and give
 RESTful responses to client applications and users.
+
+Other Built In Exceptions
+-------------------------
 
 In addition, the following framework layer exceptions are available, and will
 be thrown from a number of CakePHP core components:
@@ -321,7 +327,8 @@ be thrown from a number of CakePHP core components:
 
 .. php:exception:: RecordNotFoundException
 
-   The requested record could not be found. This will also set HTTP response headers to 404.
+   The requested record could not be found. This will also set HTTP response
+   headers to 404.
 
 .. php:namespace:: Cake\Routing\Exception
 

--- a/fr/development/errors.rst
+++ b/fr/development/errors.rst
@@ -217,12 +217,12 @@ pas été trouvés::
     
     public function view($id = null)
     {
-        $post = $this->Posts->findById($id)->first();
-        if (empty($post)) {
-            throw new NotFoundException(__('Post not found'));
+        $article = $this->Articles->findById($id)->first();
+        if (empty($article)) {
+            throw new NotFoundException(__('Article not found'));
         }
-        $this->set('post', $post);
-        $this->set('_serialize', ['post']);
+        $this->set('article', $article);
+        $this->set('_serialize', ['article']);
     }
 
 En utilisant les exceptions pour les erreurs HTTP, vous pouvez garder à la
@@ -378,12 +378,12 @@ de votre controller pour indiquer les états d'échec. Par exemple::
     
     public function view($id = null)
     {
-        $post = $this->Posts->findById($id)->first();
-        if (empty($post)) {
-            throw new NotFoundException(__('Post not found'));
+        $article = $this->Articles->findById($id)->first();
+        if (empty($article)) {
+            throw new NotFoundException(__('Article not found'));
         }
-        $this->set('post', $post);
-        $this->set('_serialize', ['post']);
+        $this->set('article', $article);
+        $this->set('_serialize', ['article']);
     }
 
 Ce qui précède va faire que le gestionnaire d'exception attrape et traite

--- a/fr/development/errors.rst
+++ b/fr/development/errors.rst
@@ -142,6 +142,9 @@ Il existe plusieurs exceptions intégrées à l'intérieur de CakePHP, en plus
 des exceptions d'infrastructure internes, et il existe plusieurs exceptions pour
 les méthodes HTTP.
 
+Exceptions HTTP
+---------------
+
 .. php:exception:: BadRequestException
 
     Utilisée pour faire une erreur 400 de Mauvaise Requête.
@@ -231,6 +234,9 @@ clientes et aux utilisateurs.
 
 De plus, les exceptions de couche du framework suivantes sont disponibles, et
 seront lancées à partir de certains components du cœur de CakePHP:
+
+Autres Exceptions Intégrées
+---------------------------
 
 .. php:namespace:: Cake\View\Exception
 


### PR DESCRIPTION
The [exception list](http://book.cakephp.org/3.0/en/development/errors.html#built-in-exceptions-for-cakephp) starts to be really long and hard to navigate or at least hard to see when exception namespace change.

I first took the lazy way by just separating the HTTP from the others, but I think that it would be good to separated also View / Controller / ORM / Console.. etc

I can update the PR if you also think that it's a good idea