### PR TITLE
Change ordering

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -319,6 +319,30 @@ In this situation, the request data for multiple articles should look like::
             'published' => 1
         ],
     ];
+    
+Once you've converted request data into entities you can ``save()`` or
+``delete()`` them::
+
+    // In a controller.
+    foreach ($entities as $entity) {
+        // Save entity
+        $articles->save($entity);
+
+        // Delete entity
+        $articles->delete($entity);
+    }
+
+The above will run a separate transaction for each entity saved. If you'd like
+to process all the entities as a single transaction you can use
+``transactional()``::
+
+    // In a controller.
+    $articles->connection()->transactional(function () use ($articles, $entities) {
+        foreach ($entities as $entity) {
+            $articles->save($entity, ['atomic' => false]);
+        }
+    });
+    
 
 .. _changing-accessible-fields:
 
@@ -346,29 +370,6 @@ ids of associated entities::
 
 The above will keep the association unchanged between Comments and Users for the
 concerned entity.
-
-Once you've converted request data into entities you can ``save()`` or
-``delete()`` them::
-
-    // In a controller.
-    foreach ($entities as $entity) {
-        // Save entity
-        $articles->save($entity);
-
-        // Delete entity
-        $articles->delete($entity);
-    }
-
-The above will run a separate transaction for each entity saved. If you'd like
-to process all the entities as a single transaction you can use
-``transactional()``::
-
-    // In a controller.
-    $articles->connection()->transactional(function () use ($articles, $entities) {
-        foreach ($entities as $entity) {
-            $articles->save($entity, ['atomic' => false]);
-        }
-    });
 
 .. note::
 


### PR DESCRIPTION
I believe the moved paragraph and code sample were out of place, and should be placed as in the change: directly under the section on Converting Multiple Records, rather than in the Changing Accessible Fields section.