### PR TITLE
Added Tip regarding automagic behavior and PaginatorComponent

### DIFF
--- a/en/core-libraries/components/pagination.rst
+++ b/en/core-libraries/components/pagination.rst
@@ -90,6 +90,11 @@ array after the model you wish to configure::
 The values of the ``Post`` and ``Author`` keys could contain all the properties
 that a model/key less ``$paginate`` array could.
 
+.. note::
+    The ``$paginate`` variable is not automatically passed to the :php:class:`PaginatorComponent`'s settings. You must explicitly set the :php:class:`PaginatorComponent`'s settings using the following line::
+
+        $this->Paginator->settings = $this->paginate;
+
 Once the ``$paginate`` variable has been defined, we can use the
 :php:class:`PaginatorComponent`'s ``paginate()`` method from our controller
 action. This will return ``find()`` results from the model. It also sets some


### PR DESCRIPTION
The docs referring to the PaginatorComponent use an additional controller property than default. Instead of declaring the PaginatorComponent settings in $components = array('Paginator' => array( **SETTINGS** )). The user is told to add them to the $paginate property, which is NOT automatically picked up by Cake. In my opinion, due to cake's automatic behavior at times, this should be explicitly stated.