### PR TITLE
Better visibility on scope option deprecation

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -109,6 +109,9 @@ keys.
 - ``passwordHasher`` Password hasher class; Defaults to ``Default``.
 - The ``scope`` and ``contain`` options have been deprecated as of 3.1. Use
   a custom finder instead to modify the query to fetch a user record.
+  
+.. note::
+    ``finder`` scope and contain are deprecated since 3.1.
 
 To configure different fields for user in your ``initialize()`` method::
 


### PR DESCRIPTION
This seems like an oversight to me. Deprecating scope will cause any application which rely on it who upgrade from 3.0 to 3.1 to allow anyone to login to the application without any warnings, notices or exceptions. So I think this should be much clearer in the book, to help people keep their applications secure.