### PR TITLE
Update nomenclature used for virtual fields.

### DIFF
--- a/en/appendices/3-2-migration-guide.rst
+++ b/en/appendices/3-2-migration-guide.rst
@@ -92,26 +92,54 @@ In order to make setting headers related to Cross Origin Requests (CORS) easier,
 a new ``CorsBuilder`` has been added. This class lets you define CORS related
 headers with a fluent interface. See :ref:`cors-headers` for more information.
 
-ORM
----
+RedirectRoute raises an exception on redirect
+---------------------------------------------
+
+``Router::redirect()`` now raises ``Cake\Network\Routing\RedirectException``
+when a redirect condition is reached. This exception is caught by the routing
+filter and converted into a response. This replaces calls to
+``response->send()`` and allows dispatcher filters to interact with redirect
+responses.
+
+
+ORM Improvements
+----------------
 
 * Containing the same association multiple times now works as expected, and the
   query builder functions are now stacked.
+* Function expressions now correctly cast their results. This means that
+  expressions like ``$query->func()->current_date()`` will return datetime
+  instances.
+* Field data that fails validation can now be accessed in entities via the
+  ``invalid()`` method.
+* Entity accessor method lookups are now cached and perform better.
 
 
-Shell
------
+Improved Validator API
+----------------------
+
+The Validator object has a number of new methods that make building validators
+less verbose. For example adding validation rules to a username field can now
+look like::
+
+    $validator->email('username')
+        ->ascii('username')
+        ->lengthBetween('username', [4, 8]);
+
+Console Improvements
+--------------------
 
 * ``Shell::info()``, ``Shell::warn()`` and ``Shell::success()`` were added.
   These helper methods make using commonly used styling simpler.
 * ``Cake\Console\Exception\StopException`` was added.
 * ``Shell::abort()`` was added to replace ``error()``.
 
-exit() no longer called by _stop() and error()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+StopException Added
+-------------------
 
 ``Shell::_stop()`` and ``Shell::error()`` no longer call ``exit()``. Instead
-they raise ``Cake\\Console\\Exception\\StopException``. If your shells/tasks are
+they raise ``Cake\Console\Exception\StopException``. If your shells/tasks are
 catching ``\Exception`` where these methods would have been called, those catch
 blocks will need to be updated so they don't catch the ``StopException``. By not
 calling ``exit()`` testing shells should be easier and require fewer mocks.

--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -469,7 +469,7 @@ Member Visibility
 -----------------
 
 Use PHP5's private and protected keywords for methods and variables. Additionally,
-protected method or variable names start with a single underscore (``_``). Example::
+non-public method or variable names start with a single underscore (``_``). Example::
 
     class A
     {
@@ -479,23 +479,14 @@ protected method or variable names start with a single underscore (``_``). Examp
         {
            /* ... */
         }
-    }
 
-Private methods or variable names start with double underscore (``__``). Example::
+        private $_iAmAPrivateVariable;
 
-    class A
-    {
-        private $__iAmAPrivateVariable;
-
-        private function __iAmAPrivateMethod()
+        private function _iAmAPrivateMethod()
         {
             /* ... */
         }
     }
-
-Try to avoid private methods or variables, though, in favor of protected ones.
-The latter can be accessed or modified by subclasses, whereas private ones
-prevent extension or re-use. Private visibility also makes testing much more difficult.
 
 Example Addresses
 -----------------

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -151,10 +151,10 @@ notation, or using get() and set().
 
 .. _entities-virtual-properties:
 
-Creating Virtual Properties
----------------------------
+Creating Virtual Fields
+-----------------------
 
-By defining accessors you can provide access to properties that do not
+By defining accessors you can provide access to fields/properties that do not
 actually exist. For example if your users table has ``first_name`` and
 ``last_name`` you could create a method for the full name::
 
@@ -173,12 +173,12 @@ actually exist. For example if your users table has ``first_name`` and
 
     }
 
-You can access virtual properties as if they existed on the entity. The property
+You can access virtual fields as if they existed on the entity. The property
 name will be the lower case and underscored version of the method::
 
     echo $user->full_name;
 
-Do bear in mind that virtual properties cannot be used in finds.
+Do bear in mind that virtual fields cannot be used in finds.
 
 
 Checking if an Entity Has Been Modified


### PR DESCRIPTION
Use fields instead of properties. This makes the docs more consistent as other things like find(list) reference fields not properties.

Refs #3701