### PR TITLE
getMock does not accept an empty array, it should be null instead

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1162,7 +1162,7 @@ set correctly by the ``adjust()`` method in our component. We create the file
             $response = new Response();
             $this->controller = $this->getMock(
                 'Cake\Controller\Controller',
-                [],
+                null,
                 [$request, $response]
             );
             $registry = new ComponentRegistry($this->controller);

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -1219,7 +1219,7 @@ dans notre component. Nous créons le fichier
             $response = new Response();
             $this->controller = $this->getMock(
                 'Cake\Controller\Controller',
-                [],
+                null,
                 [$request, $response]
             );
             $registry = new ComponentRegistry($this->controller);


### PR DESCRIPTION
Passing an empty array to `getMock` throws an error:

    Error: Argument 2 passed to Mock_Controller_XXXXXXX::modelFactory() must be callable

It should be null instead.