### PR TITLE
Updated addColumn examples

### DIFF
--- a/en/orm/schema-system.rst
+++ b/en/orm/schema-system.rst
@@ -26,13 +26,11 @@ in a database. This object is returned by the schema reflection features::
 
     // Create a table one column at a time.
     $t = new Table('posts');
-    $t->addColumn('id', [
-      'type' => 'integer',
+    $t->addColumn('id', 'integer', [
       'length' => 11,
       'null' => false,
       'default' => null,
-    ])->addColumn('title', [
-      'type' => 'string',
+    ])->addColumn('title', 'string', [
       'length' => 255,
       // Create a fixed length (char field)
       'fixed' => true
@@ -50,8 +48,9 @@ following two forms are equivalent::
 
     $t->addColumn('title', 'string');
     // and
-    $t->addColumn('title', [
-      'type' => 'string'
+    $t->addColumn('title', 'string', [
+      'null' => true,
+      'default' => 'root beer'
     ]);
 
 While equivalent, the 2nd form allows more detail and control. This emulates
@@ -134,8 +133,7 @@ tell the table object which column in the composite key you want to
 auto-increment::
 
     $t = new Table('posts');
-    $t->addColumn('id', [
-        'type' => 'integer',
+    $t->addColumn('id', 'integer', [
         'autoIncrement' => true,
     ])
     ->addColumn('account_id', 'integer')


### PR DESCRIPTION
Recent versions do not permit the second parameter of `addColumn()` to be an array.

```
vagrant@ts-dev:~/ts$ bin/cake migrations migrate

Welcome to CakePHP v3.1.7 Console
---------------------------------------------------------------
App : src
Path: /home/vagrant/ts/src/
PHP : 5.6.17-3+deb.sury.org~trusty+1
---------------------------------------------------------------
using migration path /home/vagrant/ts/config/Migrations
using environment default
using adapter pgsql
using database ts

 == 20160203181740 AddSalesforceIdToScreens: migrating
Warning Error: preg_match() expects parameter 2 to be string, array given in [/home/vagrant/transitscreen/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/PostgresAdapter.php, line 1172]
```