### PR TITLE
add support for docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 build/*
 */_build/*
+/docs_search
 
 # IDE and editor specific files #
 #################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ services:
 
 before_install:
     - docker pull cakephpfr/docs
-    - docker pull cakephpfr/3.x
+    - docker pull cakephpfr/3.x:php70-fpm
+    - docker pull cakephpfr/3.x:nginx
 
 script:
     - chmod +x start.sh; ./start.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 sudo: required
 
+language: php
+
+php:
+  - 7.0
+
 services:
     - docker
+    - docker-compose
 
 before_install:
     - docker pull cakephpfr/docs
+    - docker pull cakephpfr/3.x
 
 script:
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs:light make html SPHINXOPTS='-W'
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make pdf
+    - chmod +x start.sh; ./start.sh
+    - docker-compose run --rm docs make html SPHINXOPTS='-W'
+    - docker-compose run --rm docs make epub
+    - docker-compose run --rm docs make latex
+    - docker-compose run --rm docs make pdf
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     - docker pull cakephpfr/3.x:nginx
 
 script:
-    - git clone --depth=50 --branch=docker-compose https://github.com/cakephp-fr/docs_search.git docs_search
+    - git clone --depth=50 --branch=master https://github.com/cakephp/docs_search.git docs_search
     - cd docs_search
     - composer install --prefer-dist --no-interaction
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ script:
     - docker-compose run --rm docs make pdf
 
 after_script:
-  - docker-compose stop
-  - docker-compose rm -f
+    - docker-compose stop
+    - docker-compose rm -f
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,19 @@ before_install:
     - docker pull cakephpfr/3.x:nginx
 
 script:
-    - chmod +x start.sh; ./start.sh
+    - git clone --depth=50 --branch=docker-compose https://github.com/cakephp-fr/docs_search.git docs_search
+    - cd docs_search
+    - composer install --prefer-dist --no-interaction
+    - cd ..
+    - docker-compose up -d
     - docker-compose run --rm docs make html SPHINXOPTS='-W'
     - docker-compose run --rm docs make epub
     - docker-compose run --rm docs make latex
     - docker-compose run --rm docs make pdf
+
+after_script:
+  - docker-compose stop
+  - docker-compose rm -f
 
 notifications:
     email: false

--- a/README.mdown
+++ b/README.mdown
@@ -21,9 +21,9 @@ Docker-Compose will create and link multi-containers with all packages needed (i
 
 A `start.sh` script will install all the tools you need to build and serve the docs:
 
-    git clone git@github.com:cakephp-fr/docs-cakephp.git
-    cd docs-cakephp
-    git checkout --track origin/3.0-docker-compose
+    git clone git@github.com:cakephp/docs.git
+    cd docs
+    git checkout --track origin/3.0
     // Just run the `start.sh` script
     ./start.sh
 

--- a/README.mdown
+++ b/README.mdown
@@ -6,56 +6,108 @@ CakePHP Documentation
 
 This is the official documentation for the CakePHP project. It is available online in HTML, PDF and EPUB formats at http://book.cakephp.org.
 
-Contributing to the documentation is pretty simple. Please read the
-documentation on contributing to the documentation over on [the
-cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for
-help. You can read all of the documentation within as its just in plain text
-files, marked up with ReST text formatting.
+Contributing to the documentation is pretty simple. Please read the documentation on contributing to the documentation over on [the cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for help. You can read all of the documentation within as its just in plain text files, marked up with ReST text formatting.
 
-There are two ways for building the documentation: with Docker, or by installing
-the packages directly on your OS.
+There are three ways for using the documentation:
+- with Docker-compose : To build AND serve the documentation.
+- with Docker : Only if you need to build the documentation.
+- or by installing the packages directly on your OS.
 
-Build the Documentation with Docker
------------------------------------
+## Docker-compose : Build and serve the Documentation
 
-Docker will let you create a container with all packages needed to build the
-docs. You need to have docker installed, see the [official docs of
-docker](http://docs.docker.com/mac/started/) for more information.
+Docker-Compose will create and link multi-containers with all packages needed (including elasticsearch). You need to have [Docker](http://docs.docker.com/mac/started/) and [Docker-compose](https://docs.docker.com/compose/install/) installed.
 
-### Use the image on DockerHub ###
+### A shell to build and serve the docs
 
-The easiest way is to use the image already hosted on [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
+A `start.sh` script will install all the tools you need to build and serve the docs:
 
-You can directly run the following commands:
+    git clone git@github.com:cakephp-fr/docs-cakephp.git
+    cd docs-cakephp
+    git checkout --track origin/3.0-docker-compose
+    // Just run the `start.sh` script
+    ./start.sh
+
+This can take a little while the first time you run a command because all
+packages need to be downloaded via images created on
+[DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
+
+The script will do the following:
+- The docs_search repo will be cloned at the root and be installed (composer)
+- The host url for search `http://192.168.99.100:8080/search` will be replaced in `themes/cakephp/static/app.js` with the host given by the command `$(docker-machine ip $(docker-machine active))`
+- The docs will be built in `/build` folder
+- `docker-compose up -d` will be run, creating the 5 following containers:
+    - 2 containers with nginx webserver and a php server : it's a Cakephp 3 app which get the docs search results dynamically from the elasticsearch server
+    - 1 container with an nginx server : it is a http server with the static version of the docs
+    - 1 container with all tools useful to build the docs : python and sphinx
+    - 1 elasticsearch server : contains index for the docs search
+
+To see which containers are up and their host and port names, run:
+
+    docker-compose ps
+
+### Rebuild the docs with Docker-compose
+
+If you need to rebuild the docs after changes you've done, run the following:
 
     # To build the html
     cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephpfr/docs:light make html
+    docker-compose run --rm docs make html
 
     # To build the epub
     cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub
+    docker-compose run --rm docs make epub
 
     # To build the latex
     cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex
+    docker-compose run --rm docs make latex
 
     # To build the pdf
     cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephpfr/docs make pdf
+    docker-compose run --rm docs make pdf
+
+### Repopulate the elasticsearch search index
+
+If you need to repopulate the search index, you can use:
+
+    docker-compose run --rm php /bin/sh -c 'cd /data;make rebuild-index ES_HOST=http://'$(docker-machine ip $(docker-machine active))':9200'
+
+
+## Docker : Build the documentation
+
+Docker will let you create a container with all packages needed to build the docs. You need to have docker installed, see the [official docs of docker](http://docs.docker.com/mac/started/) for more information.
+
+### Use images hosted on Dockerhub
+
+You can run all the following commands to build the docs. This can take a little while the first time you run a command because all packages need to be downloaded via images created on [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
+
+    # To build the html
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs:light make html
+
+    # To build the epub
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make epub
+
+    # To build the latex
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make latex
+
+    # To build the pdf
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make pdf
+
+All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
+
 
 ### Build the image locally ###
 
-There is a Dockerfile included at the root of this repository. You can build
-an image using:
+There is a Dockerfile included at the root of this repository. You can build an image using:
 
     docker build -t cakephp/docs .
 
-This can take a little while, because all packages needs to be downloaded, but
-you'll only need to do this once.
+This can take a little while, because all packages needs to be downloaded, but you'll only need to do this once.
 
-You can run `docker images` to check that the image has been correctly built,
-you should see this output:
+You can run `docker images` to check that the image has been correctly built, you should see this output:
 
 ```
 REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
@@ -63,8 +115,7 @@ cakephp/docs        latest              9783ad2c375b        3 hours ago         
 debian              jessie              3d88cbf54477        12 days ago         125.2 MB
 ```
 
-If you can't see an image called `cakephp/docs`, it can mean that the image has
-been wrongly built. If you notice an image called <none> like the following:
+If you can't see an image called `cakephp/docs`, it can mean that the image has been wrongly built. If you notice an image called <none> like the following:
 
 ```
 REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
@@ -97,11 +148,10 @@ Now that the image is built, you can run all the commands to build the docs:
     cd /path/to/your/local/docs
     docker run -it --rm -v $(pwd):/data cakephp/docs make pdf
 
-All the commands below will create and start containers and build the docs in
-the `build` folder. The `--rm` flag will delete the container after run.
+All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
 
-Build the Documentation Manually
---------------------------------
+
+## Build the Documentation Manually
 
 ### Installing the needed Packages ###
 
@@ -125,8 +175,7 @@ You can install the phpdomain using:
 
 ### Building the Documentation ###
 
-After installing the required packages, you can build the documentation using
-`make`.
+After installing the required packages, you can build the documentation using `make`.
 
     # Create all the HTML docs. Including all the languages.
     make html
@@ -143,12 +192,9 @@ After installing the required packages, you can build the documentation using
     # Populate the search index
     make populate-index
 
-This will generate all the documentation in an HTML form. Other output such as
-'htmlhelp' are not fully complete at this time.
+This will generate all the documentation in an HTML form. Other output such as 'htmlhelp' are not fully complete at this time.
 
-After making changes to the documentation, you can build the HTML version of the
-docs by using `make html` again.  This will build only the HTML files that have
-had changes made to them.
+After making changes to the documentation, you can build the HTML version of the docs by using `make html` again.  This will build only the HTML files that have had changes made to them.
 
 ### Building the PDF ###
 
@@ -162,31 +208,7 @@ Building the PDF is a non-trivial task.
 
 At this point the completed PDF should be in build/latex/en/CakePHPCookbook.pdf.
 
-Contributing
-------------
-
-There are currently a number of outstanding issues that need to be addressed.
-We've tried to flag these with `.. todo::` where possible. To see all the
-outstanding todo's add the following to your `config/all.py`
-
-    todo_include_todos = True
-
-After rebuilding the HTML content, you should see a list of existing todo items
-at the bottom of the table of contents.
-
-You are also welcome to make and suggestions for new content as commits in a
-GitHub fork. Please make any totally new sections in a separate branch. This
-makes changes far easier to integrate later on.
-
-Translations
-------------
-
-Contributing translations requires that you make a new directory using the two
-letter name for your language. As content is translated, directories mirroring
-the english content should be created with localized content.
-
-Making Search Work Locally
---------------------------
+### Making Search Work Locally
 
 * Install elasticsearch. This varies based on your platform, but most
   package managers have a package for it.
@@ -197,3 +219,19 @@ Making Search Work Locally
 * Start elasticsearch with the default configuration.
 * Populate the search index using `make populate-index`.
 * You should now be able to search the docs using elasticsearch.
+
+
+## Contributing
+
+There are currently a number of outstanding issues that need to be addressed. We've tried to flag these with `.. todo::` where possible. To see all the outstanding todo's add the following to your `config/all.py`
+
+    todo_include_todos = True
+
+After rebuilding the HTML content, you should see a list of existing todo items at the bottom of the table of contents.
+
+You are also welcome to make and suggestions for new content as commits in a GitHub fork. Please make any totally new sections in a separate branch. This makes changes far easier to integrate later on.
+
+
+## Translations
+
+Contributing translations requires that you make a new directory using the two letter name for your language. As content is translated, directories mirroring the english content should be created with localized content.

--- a/README.mdown
+++ b/README.mdown
@@ -4,14 +4,15 @@ CakePHP Documentation
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.txt)
 [![Build Status](https://img.shields.io/travis/cakephp/docs/3.0.svg?style=flat-square)](https://travis-ci.org/cakephp/docs)
 
-This is the official documentation for the CakePHP project. It is available online in
-HTML, PDF and EPUB formats at http://book.cakephp.org.
+This is the official documentation for the CakePHP project. It is available
+online in HTML, PDF and EPUB formats at http://book.cakephp.org.
 
-Contributing to the documentation is pretty simple. Please read the documentation on
-contributing to the documentation over on
-[the cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for help.
-You can read all of the documentation within as its just in plain text files, marked up
-with ReST text formatting.
+Contributing to the documentation is pretty simple. Please read the
+documentation on contributing to the documentation over on
+[the cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html)
+for help.
+You can read all of the documentation within as its just in plain text files,
+marked up with ReST text formatting.
 
 There are three ways for using the documentation:
 - with Docker-compose : To build AND serve the documentation.
@@ -20,7 +21,8 @@ There are three ways for using the documentation:
 
 ## Docker-compose : Build and serve the Documentation
 
-Please go to the [docker-compose page](contrib/docker-compose.md) for more information.
+Please go to the [docker-compose page](contrib/docker-compose.md) for more
+information.
 
 ## Docker : Build the documentation
 
@@ -28,18 +30,26 @@ Please go to the [docker page](contrib/docker.md) for more information.
 
 ## Directly install the tools : Build the Documentation
 
-Please go to the [direct install page](contrib/direct-install.md) for more information.
+Please go to the [direct install page](contrib/direct-install.md) for more
+information.
 
 ## Contributing
 
-There are currently a number of outstanding issues that need to be addressed. We've tried to flag these with `.. todo::` where possible. To see all the outstanding todo's add the following to your `config/all.py`
+There are currently a number of outstanding issues that need to be addressed.
+We've tried to flag these with `.. todo::` where possible. To see all the
+outstanding todo's add the following to your `config/all.py`
 
     todo_include_todos = True
 
-After rebuilding the HTML content, you should see a list of existing todo items at the bottom of the table of contents.
+After rebuilding the HTML content, you should see a list of existing todo items
+at the bottom of the table of contents.
 
-You are also welcome to make and suggestions for new content as commits in a GitHub fork. Please make any totally new sections in a separate branch. This makes changes far easier to integrate later on.
+You are also welcome to make and suggestions for new content as commits in a
+GitHub fork. Please make any totally new sections in a separate branch. This
+makes changes far easier to integrate later on.
 
 ## Translations
 
-Contributing translations requires that you make a new directory using the two letter name for your language. As content is translated, directories mirroring the english content should be created with localized content.
+Contributing translations requires that you make a new directory using the two
+letter name for your language. As content is translated, directories mirroring
+the english content should be created with localized content.

--- a/README.mdown
+++ b/README.mdown
@@ -4,7 +4,8 @@ CakePHP Documentation
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.txt)
 [![Build Status](https://img.shields.io/travis/cakephp/docs/3.0.svg?style=flat-square)](https://travis-ci.org/cakephp/docs)
 
-This is the official documentation for the CakePHP project. It is available online in HTML, PDF and EPUB formats at http://book.cakephp.org.
+This is the official documentation for the CakePHP project. It is available online in
+HTML, PDF and EPUB formats at http://book.cakephp.org.
 
 Contributing to the documentation is pretty simple. Please read the documentation on
 contributing to the documentation over on

--- a/README.mdown
+++ b/README.mdown
@@ -15,213 +15,15 @@ There are three ways for using the documentation:
 
 ## Docker-compose : Build and serve the Documentation
 
-Docker-Compose will create and link multi-containers with all packages needed (including elasticsearch). You need to have [Docker](http://docs.docker.com/mac/started/) and [Docker-compose](https://docs.docker.com/compose/install/) installed.
-
-### A shell to build and serve the docs
-
-A `start.sh` script will install all the tools you need to build and serve the docs:
-
-    git clone git@github.com:cakephp/docs.git
-    cd docs
-    git checkout --track origin/3.0
-    // Just run the `start.sh` script
-    ./start.sh
-
-This can take a little while the first time you run a command because all
-packages need to be downloaded via images created on
-[DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
-
-You can now access to the docs server on http://MACHINE_HOST (`$(docker-machine ip $(docker-machine active))` to get it)
-
-The script will do the following:
-- The docs_search repo will be cloned at the root and be installed (composer)
-- The host url for search `http://192.168.99.100:8080/search` will be replaced in `themes/cakephp/static/app.js` with the host given by the command `$(docker-machine ip $(docker-machine active))`
-- The docs will be built in `/build` folder
-- `docker-compose up -d` will be run, creating the 5 following containers:
-    - 2 containers with nginx webserver and a php server : it's a Cakephp 3 app which get the docs search results dynamically from the elasticsearch server
-    - 1 container with an nginx server : it is a http server with the static version of the docs
-    - 1 container with all tools useful to build the docs : python and sphinx
-    - 1 elasticsearch server : contains index for the docs search
-
-To see which containers are up and their host and port names, run:
-
-    docker-compose ps
-
-### Rebuild the docs with Docker-compose
-
-If you need to rebuild the docs after changes you've done, run the following:
-
-    # To build the html
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make html
-
-    # To build the epub
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make epub
-
-    # To build the latex
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make latex
-
-    # To build the pdf
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make pdf
-
-### Repopulate the elasticsearch search index
-
-If you need to repopulate the search index, you can use:
-
-    docker-compose run --rm php /bin/sh -c 'cd /data;make rebuild-index ES_HOST=http://'$(docker-machine ip $(docker-machine active))':9200'
-
+Please go to the [docker-compose page](docs/docker-compose.md) for more information.
 
 ## Docker : Build the documentation
 
-Docker will let you create a container with all packages needed to build the docs. You need to have docker installed, see the [official docs of docker](http://docs.docker.com/mac/started/) for more information.
+Please go to the [docker page](docs/docker.md) for more information.
 
-### Use images hosted on Dockerhub
+## Directly install the tools : Build the Documentation
 
-You can run all the following commands to build the docs. This can take a little while the first time you run a command because all packages need to be downloaded via images created on [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
-
-    # To build the html
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs:light make html
-
-    # To build the epub
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make epub
-
-    # To build the latex
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make latex
-
-    # To build the pdf
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make pdf
-
-All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
-
-
-### Build the image locally ###
-
-There is a Dockerfile included at the root of this repository. You can build an image using:
-
-    docker build -t cakephp/docs .
-
-This can take a little while, because all packages needs to be downloaded, but you'll only need to do this once.
-
-You can run `docker images` to check that the image has been correctly built, you should see this output:
-
-```
-REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-cakephp/docs        latest              9783ad2c375b        3 hours ago         125.2 MB
-debian              jessie              3d88cbf54477        12 days ago         125.2 MB
-```
-
-If you can't see an image called `cakephp/docs`, it can mean that the image has been wrongly built. If you notice an image called <none> like the following:
-
-```
-REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-<none>              <none>              9783ad2c375b        3 hours ago         125.2 MB
-debian              jessie              3d88cbf54477        12 days ago         125.2 MB
-```
-
-Run the following command (with your image id of course):
-
-    // to remove the image
-    docker rmi 9783ad2c375b
-    // re-run the build command
-    docker build -t cakephp/docs .
-
-Now that the image is built, you can run all the commands to build the docs:
-
-    # To build the html
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make html
-
-    # To build the epub
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make epub
-
-    # To build the latex
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make latex
-
-    # To build the pdf
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make pdf
-
-All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
-
-
-## Build the Documentation Manually
-
-### Installing the needed Packages ###
-
-To build the documentation you'll need the following for linux/OS X:
-
-* Make
-* Python
-* Sphinx 1.2.* (currently the make commands will not work with 1.3.* versions
-  and up)
-* PhpDomain for sphinx
-
-You can install sphinx using:
-
-    pip install sphinx==1.2.3
-
-You can install the phpdomain using:
-
-    pip install sphinxcontrib-phpdomain
-
-*To run the pip command, python-pip package must be previously installed.*
-
-### Building the Documentation ###
-
-After installing the required packages, you can build the documentation using `make`.
-
-    # Create all the HTML docs. Including all the languages.
-    make html
-
-    # Create just the English HTML docs.
-    make html-en
-
-    # Create all the EPUB (e-book) docs.
-    make epub
-
-    # Create just the English EPUB docs.
-    make epub-en
-
-    # Populate the search index
-    make populate-index
-
-This will generate all the documentation in an HTML form. Other output such as 'htmlhelp' are not fully complete at this time.
-
-After making changes to the documentation, you can build the HTML version of the docs by using `make html` again.  This will build only the HTML files that have had changes made to them.
-
-### Building the PDF ###
-
-Building the PDF is a non-trivial task.
-
-1. Install LaTeX - This varies by distribution/OS so refer to your package
-   manager. You should install the full LaTeX package. The basic one requires
-   any additional packages to be installed with `tlmgr`
-2. Run `make latex-en`.
-3. Run `make pdf-en`.
-
-At this point the completed PDF should be in build/latex/en/CakePHPCookbook.pdf.
-
-### Making Search Work Locally
-
-* Install elasticsearch. This varies based on your platform, but most
-  package managers have a package for it.
-* Clone the [docs_search](https://github.com/cakephp/docs_search) into a
-  web accessible directory.
-* Modify `searchUrl` in `themes/cakephp/static/app.js` to point at the
-  baseurl for your docs_search clone.
-* Start elasticsearch with the default configuration.
-* Populate the search index using `make populate-index`.
-* You should now be able to search the docs using elasticsearch.
-
+Please go to the [direct install page](docs/direct-install.md) for more information.
 
 ## Contributing
 
@@ -232,7 +34,6 @@ There are currently a number of outstanding issues that need to be addressed. We
 After rebuilding the HTML content, you should see a list of existing todo items at the bottom of the table of contents.
 
 You are also welcome to make and suggestions for new content as commits in a GitHub fork. Please make any totally new sections in a separate branch. This makes changes far easier to integrate later on.
-
 
 ## Translations
 

--- a/README.mdown
+++ b/README.mdown
@@ -31,6 +31,8 @@ This can take a little while the first time you run a command because all
 packages need to be downloaded via images created on
 [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
 
+You can now access to the docs server on http://MACHINE_HOST (`$(docker-machine ip $(docker-machine active))` to get it)
+
 The script will do the following:
 - The docs_search repo will be cloned at the root and be installed (composer)
 - The host url for search `http://192.168.99.100:8080/search` will be replaced in `themes/cakephp/static/app.js` with the host given by the command `$(docker-machine ip $(docker-machine active))`

--- a/README.mdown
+++ b/README.mdown
@@ -15,15 +15,15 @@ There are three ways for using the documentation:
 
 ## Docker-compose : Build and serve the Documentation
 
-Please go to the [docker-compose page](docs/docker-compose.md) for more information.
+Please go to the [docker-compose page](contrib/docker-compose.md) for more information.
 
 ## Docker : Build the documentation
 
-Please go to the [docker page](docs/docker.md) for more information.
+Please go to the [docker page](contrib/docker.md) for more information.
 
 ## Directly install the tools : Build the Documentation
 
-Please go to the [direct install page](docs/direct-install.md) for more information.
+Please go to the [direct install page](contrib/direct-install.md) for more information.
 
 ## Contributing
 

--- a/README.mdown
+++ b/README.mdown
@@ -6,7 +6,11 @@ CakePHP Documentation
 
 This is the official documentation for the CakePHP project. It is available online in HTML, PDF and EPUB formats at http://book.cakephp.org.
 
-Contributing to the documentation is pretty simple. Please read the documentation on contributing to the documentation over on [the cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for help. You can read all of the documentation within as its just in plain text files, marked up with ReST text formatting.
+Contributing to the documentation is pretty simple. Please read the documentation on
+contributing to the documentation over on
+[the cookbook](http://book.cakephp.org/3.0/en/contributing/documentation.html) for help.
+You can read all of the documentation within as its just in plain text files, marked up
+with ReST text formatting.
 
 There are three ways for using the documentation:
 - with Docker-compose : To build AND serve the documentation.

--- a/config/default.conf
+++ b/config/default.conf
@@ -1,0 +1,22 @@
+server {
+    listen       80;
+    server_name  localhost;
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+    location = / {
+        return 301 /en/index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/contrib/direct-install.md
+++ b/contrib/direct-install.md
@@ -22,26 +22,32 @@ You can install the phpdomain using:
 
 ### Building the Documentation ###
 
-After installing the required packages, you can build the documentation using `make`.
+After installing the required packages, you can build the documentation using
+`make`.
 
-    # Create all the HTML docs. Including all the languages.
-    make html
+```bash
+# Create all the HTML docs. Including all the languages.
+make html
 
-    # Create just the English HTML docs.
-    make html-en
+# Create just the English HTML docs.
+make html-en
 
-    # Create all the EPUB (e-book) docs.
-    make epub
+# Create all the EPUB (e-book) docs.
+make epub
 
-    # Create just the English EPUB docs.
-    make epub-en
+# Create just the English EPUB docs.
+make epub-en
 
-    # Populate the search index
-    make populate-index
+# Populate the search index
+make populate-index
+```
 
-This will generate all the documentation in an HTML form. Other output such as 'htmlhelp' are not fully complete at this time.
+This will generate all the documentation in an HTML form. Other output such as
+'htmlhelp' are not fully complete at this time.
 
-After making changes to the documentation, you can build the HTML version of the docs by using `make html` again.  This will build only the HTML files that have had changes made to them.
+After making changes to the documentation, you can build the HTML version of the
+docs by using `make html` again.  This will build only the HTML files that have
+had changes made to them.
 
 ### Building the PDF ###
 

--- a/contrib/direct-install.md
+++ b/contrib/direct-install.md
@@ -1,0 +1,68 @@
+## Build the Documentation Manually
+
+### Installing the needed Packages ###
+
+To build the documentation you'll need the following for linux/OS X:
+
+* Make
+* Python
+* Sphinx 1.2.* (currently the make commands will not work with 1.3.* versions
+  and up)
+* PhpDomain for sphinx
+
+You can install sphinx using:
+
+    pip install sphinx==1.2.3
+
+You can install the phpdomain using:
+
+    pip install sphinxcontrib-phpdomain
+
+*To run the pip command, python-pip package must be previously installed.*
+
+### Building the Documentation ###
+
+After installing the required packages, you can build the documentation using `make`.
+
+    # Create all the HTML docs. Including all the languages.
+    make html
+
+    # Create just the English HTML docs.
+    make html-en
+
+    # Create all the EPUB (e-book) docs.
+    make epub
+
+    # Create just the English EPUB docs.
+    make epub-en
+
+    # Populate the search index
+    make populate-index
+
+This will generate all the documentation in an HTML form. Other output such as 'htmlhelp' are not fully complete at this time.
+
+After making changes to the documentation, you can build the HTML version of the docs by using `make html` again.  This will build only the HTML files that have had changes made to them.
+
+### Building the PDF ###
+
+Building the PDF is a non-trivial task.
+
+1. Install LaTeX - This varies by distribution/OS so refer to your package
+   manager. You should install the full LaTeX package. The basic one requires
+   any additional packages to be installed with `tlmgr`
+2. Run `make latex-en`.
+3. Run `make pdf-en`.
+
+At this point the completed PDF should be in build/latex/en/CakePHPCookbook.pdf.
+
+### Making Search Work Locally
+
+* Install elasticsearch. This varies based on your platform, but most
+  package managers have a package for it.
+* Clone the [docs_search](https://github.com/cakephp/docs_search) into a
+  web accessible directory.
+* Modify `searchUrl` in `themes/cakephp/static/app.js` to point at the
+  baseurl for your docs_search clone.
+* Start elasticsearch with the default configuration.
+* Populate the search index using `make populate-index`.
+* You should now be able to search the docs using elasticsearch.

--- a/contrib/docker-compose.md
+++ b/contrib/docker-compose.md
@@ -1,0 +1,59 @@
+## Docker-compose : Build and serve the Documentation
+
+Docker-Compose will create and link multi-containers with all packages needed (including elasticsearch). You need to have [Docker](http://docs.docker.com/mac/started/) and [Docker-compose](https://docs.docker.com/compose/install/) installed.
+
+### A shell to build and serve the docs
+
+A `start.sh` script will install all the tools you need to build and serve the docs:
+
+    git clone git@github.com:cakephp/docs.git
+    cd docs
+    git checkout --track origin/3.0
+    // Just run the `start.sh` script
+    ./start.sh
+
+This can take a little while the first time you run a command because all
+packages need to be downloaded via images created on
+[DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
+
+You can now access to the docs server on http://MACHINE_HOST (`$(docker-machine ip $(docker-machine active))` to get it)
+
+The script will do the following:
+- The docs_search repo will be cloned at the root and be installed (composer)
+- The host url for search `http://192.168.99.100:8080/search` will be replaced in `themes/cakephp/static/app.js` with the host given by the command `$(docker-machine ip $(docker-machine active))`
+- The docs will be built in `/build` folder
+- `docker-compose up -d` will be run, creating the 5 following containers:
+    - 2 containers with nginx webserver and a php server : it's a Cakephp 3 app which get the docs search results dynamically from the elasticsearch server
+    - 1 container with an nginx server : it is a http server with the static version of the docs
+    - 1 container with all tools useful to build the docs : python and sphinx
+    - 1 elasticsearch server : contains index for the docs search
+
+To see which containers are up and their host and port names, run:
+
+    docker-compose ps
+
+### Rebuild the docs with Docker-compose
+
+If you need to rebuild the docs after changes you've done, run the following:
+
+    # To build the html
+    cd /path/to/your/local/docs
+    docker-compose run --rm docs make html
+
+    # To build the epub
+    cd /path/to/your/local/docs
+    docker-compose run --rm docs make epub
+
+    # To build the latex
+    cd /path/to/your/local/docs
+    docker-compose run --rm docs make latex
+
+    # To build the pdf
+    cd /path/to/your/local/docs
+    docker-compose run --rm docs make pdf
+
+### Repopulate the elasticsearch search index
+
+If you need to repopulate the search index, you can use:
+
+    docker-compose run --rm php /bin/sh -c 'cd /data;make rebuild-index ES_HOST=http://'$(docker-machine ip $(docker-machine active))':9200'

--- a/contrib/docker-compose.md
+++ b/contrib/docker-compose.md
@@ -2,8 +2,10 @@
 
 Docker-Compose will create and link multi-containers with all packages needed
 (including elasticsearch). You need to have
-[Docker](http://docs.docker.com/mac/started/) and
+[Docker](https://docs.docker.com/engine/installation/) and
 [Docker-compose](https://docs.docker.com/compose/install/) installed.
+
+Windows is currently not supported.
 
 ### A shell to build and serve the docs
 
@@ -11,9 +13,8 @@ A `start.sh` script will install all the tools you need to build and serve the
 docs:
 
 ```bash
-git clone git@github.com:cakephp/docs.git
+git clone git@github.com:cakephp/docs.git --branch 3.0
 cd docs
-git checkout --track origin/3.0
 // Just run the `start.sh` script
 ./start.sh
 ```

--- a/contrib/docker-compose.md
+++ b/contrib/docker-compose.md
@@ -1,59 +1,81 @@
 ## Docker-compose : Build and serve the Documentation
 
-Docker-Compose will create and link multi-containers with all packages needed (including elasticsearch). You need to have [Docker](http://docs.docker.com/mac/started/) and [Docker-compose](https://docs.docker.com/compose/install/) installed.
+Docker-Compose will create and link multi-containers with all packages needed
+(including elasticsearch). You need to have
+[Docker](http://docs.docker.com/mac/started/) and
+[Docker-compose](https://docs.docker.com/compose/install/) installed.
 
 ### A shell to build and serve the docs
 
-A `start.sh` script will install all the tools you need to build and serve the docs:
+A `start.sh` script will install all the tools you need to build and serve the
+docs:
 
-    git clone git@github.com:cakephp/docs.git
-    cd docs
-    git checkout --track origin/3.0
-    // Just run the `start.sh` script
-    ./start.sh
+```bash
+git clone git@github.com:cakephp/docs.git
+cd docs
+git checkout --track origin/3.0
+// Just run the `start.sh` script
+./start.sh
+```
 
 This can take a little while the first time you run a command because all
 packages need to be downloaded via images created on
 [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
 
-You can now access to the docs server on http://MACHINE_HOST (`$(docker-machine ip $(docker-machine active))` to get it)
+You can now access to the docs server on http://MACHINE_HOST. To get your
+machine host, run:
 
-The script will do the following:
+```bash
+$(docker-machine ip $(docker-machine active))
+```
+
+The `start.sh` script will do the following:
 - The docs_search repo will be cloned at the root and be installed (composer)
-- The host url for search `http://192.168.99.100:8080/search` will be replaced in `themes/cakephp/static/app.js` with the host given by the command `$(docker-machine ip $(docker-machine active))`
+- The host url for search `http://192.168.99.100:8080/search` will be replaced
+  in `themes/cakephp/static/app.js` with the host given by the command
+  `$(docker-machine ip $(docker-machine active))`
 - The docs will be built in `/build` folder
 - `docker-compose up -d` will be run, creating the 5 following containers:
-    - 2 containers with nginx webserver and a php server : it's a Cakephp 3 app which get the docs search results dynamically from the elasticsearch server
-    - 1 container with an nginx server : it is a http server with the static version of the docs
+    - 2 containers with nginx webserver and a php server : it's a Cakephp 3 app
+      which get the docs search results dynamically from the elasticsearch
+      server
+    - 1 container with an nginx server : it is a http server with the static
+      version of the docs
     - 1 container with all tools useful to build the docs : python and sphinx
     - 1 elasticsearch server : contains index for the docs search
 
 To see which containers are up and their host and port names, run:
 
-    docker-compose ps
+```bash
+docker-compose ps
+```
 
 ### Rebuild the docs with Docker-compose
 
 If you need to rebuild the docs after changes you've done, run the following:
 
-    # To build the html
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make html
+```bash
+# To build the html
+cd /path/to/your/local/docs
+docker-compose run --rm docs make html
 
-    # To build the epub
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make epub
+# To build the epub
+cd /path/to/your/local/docs
+docker-compose run --rm docs make epub
 
-    # To build the latex
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make latex
+# To build the latex
+cd /path/to/your/local/docs
+docker-compose run --rm docs make latex
 
-    # To build the pdf
-    cd /path/to/your/local/docs
-    docker-compose run --rm docs make pdf
+# To build the pdf
+cd /path/to/your/local/docs
+docker-compose run --rm docs make pdf
+```
 
 ### Repopulate the elasticsearch search index
 
 If you need to repopulate the search index, you can use:
 
-    docker-compose run --rm php /bin/sh -c 'cd /data;make rebuild-index ES_HOST=http://'$(docker-machine ip $(docker-machine active))':9200'
+```bash
+docker-compose run --rm php /bin/sh -c 'cd /data;make rebuild-index ES_HOST=http://'$(docker-machine ip $(docker-machine active))':9200'
+```

--- a/contrib/docker.md
+++ b/contrib/docker.md
@@ -1,39 +1,52 @@
 ## Docker : Build the documentation
 
-Docker will let you create a container with all packages needed to build the docs. You need to have docker installed, see the [official docs of docker](http://docs.docker.com/mac/started/) for more information.
+Docker will let you create a container with all packages needed to build the
+docs. You need to have docker installed, see the [official docs of
+docker](http://docs.docker.com/mac/started/) for more information.
 
 ### Use images hosted on Dockerhub
 
-You can run all the following commands to build the docs. This can take a little while the first time you run a command because all packages need to be downloaded via images created on [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
+You can run all the following commands to build the docs. This can take a little
+while the first time you run a command because all packages need to be
+downloaded via images created on
+[DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
 
-    # To build the html
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs:light make html
+```bash
+# To build the html
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp-fr/docs:light make html
 
-    # To build the epub
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make epub
+# To build the epub
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp-fr/docs make epub
 
-    # To build the latex
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make latex
+# To build the latex
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp-fr/docs make latex
 
-    # To build the pdf
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make pdf
+# To build the pdf
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp-fr/docs make pdf
+```
 
-All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
+All the commands below will create and start containers and build the docs in
+the `build` folder. The `--rm` flag will delete the container after run.
 
 
 ### Build the image locally ###
 
-There is a Dockerfile included at the root of this repository. You can build an image using:
+There is a Dockerfile included at the root of this repository. You can build an
+image using:
 
-    docker build -t cakephp/docs .
+```bash
+docker build -t cakephp/docs .
+```
 
-This can take a little while, because all packages needs to be downloaded, but you'll only need to do this once.
+This can take a little while, because all packages needs to be downloaded, but
+you'll only need to do this once.
 
-You can run `docker images` to check that the image has been correctly built, you should see this output:
+You can run `docker images` to check that the image has been correctly built,
+you should see this output:
 
 ```
 REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
@@ -51,27 +64,32 @@ debian              jessie              3d88cbf54477        12 days ago         
 
 Run the following command (with your image id of course):
 
-    // to remove the image
-    docker rmi 9783ad2c375b
-    // re-run the build command
-    docker build -t cakephp/docs .
+```bash
+// to remove the image
+docker rmi 9783ad2c375b
+// re-run the build command
+docker build -t cakephp/docs .
+```
 
 Now that the image is built, you can run all the commands to build the docs:
 
-    # To build the html
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make html
+```bash
+# To build the html
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp/docs make html
 
-    # To build the epub
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make epub
+# To build the epub
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp/docs make epub
 
-    # To build the latex
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make latex
+# To build the latex
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp/docs make latex
 
-    # To build the pdf
-    cd /path/to/your/local/docs
-    docker run -it --rm -v $(pwd):/data cakephp/docs make pdf
+# To build the pdf
+cd /path/to/your/local/docs
+docker run -it --rm -v $(pwd):/data cakephp/docs make pdf
+```
 
-All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
+All the commands below will create and start containers and build the docs in
+the `build` folder. The `--rm` flag will delete the container after run.

--- a/contrib/docker.md
+++ b/contrib/docker.md
@@ -1,0 +1,77 @@
+## Docker : Build the documentation
+
+Docker will let you create a container with all packages needed to build the docs. You need to have docker installed, see the [official docs of docker](http://docs.docker.com/mac/started/) for more information.
+
+### Use images hosted on Dockerhub
+
+You can run all the following commands to build the docs. This can take a little while the first time you run a command because all packages need to be downloaded via images created on [DockerHub](https://hub.docker.com/r/cakephpfr/docs/).
+
+    # To build the html
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs:light make html
+
+    # To build the epub
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make epub
+
+    # To build the latex
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make latex
+
+    # To build the pdf
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp-fr/docs make pdf
+
+All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.
+
+
+### Build the image locally ###
+
+There is a Dockerfile included at the root of this repository. You can build an image using:
+
+    docker build -t cakephp/docs .
+
+This can take a little while, because all packages needs to be downloaded, but you'll only need to do this once.
+
+You can run `docker images` to check that the image has been correctly built, you should see this output:
+
+```
+REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+cakephp/docs        latest              9783ad2c375b        3 hours ago         125.2 MB
+debian              jessie              3d88cbf54477        12 days ago         125.2 MB
+```
+
+If you can't see an image called `cakephp/docs`, it can mean that the image has been wrongly built. If you notice an image called <none> like the following:
+
+```
+REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+<none>              <none>              9783ad2c375b        3 hours ago         125.2 MB
+debian              jessie              3d88cbf54477        12 days ago         125.2 MB
+```
+
+Run the following command (with your image id of course):
+
+    // to remove the image
+    docker rmi 9783ad2c375b
+    // re-run the build command
+    docker build -t cakephp/docs .
+
+Now that the image is built, you can run all the commands to build the docs:
+
+    # To build the html
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make html
+
+    # To build the epub
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make epub
+
+    # To build the latex
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make latex
+
+    # To build the pdf
+    cd /path/to/your/local/docs
+    docker run -it --rm -v $(pwd):/data cakephp/docs make pdf
+
+All the commands below will create and start containers and build the docs in the `build` folder. The `--rm` flag will delete the container after run.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ php:
         - elasticsearch
         - docs-server
 elasticsearch:
-    image: elasticsearch:2.1
+    image: elasticsearch:2.2
     command: elasticsearch -Des.network.host=0.0.0.0
     ports:
         - "9200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+docs:
+    image: cakephpfr/docs
+    volumes:
+        - .:/data
+docs-server:
+    image: nginx:1.9
+    ports:
+        - "80:80"
+    volumes:
+        - ./build/html/:/usr/share/nginx/html
+        - ./config:/etc/nginx/conf.d
+nginx:
+    image: cakephpfr/3.x:nginx
+    ports:
+        - "8080:80"
+    links:
+        - php
+    volumes:
+        - ./docs_search:/var/www/html
+php:
+    image: cakephpfr/3.x:php70-fpm
+    volumes:
+        - .:/data
+        - ./docs_search:/var/www/html
+    links:
+        - elasticsearch
+        - docs-server
+elasticsearch:
+    image: elasticsearch:2.1
+    command: elasticsearch -Des.network.host=0.0.0.0
+    ports:
+        - "9200:9200"
+        - "9300:9300"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# clone and initialize docs_search
+git clone git@github.com:cakephp-fr/docs_search.git
+cd docs_search
+git checkout --track origin/docker-compose
+composer install --prefer-dist --no-interaction
+cd ..
+
+# define machine host and replace it in app.js
+MACHINE_HOST=$(docker-machine ip $(docker-machine active))
+if [ "$(uname)" == "Darwin" ]
+then
+    sed -i '' -- 's/search.cakephp.org/'$MACHINE_HOST':8080/' themes/cakephp/static/app.js
+    sed -i '' -- 's/docs.cakephp.org/http:\/\/'$MACHINE_HOST'/' docs_search/config/app.php
+    sed -i '' -- 's/127.0.0.1/'$MACHINE_HOST'/' docs_search/config/app.php
+    sed -i '' -- "s#var base = location.href.replace(location.protocol + '//' + location.host, '').split('/').slice(0, 2).join('/') + '/';#var base = 'http://"$MACHINE_HOST"/'#" themes/cakephp/static/app.js
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
+then
+    sed -i 's/search.cakephp.org/'$MACHINE_HOST':8080/' themes/cakephp/static/app.js
+    sed -i 's/docs.cakephp.org/http:\/\/'$MACHINE_HOST'/' docs_search/config/app.php
+    docs_search/config/app.php
+    sed -i 's/127.0.0.1/'$MACHINE_HOST'/' docs_search/config/app.php
+    sed -i "s#var base = location.href.replace(location.protocol + '//' + location.host, '').split('/').slice(0, 2).join('/') + '/';#var base = 'http://"$MACHINE_HOST"/'#" themes/cakephp/static/app.js
+# elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]
+# then
+#     # Do something under Windows NT platform
+fi
+
+# Build the docs once before running the containers
+docker run -it --rm -v $(pwd):/data cakephpfr/docs:light make html
+
+# Run all containers
+docker-compose up -d
+sleep 10
+
+# Populate search index in elasticsearch
+docker-compose run --rm php /bin/sh -c 'cd /data;make rebuild-index ES_HOST=http://'$MACHINE_HOST':9200'

--- a/start.sh
+++ b/start.sh
@@ -21,9 +21,6 @@ then
     docs_search/config/app.php
     sed -i 's/127.0.0.1/'$MACHINE_HOST'/' docs_search/config/app.php
     sed -i "s#var base = location.href.replace(location.protocol + '//' + location.host, '').split('/').slice(0, 2).join('/') + '/';#var base = 'http://"$MACHINE_HOST"/'#" themes/cakephp/static/app.js
-# elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]
-# then
-#     # Do something under Windows NT platform
 fi
 
 # Build the docs once before running the containers

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
 # clone and initialize docs_search
-git clone git@github.com:cakephp-fr/docs_search.git
+git clone --depth=50 --branch=docker-compose https://github.com/cakephp-fr/docs_search.git docs_search
 cd docs_search
-git checkout --track origin/docker-compose
 composer install --prefer-dist --no-interaction
 cd ..
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # clone and initialize docs_search
-git clone --depth=50 --branch=docker-compose https://github.com/cakephp-fr/docs_search.git docs_search
+git clone --depth=50 --branch=master https://github.com/cakephp/docs_search.git docs_search
 cd docs_search
 composer install --prefer-dist --no-interaction
 cd ..

--- a/start.sh
+++ b/start.sh
@@ -11,13 +11,13 @@ MACHINE_HOST=$(docker-machine ip $(docker-machine active))
 if [ "$(uname)" == "Darwin" ]
 then
     sed -i '' -- 's/search.cakephp.org/'$MACHINE_HOST':8080/' themes/cakephp/static/app.js
-    sed -i '' -- 's/docs.cakephp.org/http:\/\/'$MACHINE_HOST'/' docs_search/config/app.php
+    sed -i '' -- 's/*.cakephp.org/http:\/\/'$MACHINE_HOST'/' docs_search/config/app.php
     sed -i '' -- 's/127.0.0.1/'$MACHINE_HOST'/' docs_search/config/app.php
     sed -i '' -- "s#var base = location.href.replace(location.protocol + '//' + location.host, '').split('/').slice(0, 2).join('/') + '/';#var base = 'http://"$MACHINE_HOST"/'#" themes/cakephp/static/app.js
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
 then
     sed -i 's/search.cakephp.org/'$MACHINE_HOST':8080/' themes/cakephp/static/app.js
-    sed -i 's/docs.cakephp.org/http:\/\/'$MACHINE_HOST'/' docs_search/config/app.php
+    sed -i 's/*.cakephp.org/http:\/\/'$MACHINE_HOST'/' docs_search/config/app.php
     docs_search/config/app.php
     sed -i 's/127.0.0.1/'$MACHINE_HOST'/' docs_search/config/app.php
     sed -i "s#var base = location.href.replace(location.protocol + '//' + location.host, '').split('/').slice(0, 2).join('/') + '/';#var base = 'http://"$MACHINE_HOST"/'#" themes/cakephp/static/app.js


### PR DESCRIPTION
This PR aims to provide an easy way to serve and build the documentation, including the search repository.
The goal is to be able to clone the docs repository and run a `./start.sh`. Everything is explained in the [README.mdown](https://github.com/cakephp/docs/blob/3.0-docker-compose-support/README.mdown).

The script works on a mac with docker-machine, it should be tested on linux.