### PR TITLE
Update security.rst

### DIFF
--- a/en/security.rst
+++ b/en/security.rst
@@ -9,7 +9,7 @@ The following sections cover those tools:
 
     core-libraries/security
     controllers/components/csrf
-    controllers/components/security
+    Security Component <controllers/components/security>
 
 
 .. meta::


### PR DESCRIPTION
Having two links to "security" in the TOC is a tad confusing. I haven't tried this reStructuredText format before, but the docs say it will work!