### PR TITLE
git clone command changed

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -58,7 +58,7 @@ bug-fixes and up to the minute enhancements.
 These can be accessed from GitHub by cloning the
 `GitHub`_ repository::
 
-    git clone -b 2.7 git://github.com/cakephp/cakephp.git
+    git clone -b 2.x git://github.com/cakephp/cakephp.git
 
 
 Permissions


### PR DESCRIPTION
 Repo 2.7 does not exist anymore, so executing the git glone in the docs won't clone the repo. Changed from 2.7 to 2.x