### PR TITLE
Migrations overhaul

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -1,9 +1,9 @@
 Migrations
 ##########
 
-Migrations is another plugin supported by the core team that helps you
-do schema changes in your database by writing PHP files that can be tracked
-using your version control system.
+Migrations is a plugin supported by the core team that helps you do schema
+changes in your database by writing PHP files that can be tracked using your
+version control system.
 
 It allows you to evolve your database tables over time. Instead of writing
 schema modifications in SQL, this plugin allows you to use an intuitive set
@@ -44,8 +44,8 @@ application in your **config/app.php** file as explained in the
 Overview
 ========
 
-A migration is basically a single PHP file that describes a new version of
-the database. A migration file can create or drop tables, add or remove
+A migration is basically a single PHP file that describes the changes to operate
+to the database. A migration file can create or drop tables, add or remove
 columns, create indexes and even insert data into your database.
 
 Here's an example of a migration::
@@ -86,17 +86,18 @@ Here's an example of a migration::
         }
     }
 
-The migration will add a table to your database named ``products`` with the
+This migration will add a table to your database named ``products`` with the
 following column definitions:
 
-- ``id`` column of type ``integer``
+- ``id`` column of type ``integer`` as primary key
 - ``name`` column of type ``string``
 - ``description`` column of type ``text``
 - ``created`` column of type ``datetime``
+- ``modified`` column of type ``datetime``
 
 .. tip::
 
-    A primary key column named ``id`` will be added **implicitly**.
+    The primary key column named ``id`` will be added **implicitly**.
 
 .. note::
 
@@ -123,7 +124,7 @@ Creating Migrations
 Migration files are stored in the **config/Migrations** directory of your
 application. The name of the migration files are prefixed with the date in
 which they were created, in the format **YYYYMMDDHHMMSS_MigrationName.php**.
-Here are examples of migration filenames::
+Here are examples of migration filenames:
 
 * 20160121163850_CreateProducts.php
 * 20160210133047_AddRatingToProducts.php
@@ -132,7 +133,13 @@ The easiest way to create a migrations file is by using the
 :doc:`/bake/usage` CLI command.
 
 Please make sure you read the official `Phinx documentation <http://docs.phinx.org/en/latest/migrations.html>`_
-in order to know the complete list of methods you can use for writing migration files.
+in order to know the complete list of methods you can use for writing migration
+files.
+
+.. note::
+
+    When using the ``bake`` option, you can still modify the migration before
+    running them if so desired.
 
 Syntax
 ------
@@ -142,12 +149,15 @@ The ``bake`` command syntax follows the form below::
     $ bin/cake bake migration CreateProducts name:string description:text created modified
 
 When using ``bake`` to create tables, add columns and so on, to your
-database, you will usually provide two things :
+database, you will usually provide two things:
 
 * the name of the migration you will generate (``CreateProducts`` in our
-example)
+  example)
 * the columns of the table that will be added or removed in the migration
-(``name:string description:text created modified`` in our example)
+  (``name:string description:text created modified`` in our example)
+
+Due to the conventions, not all schema changes can be performed via these shell
+commands.
 
 Additionally you can create an empty migrations file if you want full control
 over what needs to be executed, by ommiting to specify a columns definition::
@@ -159,11 +169,15 @@ Migrations file name
 
 Migration names can follow any of the following patterns:
 
-* **Create a table**: (``/^(Create)(.*)/``) Creates the specified table.
-* **Drop a table**: (``/^(Drop)(.*)/``) Drops the specified table. Ignores specified field arguments.
-* **Add a field**: (``/^(Add).*(?:To)(.*)/``) Adds fields to the specified table.
-* **Remove a field**: (``/^(Remove).*(?:From)(.*)/``) Removes fields from the specified table.
-* **Alter a table**:  (``/^(Alter)(.*)/``) Alters the specified table. An alias for CreateTable and AddField.
+* (``/^(Create)(.*)/``) Creates the specified table.
+* (``/^(Drop)(.*)/``) Drops the specified table.
+  Ignores specified field arguments
+* (``/^(Add).*(?:To)(.*)/``) Adds fields to the specified
+  table
+* (``/^(Remove).*(?:From)(.*)/``) Removes fields from the
+  specified table
+* (``/^(Alter)(.*)/``) Alters the specified table. An alias
+  for CreateTable and AddField.
 
 You can also use the ``underscore_form`` as the name for your migrations
 i.e. ``create_products``.
@@ -176,13 +190,20 @@ i.e. ``create_products``.
     version of the plugin the migration name would be in the underscore form,
     i.e. ``20160121164955_create_products.php``.
 
+.. warning::
+
+    Migration names are used as migration class names, and thus may collide with
+    other migrations if the class names are not unique. In this case, it may be
+    necessary to manually override the name at a later date, or simply change the
+    name you are specifying.
+
 Columns definition
 ~~~~~~~~~~~~~~~~~~
 
 When using columns in the command line, it may be handy to remember that they
 follow the following pattern::
 
-    field:fieldType[length]:indexType:indexName
+    fieldName:fieldType[length]:indexType:indexName
 
 For instance, the following are all valid ways of specifying an email field:
 
@@ -212,6 +233,12 @@ can be:
 * binary
 * boolean
 * uuid
+
+There are some heuristics to choosing fieldtypes when left unspecified or set to
+an invalid value. Default field type is ``string``:
+
+* id: integer
+* created, modified, updated: datetime
 
 Creating a table
 ----------------
@@ -335,6 +362,12 @@ Executing the command line above will generate::
         }
     }
 
+If no length is specified, lengths for certain type of columns are defaulted:
+
+* string: 255
+* integer: 11
+* biginteger: 20
+
 Removing a column from a table
 ------------------------------
 
@@ -369,7 +402,7 @@ database, you can run the ``migration_snapshot`` command::
 It will generate a migration file called **YYYYMMDDHHMMSS_Initial.php**
 containing all the create statements for all tables in your database.
 
-By default, the snapshot will be created by connection to the database defined
+By default, the snapshot will be created by connecting to the database defined
 in the ``default`` connection configuration.
 If you need to bake a snapshot from a different datasource, you can use the
 ``--connection`` option::
@@ -396,7 +429,7 @@ to the snapshot of your plugin.
 .. note::
 
     When baking a snapshot for a plugin, the migration files will be created
-    in your plugin **config** directory.
+    in your plugin's **config/Migrations** directory.
 
 Be aware that when you bake a snapshot, it is automatically added to the phinx
 log table as migrated.
@@ -410,7 +443,6 @@ The commands
 Once you have generated or written your migration file, you need to execute the
 following command to apply the changes to your database::
 
-```bash
     # Run all the migrations
     $ bin/cake migrations migrate
 
@@ -433,15 +465,13 @@ following command to apply the changes to your database::
     # Migrations can also be run for plugins. Simply use the ``--plugin`` option
     # or ``-p`` for short
     $ bin/cake migrations migrate -p MyAwesomePlugin
-```
 
 ``rollback`` : Reverting Migrations
 -----------------------------------
 
 The Rollback command is used to undo previous migrations executed by this
-plugin. It is the reverse action of the ``migrate`` command.
+plugin. It is the reverse action of the ``migrate`` command::
 
-```bash
     # You can rollback to the previous migration by using the
     # ``rollback`` command::
     $ bin/cake migrations rollback
@@ -449,7 +479,6 @@ plugin. It is the reverse action of the ``migrate`` command.
     # You can also pass a migration version number to rollback
     # to a specific version::
     $ bin/cake migrations rollback -t 20150103081132
-```
 
 You can also use the ``--source``, ``--connection`` and ``--plugin`` option just
 like for the ``migrate`` command.
@@ -529,41 +558,37 @@ leverages the `Phinx library seed feature <http://docs.phinx.org/en/latest/seedi
 By default, seed files will be looked for in the ``config/Seeds`` directory of
 your application. Please make sure you follow `Phinx instructions to build your seed files` <http://docs.phinx.org/en/latest/seeding.html#creating-a-new-seed-class>`_.
 
-As for migrations, a ``bake`` interface is provided for seed files:
+As for migrations, a ``bake`` interface is provided for seed files::
 
-```bash
-# This will create a ArticlesSeed.php file in the directory config/Seeds of your application
-# By default, the table the seed will try to alter is the "tableized" version of the seed filename
-$ bin/cake bake seed Articles
+    # This will create a ArticlesSeed.php file in the directory config/Seeds of your application
+    # By default, the table the seed will try to alter is the "tableized" version of the seed filename
+    $ bin/cake bake seed Articles
 
-# You specify the name of the table the seed files will alter by using the ``--table`` option
-$ bin/cake bake seed Articles --table my_articles_table
+    # You specify the name of the table the seed files will alter by using the ``--table`` option
+    $ bin/cake bake seed Articles --table my_articles_table
 
-# You can specify a plugin to bake into
-$ bin/cake bake seed Articles --plugin PluginName
+    # You can specify a plugin to bake into
+    $ bin/cake bake seed Articles --plugin PluginName
 
-# You can specify an alternative connection when generating a seeder.
-$ bin/cake bake seed Articles --connection connection
-```
+    # You can specify an alternative connection when generating a seeder.
+    $ bin/cake bake seed Articles --connection connection
 
-To seed your database, you can use the ``seed`` subcommand:
+To seed your database, you can use the ``seed`` subcommand::
 
-```bash
-# Without parameters, the seed subcommand will run all available seeders in the target directory, in alphabetical order.
-$ bin/cake migrations seed
+    # Without parameters, the seed subcommand will run all available seeders in the target directory, in alphabetical order.
+    $ bin/cake migrations seed
 
-# You can specify only one seeder to be run using the `--seed` option
-$ bin/cake migrations seed --seed ArticlesSeed
+    # You can specify only one seeder to be run using the `--seed` option
+    $ bin/cake migrations seed --seed ArticlesSeed
 
-# You can run seeders from an alternative directory
-$ bin/cake migrations seed --source AlternativeSeeds
+    # You can run seeders from an alternative directory
+    $ bin/cake migrations seed --source AlternativeSeeds
 
-# You can run seeders from a plugin
-$ bin/cake migrations seed --plugin PluginName
+    # You can run seeders from a plugin
+    $ bin/cake migrations seed --plugin PluginName
 
-# You can run seeders from a specific connection
-$ bin/cake migrations seed --connection connection
-```
+    # You can run seeders from a specific connection
+    $ bin/cake migrations seed --connection connection
 
 Be aware that, as opposed to migrations, seeders are not tracked, which means
 that the same seeder can be applied multiple times.
@@ -590,7 +615,7 @@ migrations from a non-shell environment, directly from an app, by using the new
 ``Migrations`` class. This can be handy in case you are developing a plugin
 installer for a CMS for instance.
 The ``Migrations`` class allows you to run the following commands from the
-migrations shell :
+migrations shell:
 
 * migrate
 * rollback
@@ -728,7 +753,7 @@ it to the table declaration::
     }
 
 Compared to the previous way of dealing with primary key, this method gives you
-the ability to have more control over the primary key column definition :
+the ability to have more control over the primary key column definition:
 unsigned or not, limit, comment, etc.
 
 All baked migrations and snapshot will use this new way when necessary.
@@ -770,3 +795,12 @@ no way of adding a column to an existing table with a different collation than
 the table or the database.
 Only ``MySQL`` and ``SqlServer`` supports this configuration key for the time
 being.
+
+Updating columns name and using Table objects
+---------------------------------------------
+
+If you use a CakePHP ORM Table object to manipulate values from your database
+along with renaming or removing a column, make sure you create a new instance of
+your Table object after the update() call. The Table object registry is cleared
+after an update() call in order to refresh the schema that is reflected and
+stored in the Table object upon instantiation.

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -122,47 +122,103 @@ Creating Migrations
 
 Migration files are stored in the **config/Migrations** directory of your
 application. The name of the migration files are prefixed with the date in
-which they were created, in the format **YYYYMMDDHHMMSS_MigrationName.php**::
+which they were created, in the format **YYYYMMDDHHMMSS_MigrationName.php**.
+Here are examples of migration filenames::
 
-    -rw-rw-r-- 1 user user  914 Jan 21 10:38 20160121163850_CreateProducts.php
+* 20160121163850_CreateProducts.php
+* 20160210133047_AddRatingToProducts.php
 
 The easiest way to create a migrations file is by using the
-:doc:`/bake/usage` CLI command. The following ``Bake`` command would create a
-migration to add a ``products`` table::
+:doc:`/bake/usage` CLI command.
+
+Please make sure you read the official `Phinx documentation <http://docs.phinx.org/en/latest/migrations.html>`_
+in order to know the complete list of methods you can use for writing migration files.
+
+Syntax
+------
+
+The ``bake`` command syntax follows the form below::
 
     $ bin/cake bake migration CreateProducts name:string description:text created modified
 
-    Welcome to CakePHP v3.1.7 Console
-    ---------------------------------------------------------------
-    App : src
-    Path: /home/user/Work/php/cakeblog/src/
-    PHP : 5.5.28-1+deb.sury.org~precise+1
-    ---------------------------------------------------------------
+When using ``bake`` to create tables, add columns and so on, to your
+database, you will usually provide two things :
 
-    Creating file /home/user/Work/php/cakeblog/config/Migrations/20160121163249_CreateProducts.php
-    Wrote `/home/user/Work/php/cakeblog/config/Migrations/20160121163249_CreateProducts.php`
+* the name of the migration you will generate (``CreateProducts`` in our
+example)
+* the columns of the table that will be added or removed in the migration
+(``name:string description:text created modified`` in our example)
+
+Additionally you can create an empty migrations file if you want full control
+over what needs to be executed, by ommiting to specify a columns definition::
+
+    $ bin/cake migrations create MyCustomMigration
+
+Migrations file name
+~~~~~~~~~~~~~~~~~~~~
+
+Migration names can follow any of the following patterns:
+
+* **Create a table**: (``/^(Create)(.*)/``) Creates the specified table.
+* **Drop a table**: (``/^(Drop)(.*)/``) Drops the specified table. Ignores specified field arguments.
+* **Add a field**: (``/^(Add).*(?:To)(.*)/``) Adds fields to the specified table.
+* **Remove a field**: (``/^(Remove).*(?:From)(.*)/``) Removes fields from the specified table.
+* **Alter a table**:  (``/^(Alter)(.*)/``) Alters the specified table. An alias for CreateTable and AddField.
 
 You can also use the ``underscore_form`` as the name for your migrations
-i.e. create_products::
-
-    $ bin/cake bake migration create_products name:string description:text created modified
-
-    Welcome to CakePHP v3.1.17 Console
-    ---------------------------------------------------------------
-    App : src
-    Path: /home/user/Work/php/cakeblog/src/
-    ---------------------------------------------------------------
-
-    Creating file /home/user/Work/php/cakeblog/config/Migrations/20160121164955_CreateProducts.php
-    Wrote `/home/user/Work/php/cakeblog/config/Migrations/20160121164955_CreateProducts.php`
+i.e. ``create_products``.
 
 .. versionadded:: cakephp/migrations 1.5.2
 
-    Camelizing the name of the migration file was introduced in v1.5.2 of the
-    `migrations plugin <https://github.com/cakephp/migrations/>`_. This version
-    of the plugin is only available with a release of CakePHP >= to 3.1. Prior
-    to this version of the plugin the migration name would be in the
-    underscore form: 20160121164955_create_products.php.
+    As of v1.5.2 of the `migrations plugin <https://github.com/cakephp/migrations/>`_,
+    the migration filename will be automatically camelized. This version of the
+    plugin is only available with a release of CakePHP >= to 3.1. Prior to this
+    version of the plugin the migration name would be in the underscore form,
+    i.e. ``20160121164955_create_products.php``.
+
+Columns definition
+~~~~~~~~~~~~~~~~~~
+
+When using columns in the command line, it may be handy to remember that they
+follow the following pattern::
+
+    field:fieldType[length]:indexType:indexName
+
+For instance, the following are all valid ways of specifying an email field:
+
+* ``email:string:unique``
+* ``email:string:unique:EMAIL_INDEX``
+* ``email:string[120]:unique:EMAIL_INDEX``
+
+The ``length`` parameter for the ``fieldType`` is optional and should always be
+written between bracket.
+
+Fields named ``created`` and ``modified`` will automatically be set to the type
+``datetime``.
+
+Field types a those generically made available by the ``Phinx`` library. Those
+can be:
+
+* string
+* text
+* integer
+* biginteger
+* float
+* decimal
+* datetime
+* timestamp
+* time
+* date
+* binary
+* boolean
+* uuid
+
+Creating a table
+----------------
+
+You can use ``bake`` to create a table::
+
+    $ bin/cake bake migration CreateProducts name:string description:text created modified
 
 The command line above will generate a migration file that resembles::
 
@@ -202,17 +258,18 @@ The command line above will generate a migration file that resembles::
         }
     }
 
+Adding columns to an existing table
+-----------------------------------
 
-If the migration name in the command line is of the form "AddXXXToYYY" or "RemoveXXXFromYYY"
-and is followed by a list of column names and types then a migration file
-containing the code for creating or dropping the columns will be generated::
+If the migration name in the command line is of the form "AddXXXToYYY" and is
+followed by a list of column names and types then a migration file containing
+the code for creating the columns will be generated::
 
-    bin/cake bake migration AddPriceToProducts price:decimal
+    $ bin/cake bake migration AddPriceToProducts price:decimal
 
 Executing the command line above will generate::
 
     <?php
-
     use Migrations\AbstractMigration;
 
     class AddPriceToProducts extends AbstractMigration
@@ -225,41 +282,16 @@ Executing the command line above will generate::
         }
     }
 
-.. versionadded:: cakephp/migrations 1.4
-
-If you need to specify a field length, you can do it within brackets in the
-field type, ie::
-
-    bin/cake bake migration AddFullDescriptionToProducts full_description:string[60]
-
-Executing the command line above will generate::
-
-    <?php
-
-    use Migrations\AbstractMigration;
-
-    class AddFullDescriptionToProducts extends AbstractMigration
-    {
-        public function change()
-        {
-            $table = $this->table('products');
-            $table->addColumn('full_description', 'string', [
-                    'default' => null,
-                    'limit' => 60,
-                    'null' => false,
-                 ])
-                  ->update();
-        }
-    }
+Adding a column as index to a table
+-----------------------------------
 
 It is also possible to add indexes to columns::
 
-    bin/cake bake migration AddNameIndexToProducts name:string:index
+    $ bin/cake bake migration AddNameIndexToProducts name:string:index
 
 will generate::
 
     <?php
-
     use Migrations\AbstractMigration;
 
     class AddNameIndexToProducts extends AbstractMigration
@@ -273,28 +305,47 @@ will generate::
         }
     }
 
-When using fields in the command line it may be handy to remember that they
-follow the following pattern::
 
-    field:fieldType:indexType:indexName
+Specifying field length
+-----------------------
 
-For instance, the following are all valid ways of specifying an email field:
+.. versionadded:: cakephp/migrations 1.4
 
-* ``email:string:unique``
-* ``email:string:unique:EMAIL_INDEX``
+If you need to specify a field length, you can do it within brackets in the
+field type, ie::
 
-Fields named ``created`` and ``modified`` will automatically be set to the type
-``datetime``.
+    $ bin/cake bake migration AddFullDescriptionToProducts full_description:string[60]
+
+Executing the command line above will generate::
+
+    <?php
+    use Migrations\AbstractMigration;
+
+    class AddFullDescriptionToProducts extends AbstractMigration
+    {
+        public function change()
+        {
+            $table = $this->table('products');
+            $table->addColumn('full_description', 'string', [
+                'default' => null,
+                'limit' => 60,
+                'null' => false,
+            ])
+            ->update();
+        }
+    }
+
+Removing a column from a table
+------------------------------
 
 In the same way, you can generate a migration to remove a column by using the
-command line::
+command line, if the migration name is of the form "RemoveXXXFromYYY"::
 
     bin/cake bake migration RemovePriceFromProducts price
 
 creates the file::
 
     <?php
-
     use Migrations\AbstractMigration;
 
     class RemovePriceFromProducts extends AbstractMigration
@@ -305,39 +356,6 @@ creates the file::
             $table->removeColumn('price');
         }
     }
-
-Migration Names can follow any of the following patterns:
-
-* Create a table: (``/^(Create)(.*)/``) Creates the specified table.
-* Drop a table: (``/^(Drop)(.*)/``) Drops the specified table. Ignores specified field arguments.
-* Add a field: (``/^(Add).*(?:To)(.*)/``) Adds fields to the specified table.
-* Remove a field: (``/^(Remove).*(?:From)(.*)/``) Removes fields from the specified table.
-* Alter a table:  (``/^(Alter)(.*)/``) Alters the specified table. An alias for CreateTable and AddField.
-
-Field types a those generically made available by the ``Phinx`` library. Those
-can be:
-
-* string
-* text
-* integer
-* biginteger
-* float
-* decimal
-* datetime
-* timestamp
-* time
-* date
-* binary
-* boolean
-* uuid
-
-Additionally you can create an empty migrations file if you want full control
-over what needs to be executed::
-
-    bin/cake migrations create MyCustomMigration
-
-Please make sure you read the official `Phinx documentation <http://docs.phinx.org/en/latest/migrations.html>`_
-in order to know the complete list of methods you can use for writing migration files.
 
 Generating Migrations From Existing Databases
 ---------------------------------------------
@@ -359,7 +377,6 @@ adding new tables to the database, you can use the second argument of the
 ``table()`` method::
 
     <?php
-
     use Migrations\AbstractMigration;
 
     class CreateProductsTable extends AbstractMigration
@@ -383,8 +400,7 @@ The above will create a ``CHAR(36)`` ``id`` column that is also the primary key.
     it as the primary key in the id field, otherwise you may get an error
     regarding duplicate id fields, i.e.::
 
-        bin/cake bake migration CreateProducts id:uuid:primary name:string description:text created modified
-
+        $ bin/cake bake migration CreateProducts id:uuid:primary name:string description:text created modified
 
 Additionally, since Migrations 1.3, a new way to deal with primary key was
 introduced. To do so, your migration class should extend the new
@@ -395,7 +411,6 @@ need to manually create the column that will be used as a primary key and add
 it to the table declaration::
 
     <?php
-
     use Migrations\AbstractMigration;
 
     class CreateProductsTable extends AbstractMigration
@@ -635,3 +650,50 @@ pass them to the method::
     $status = $migrations->status();
     // This one with the "default" connection
     $migrate = $migrations->migrate(['connection' => 'default']);
+
+Seeding your database
+=====================
+
+As of 1.5.5, you can use the ``migrations`` shell to seed your database. This
+leverages the `Phinx library seed feature <http://docs.phinx.org/en/latest/seeding.html>`_.
+By default, seed files will be looked for in the ``config/Seeds`` directory of
+your application. Please make sure you follow `Phinx instructions to build your seed files` <http://docs.phinx.org/en/latest/seeding.html#creating-a-new-seed-class>`_.
+
+As for migrations, a ``bake`` interface is provided for seed files:
+
+```bash
+# This will create a ArticlesSeed.php file in the directory config/Seeds of your application
+# By default, the table the seed will try to alter is the "tableized" version of the seed filename
+bin/cake bake seed Articles
+
+# You specify the name of the table the seed files will alter by using the ``--table`` option
+bin/cake bake seed Articles --table my_articles_table
+
+# You can specify a plugin to bake into
+bin/cake bake seed Articles --plugin PluginName
+
+# You can specify an alternative connection when generating a seeder.
+bin/cake bake seed Articles --connection connection
+```
+
+To seed your database, you can use the ``seed`` subcommand:
+
+```bash
+# Without parameters, the seed subcommand will run all available seeders in the target directory, in alphabetical order.
+bin/cake migrations seed
+
+# You can specify only one seeder to be run using the `--seed` option
+bin/cake migrations seed --seed ArticlesSeed
+
+# You can run seeders from an alternative directory
+bin/cake migrations seed --source AlternativeSeeds
+
+# You can run seeders from a plugin
+bin/cake migrations seed --plugin PluginName
+
+# You can run seeders from a specific connection
+bin/cake migrations seed --connection connection
+```
+
+Be aware that, as opposed to migrations, seeders are not tracked, which means
+that the same seeder can be applied multiple times.

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -357,17 +357,311 @@ creates the file::
         }
     }
 
-Generating Migrations From Existing Databases
----------------------------------------------
+Generating migrations from an existing database
+===============================================
 
 If you are dealing with a pre-existing database and want to start using
 migrations, or to version control the initial schema of your application's
 database, you can run the ``migration_snapshot`` command::
 
-    bin/cake bake migration_snapshot Initial
+    $ bin/cake bake migration_snapshot Initial
 
-It will generate a migration file called **Initial** containing all the create
-statements for all tables in your database.
+It will generate a migration file called **YYYYMMDDHHMMSS_Initial.php**
+containing all the create statements for all tables in your database.
+
+By default, the snapshot will be created by connection to the database defined
+in the ``default`` connection configuration.
+If you need to bake a snapshot from a different datasource, you can use the
+``--connection`` option::
+
+    $ bin/cake bake migration_snapshot Initial --connection my_other_connection
+
+You can also make sure the snapshot includes only the tables for which you have
+defined the corresponding model classes by using the ``--require-table`` flag::
+
+    $ bin/cake bake migration_snapshot Initial --require-table
+
+When using the ``--require-table`` flag, the shell will look through your
+application ``Table`` classes and will only add the model tables in the snapshot
+.
+
+The same logic will be applied implicitly if you wish to bake a snapshot for a
+plugin. To do so, you need to use the ``--plugin`` option::
+
+    $ bin/cake bake migration_snapshot Initial --plugin MyPlugin
+
+Only the tables which have a ``Table`` object model class defined will be added
+to the snapshot of your plugin.
+
+.. note::
+
+    When baking a snapshot for a plugin, the migration files will be created
+    in your plugin **config** directory.
+
+Be aware that when you bake a snapshot, it is automatically added to the phinx
+log table as migrated.
+
+The commands
+============
+
+``migrate`` : Applying Migrations
+---------------------------------
+
+Once you have generated or written your migration file, you need to execute the
+following command to apply the changes to your database::
+
+```bash
+    # Run all the migrations
+    $ bin/cake migrations migrate
+
+    # Migrate to a specific version using the ``--target`` option
+    # or ``-t`` for short.
+    # The value is the timestamp that is prefixed to the migrations file name::
+    $ bin/cake migrations migrate -t 20150103081132
+
+    # By default, migration files are looked for in the **config/Migrations**
+    # directory. You can specify the directory using the ``--source`` option
+    # or ``-s`` for short.
+    # The following example will run migrations in the **config/Alternate**
+    # directory
+    $ bin/cake migrations migrate -s Alternate
+
+    # You can run migrations to a different connection than the ``default`` one
+    # using the ``--connection`` option or ``-c`` for short
+    $ bin/cake migrations migrate -c my_custom_connection
+
+    # Migrations can also be run for plugins. Simply use the ``--plugin`` option
+    # or ``-p`` for short
+    $ bin/cake migrations migrate -p MyAwesomePlugin
+```
+
+``rollback`` : Reverting Migrations
+-----------------------------------
+
+The Rollback command is used to undo previous migrations executed by this
+plugin. It is the reverse action of the ``migrate`` command.
+
+```bash
+    # You can rollback to the previous migration by using the
+    # ``rollback`` command::
+    $ bin/cake migrations rollback
+
+    # You can also pass a migration version number to rollback
+    # to a specific version::
+    $ bin/cake migrations rollback -t 20150103081132
+```
+
+You can also use the ``--source``, ``--connection`` and ``--plugin`` option just
+like for the ``migrate`` command.
+
+``status`` : Migrations Status
+------------------------------
+
+The Status command prints a list of all migrations, along with their current
+status. You can use this command to determine which migrations have been run::
+
+    $ bin/cake migrations status
+
+You can also output the results as a JSON formatted string using the
+``--format`` option (or ``-f`` for short)::
+
+    $ bin/cake migrations --format json
+
+You can also use the ``--source``, ``--connection`` and ``--plugin`` option just
+like for the ``migrate`` command.
+
+``mark_migrated`` : Marking a migration as migrated
+---------------------------------------------------
+
+.. versionadded:: 1.4.0
+
+It can sometimes be useful to mark a set of migrations as migrated without
+actually running them.
+In order to do this, you can use the ``mark_migrated`` command.
+The command works seamlessly as the other commands.
+
+You can mark all migrations as migrated using this command::
+
+    $ bin/cake migrations mark_migrated
+
+You can also mark all migrations up to a specific version as migrated using
+the ``--target`` option::
+
+    $ bin/cake migrations mark_migrated --target=20151016204000
+
+If you do not want the targeted migration to be marked as migrated during the
+process, you can use the ``--exclude`` flag with it::
+
+    $ bin/cake migrations mark_migrated --target=20151016204000 --exclude
+
+Finally, if you wish to mark only the targeted migration as migrated, you can
+use the ``--only`` flag::
+
+    $ bin/cake migrations mark_migrated --target=20151016204000 --only
+
+You can also use the ``--source``, ``--connection`` and ``--plugin`` option just
+like for the ``migrate`` command.
+
+.. note::
+
+    When you bake a snapshot with the ``cake bake migration_snapshot``
+    command, the created migration will automatically be marked as migrated.
+
+.. deprecated:: 1.4.0
+
+    The following way of using the command has been deprecated. Use it only
+    if you are using a version of the plugin < 1.4.0.
+
+This command expects the migration version number as argument::
+
+    $ bin/cake migrations mark_migrated 20150420082532
+
+If you wish to mark all migrations as migrated, you can use the ``all`` special
+value. If you use it, it will mark all found migrations as migrated::
+
+    $ bin/cake migrations mark_migrated all
+
+``seed`` : Seeding your database
+--------------------------------
+
+As of 1.5.5, you can use the ``migrations`` shell to seed your database. This
+leverages the `Phinx library seed feature <http://docs.phinx.org/en/latest/seeding.html>`_.
+By default, seed files will be looked for in the ``config/Seeds`` directory of
+your application. Please make sure you follow `Phinx instructions to build your seed files` <http://docs.phinx.org/en/latest/seeding.html#creating-a-new-seed-class>`_.
+
+As for migrations, a ``bake`` interface is provided for seed files:
+
+```bash
+# This will create a ArticlesSeed.php file in the directory config/Seeds of your application
+# By default, the table the seed will try to alter is the "tableized" version of the seed filename
+$ bin/cake bake seed Articles
+
+# You specify the name of the table the seed files will alter by using the ``--table`` option
+$ bin/cake bake seed Articles --table my_articles_table
+
+# You can specify a plugin to bake into
+$ bin/cake bake seed Articles --plugin PluginName
+
+# You can specify an alternative connection when generating a seeder.
+$ bin/cake bake seed Articles --connection connection
+```
+
+To seed your database, you can use the ``seed`` subcommand:
+
+```bash
+# Without parameters, the seed subcommand will run all available seeders in the target directory, in alphabetical order.
+$ bin/cake migrations seed
+
+# You can specify only one seeder to be run using the `--seed` option
+$ bin/cake migrations seed --seed ArticlesSeed
+
+# You can run seeders from an alternative directory
+$ bin/cake migrations seed --source AlternativeSeeds
+
+# You can run seeders from a plugin
+$ bin/cake migrations seed --plugin PluginName
+
+# You can run seeders from a specific connection
+$ bin/cake migrations seed --connection connection
+```
+
+Be aware that, as opposed to migrations, seeders are not tracked, which means
+that the same seeder can be applied multiple times.
+
+Using Migrations In Plugins
+===========================
+
+Plugins can also provide migration files. This makes plugins that are intended
+to be distributed much more portable and easy to install. All commands in the
+Migrations plugin support the ``--plugin`` or ``-p`` option that will scope the
+execution to the migrations relative to that plugin::
+
+    $ bin/cake migrations status -p PluginName
+
+    $ bin/cake migrations migrate -p PluginName
+
+Running Migrations in a non-shell environment
+=============================================
+
+.. versionadded:: cakephp/migrations 1.2.0
+
+Since the release of version 1.2 of the migrations plugin, you can run
+migrations from a non-shell environment, directly from an app, by using the new
+``Migrations`` class. This can be handy in case you are developing a plugin
+installer for a CMS for instance.
+The ``Migrations`` class allows you to run the following commands from the
+migrations shell :
+
+* migrate
+* rollback
+* markMigrated
+* status
+* seed
+
+Each of these commands has a method defined in the ``Migrations`` class.
+
+Here is how to use it::
+
+    use Migrations\Migrations;
+
+    $migrations = new Migrations();
+
+    // Will return an array of all migrations and their status
+    $status = $migrations->status();
+
+    // Will return true if success. If an error occurred, an exception will be thrown
+    $migrate = $migrations->migrate();
+
+    // Will return true if success. If an error occurred, an exception will be thrown
+    $rollback = $migrations->rollback();
+
+    // Will return true if success. If an error occurred, an exception will be thrown
+    $markMigrated = $migrations->markMigrated(20150804222900);
+
+    // Will return true if success. If an error occurred, an exception will be thrown
+    $seeded = $migrations->seed();
+
+The methods can accept an array of parameters that should match options from
+the commands::
+
+    use Migrations\Migrations;
+
+    $migrations = new Migrations();
+
+    // Will return an array of all migrations and their status
+    $status = $migrations->status(['connection' => 'custom', 'source' => 'MyMigrationsFolder']);
+
+You can pass any options the shell commands would take.
+The only exception is the ``markMigrated`` command which is expecting the
+version number of the migrations to mark as migrated as first argument. Pass
+the array of parameters as the second argument for this method.
+
+Optionally, you can pass these parameters in the constructor of the class.
+They will be used as default and this will prevent you from having to pass
+them on each method call::
+
+    use Migrations\Migrations;
+
+    $migrations = new Migrations(['connection' => 'custom', 'source' => 'MyMigrationsFolder']);
+
+    // All the following calls will be done with the parameters passed to the Migrations class constructor
+    $status = $migrations->status();
+    $migrate = $migrations->migrate();
+
+If you need to override one or more default parameters for one call, you can
+pass them to the method::
+
+    use Migrations\Migrations;
+
+    $migrations = new Migrations(['connection' => 'custom', 'source' => 'MyMigrationsFolder']);
+
+    // This call will be made with the "custom" connection
+    $status = $migrations->status();
+    // This one with the "default" connection
+    $migrate = $migrations->migrate(['connection' => 'default']);
+
+Tips and tricks
+===============
 
 Creating Custom Primary Keys
 ----------------------------
@@ -476,224 +770,3 @@ no way of adding a column to an existing table with a different collation than
 the table or the database.
 Only ``MySQL`` and ``SqlServer`` supports this configuration key for the time
 being.
-
-Applying Migrations
-===================
-
-Once you have generated or written your migration file, you need to execute the
-following command to apply the changes to your database::
-
-    bin/cake migrations migrate
-
-To migrate to a specific version then use the ``--target`` parameter or -t for
-short::
-
-    bin/cake migrations migrate -t 20150103081132
-
-That corresponds to the timestamp that is prefixed to the migrations file name.
-
-Reverting Migrations
-====================
-
-The Rollback command is used to undo previous migrations executed by this
-plugin. It is the reverse action of the ``migrate`` command.
-
-You can rollback to the previous migration by using the ``rollback`` command::
-
-    bin/cake migrations rollback
-
-You can also pass a migration version number to rollback to a specific version::
-
-    bin/cake migrations rollback -t 20150103081132
-
-Migrations Status
-=================
-
-The Status command prints a list of all migrations, along with their current
-status. You can use this command to determine which migrations have been run::
-
-    bin/cake migrations status
-
-Marking a migration as migrated
-===============================
-
-.. versionadded:: 1.4.0
-
-It can sometimes be useful to mark a set of migrations as migrated without
-actually running them.
-In order to do this, you can use the ``mark_migrated`` command.
-The command works seamlessly as the other commands.
-
-You can mark all migrations as migrated using this command::
-
-    bin/cake migrations mark_migrated
-
-You can also mark all migrations up to a specific version as migrated using
-the ``--target`` option::
-
-    bin/cake migrations mark_migrated --target=20151016204000
-
-If you do not want the targeted migration to be marked as migrated during the
-process, you can use the ``--exclude`` flag with it::
-
-    bin/cake migrations mark_migrated --target=20151016204000 --exclude
-
-Finally, if you wish to mark only the targeted migration as migrated, you can
-use the ``--only`` flag::
-
-    bin/cake migrations mark_migrated --target=20151016204000 --only
-
-.. note::
-
-    When you bake a snapshot with the ``cake bake migration_snapshot``
-    command, the created migration will automatically be marked as migrated.
-
-.. deprecated:: 1.4.0
-
-    The following way of using the command has been deprecated. Use it only
-    if you are using a version of the plugin < 1.4.0.
-
-This command expects the migration version number as argument::
-
-    bin/cake migrations mark_migrated 20150420082532
-
-If you wish to mark all migrations as migrated, you can use the ``all`` special
-value. If you use it, it will mark all found migrations as migrated::
-
-    bin/cake migrations mark_migrated all
-
-Using Migrations In Plugins
-===========================
-
-Plugins can also provide migration files. This makes plugins that are intended
-to be distributed much more portable and easy to install. All commands in the
-Migrations plugin support the ``--plugin`` or ``-p`` option that will scope the
-execution to the migrations relative to that plugin::
-
-    bin/cake migrations status -p PluginName
-
-    bin/cake migrations migrate -p PluginName
-
-
-Running Migrations in a non-shell environment
-=============================================
-
-.. versionadded:: cakephp/migrations 1.2.0
-
-Since the release of version 1.2 of the migrations plugin, you can run
-migrations from a non-shell environment, directly from an app, by using the new
-``Migrations`` class. This can be handy in case you are developing a plugin
-installer for a CMS for instance.
-The ``Migrations`` class allows you to run the following commands from the
-migrations shell :
-
-* migrate
-* rollback
-* markMigrated
-* status
-
-Each of these commands has a method defined in the ``Migrations`` class.
-
-Here is how to use it::
-
-    use Migrations\Migrations;
-
-    $migrations = new Migrations();
-
-    // Will return an array of all migrations and their status
-    $status = $migrations->status();
-
-    // Will return true if success. If an error occurred, an exception will be thrown
-    $migrate = $migrations->migrate();
-
-    // Will return true if success. If an error occurred, an exception will be thrown
-    $rollback = $migrations->rollback();
-
-    // Will return true if success. If an error occurred, an exception will be thrown
-    $markMigrated = $migrations->markMigrated(20150804222900);
-
-The methods can accept an array of parameters that should match options from
-the commands::
-
-    use Migrations\Migrations;
-
-    $migrations = new Migrations();
-
-    // Will return an array of all migrations and their status
-    $status = $migrations->status(['connection' => 'custom', 'source' => 'MyMigrationsFolder']);
-
-You can pass any options the shell commands would take.
-The only exception is the ``markMigrated`` command which is expecting the
-version number of the migrations to mark as migrated as first argument. Pass
-the array of parameters as the second argument for this method.
-
-Optionally, you can pass these parameters in the constructor of the class.
-They will be used as default and this will prevent you from having to pass
-them on each method call::
-
-    use Migrations\Migrations;
-
-    $migrations = new Migrations(['connection' => 'custom', 'source' => 'MyMigrationsFolder']);
-
-    // All the following calls will be done with the parameters passed to the Migrations class constructor
-    $status = $migrations->status();
-    $migrate = $migrations->migrate();
-
-If you need to override one or more default parameters for one call, you can
-pass them to the method::
-
-    use Migrations\Migrations;
-
-    $migrations = new Migrations(['connection' => 'custom', 'source' => 'MyMigrationsFolder']);
-
-    // This call will be made with the "custom" connection
-    $status = $migrations->status();
-    // This one with the "default" connection
-    $migrate = $migrations->migrate(['connection' => 'default']);
-
-Seeding your database
-=====================
-
-As of 1.5.5, you can use the ``migrations`` shell to seed your database. This
-leverages the `Phinx library seed feature <http://docs.phinx.org/en/latest/seeding.html>`_.
-By default, seed files will be looked for in the ``config/Seeds`` directory of
-your application. Please make sure you follow `Phinx instructions to build your seed files` <http://docs.phinx.org/en/latest/seeding.html#creating-a-new-seed-class>`_.
-
-As for migrations, a ``bake`` interface is provided for seed files:
-
-```bash
-# This will create a ArticlesSeed.php file in the directory config/Seeds of your application
-# By default, the table the seed will try to alter is the "tableized" version of the seed filename
-bin/cake bake seed Articles
-
-# You specify the name of the table the seed files will alter by using the ``--table`` option
-bin/cake bake seed Articles --table my_articles_table
-
-# You can specify a plugin to bake into
-bin/cake bake seed Articles --plugin PluginName
-
-# You can specify an alternative connection when generating a seeder.
-bin/cake bake seed Articles --connection connection
-```
-
-To seed your database, you can use the ``seed`` subcommand:
-
-```bash
-# Without parameters, the seed subcommand will run all available seeders in the target directory, in alphabetical order.
-bin/cake migrations seed
-
-# You can specify only one seeder to be run using the `--seed` option
-bin/cake migrations seed --seed ArticlesSeed
-
-# You can run seeders from an alternative directory
-bin/cake migrations seed --source AlternativeSeeds
-
-# You can run seeders from a plugin
-bin/cake migrations seed --plugin PluginName
-
-# You can run seeders from a specific connection
-bin/cake migrations seed --connection connection
-```
-
-Be aware that, as opposed to migrations, seeders are not tracked, which means
-that the same seeder can be applied multiple times.


### PR DESCRIPTION
Currently, there are two places where you can find documentation about the migrations plugins : the cookbook and the README of the plugin.

There are a few problems with this :
- it's hard, cumbersome and time consuming to keep both in sync (they are currently not synced)
- they do not contain the same informations (some infos are in the README and not the doc and _vice-versa_)

This PR is an overhaul of the migrations docs : I reorganized some sections, added titles to some, rewrote sentences, added more examples, added sections from the README that were not in the docs.

Ultimately, my plan is to remove all documentation from the README (except for installation instructions and maybe a small paragraph about what the plugin can be used for) : kind of like what is already in place for ``bake``.
This will reduce the amount of work needed to have a good documentation for the plugin and prevent keeping two source of informations in sync.

That being said, this is going to need a good read-proof as well as opinions on the new content order / sections / examples / etc.

Since reading the diff is going to be complicated and that it does not render the doc layout, I attached a screenshot of the page compiled to make it easier to read the new doc. Beware, it is 15000 pixels high.

Once it is corrected, I'll completely rewrite the doc in French.

[Link to the page screenshot](https://cloud.githubusercontent.com/assets/5243386/12990685/f1b78152-d10b-11e5-84d5-f711f0be54fe.png)

