### PR TITLE
Plugin::loadAll() doesn't work lazily

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -316,9 +316,9 @@ Also make the ``AppController`` if you don't have one already::
 A plugin's ``AppController`` can hold controller logic common to all controllers
 in a plugin but is not required if you don't want to use one.
 
-Before you can access your controllers, you'll need to ensure the plugin is
+`Plugin::loadAll();` does **not** automatically default to `Plugin::loadAll([['routes' => true]]);`, so before you can access your controllers, you'll need to ensure the plugin is
 loaded and connect some routes. In your **config/bootstrap.php** add the
-following::
+following:
 
     Plugin::load('ContactManager', ['routes' => true]);
 


### PR DESCRIPTION
Imho it needs to be more clear that Plugin::loadAll() isn't really a completely lazy anymore in 3.x.   If you go through this tutorial there is a part that makes it sound like you can use loadAll() in place of load() and it will need no more configuration.  But actually you can't, and you have to specify routes is true, because it does not default to that with loadAll().