### PR TITLE
Added bytes

### DIFF
--- a/en/core-libraries/file-folder.rst
+++ b/en/core-libraries/file-folder.rst
@@ -418,7 +418,7 @@ File API
 
 .. php:method:: size()
 
-    Returns the filesize.
+    Returns the filesize in bytes.
 
 .. php:method:: writable()
 


### PR DESCRIPTION
It wasn't clear to me if the filesize was in bit or in bytes. So I looked into the CORE-code. Now this won't be necessary.