### PR TITLE
Add a note about the migrations plugin, deployment and the orm cache

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -804,7 +804,7 @@ your Table object after the ``update()`` call. The Table object registry is
 cleared after an ``update()`` call in order to refresh the schema that is
 reflected and stored in the Table object upon instantiation.
 
-Migrations and deployment
+Migrations and Deployment
 -------------------------
 
 If you use the plugin when deploying your application, be sure to clear the ORM

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -803,3 +803,18 @@ along with renaming or removing a column, make sure you create a new instance of
 your Table object after the ``update()`` call. The Table object registry is
 cleared after an ``update()`` call in order to refresh the schema that is
 reflected and stored in the Table object upon instantiation.
+
+Migrations and deployment
+-------------------------
+
+If you use the plugin when deploying your application, be sure to clear the ORM
+cache so it renews the column metadata of your tables.
+Otherwise, you might end up having errors about columns not existing when
+performing operations on those new columns.
+The CakePHP Core includes a :doc:`ORM Cache Shell <console-and-shells/orm-cache>`
+that you can use to perform this operation::
+
+    $ bin/cake orm_cache clear
+
+Be sure to read the :doc:`ORM Cache Shell <console-and-shells/orm-cache>`
+section of the cookbook if you want to know more about this shell.

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -847,11 +847,11 @@ Si vous utilisez le plugin dans vos processus de déploiement, assurez-vous de
 vider le cache de l'ORM pour qu'il renouvelle les _metadata_ des colonnes de vos
 tables.
 Autrement, vous pourrez rencontrer des erreurs de colonnes inexistantes quand
-vous effecturez des opérations sur vos nouvelles colonnes.
+vous effectuerez des opérations sur vos nouvelles colonnes.
 Le Core de CakePHP inclut un :doc:`Shell de Cache de l'ORM <console-and-shells/orm-cache>`
 que vous pouvez utilisez pour vider le cache::
 
     $ bin/cake orm_cache clear
 
-Veuillez pour référez à la section du cookbook à propos du :doc:`Shell du Cache de l’ORM <console-and-shells/orm-cache>`
+Veuillez vous référer à la section du cookbook à propos du :doc:`Shell du Cache de l’ORM <console-and-shells/orm-cache>`
 si vous voulez plus de détails à propos de ce shell.

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -840,3 +840,18 @@ de créer une nouvelle instance de votre objet Table après l'appel à
 ``update()``. Le registre de l'objet Table est nettoyé après un appel à
 ``update()`` afin de rafraîchir le schéma qui est reflèté et stocké dans l'objet
 Table lors de l'instanciation.
+
+Migrations et déploiement
+-------------------------
+Si vous utilisez le plugin dans vos processus de déploiement, assurez-vous de
+vider le cache de l'ORM pour qu'il renouvelle les _metadata_ des colonnes de vos
+tables.
+Autrement, vous pourrez rencontrer des erreurs de colonnes inexistantes quand
+vous effecturez des opérations sur vos nouvelles colonnes.
+Le Core de CakePHP inclus un :doc:`Shell de Cache de l'ORM <orm-cache>` que vous
+pouvez utilisez pour vider le cache::
+
+    $ bin/cake orm_cache clear
+
+Veuillez pour référez à la section du cookbook à propos du :doc:`Shell du Cache de l’ORM <orm-cache>`
+si vous voulez plus de détails à propos de ce shell.

--- a/fr/migrations.rst
+++ b/fr/migrations.rst
@@ -848,10 +848,10 @@ vider le cache de l'ORM pour qu'il renouvelle les _metadata_ des colonnes de vos
 tables.
 Autrement, vous pourrez rencontrer des erreurs de colonnes inexistantes quand
 vous effecturez des opérations sur vos nouvelles colonnes.
-Le Core de CakePHP inclus un :doc:`Shell de Cache de l'ORM <orm-cache>` que vous
-pouvez utilisez pour vider le cache::
+Le Core de CakePHP inclut un :doc:`Shell de Cache de l'ORM <console-and-shells/orm-cache>`
+que vous pouvez utilisez pour vider le cache::
 
     $ bin/cake orm_cache clear
 
-Veuillez pour référez à la section du cookbook à propos du :doc:`Shell du Cache de l’ORM <orm-cache>`
+Veuillez pour référez à la section du cookbook à propos du :doc:`Shell du Cache de l’ORM <console-and-shells/orm-cache>`
 si vous voulez plus de détails à propos de ce shell.


### PR DESCRIPTION
Following https://github.com/cakephp/migrations/issues/199 and https://github.com/cakephp/migrations/pull/201

This adds a note about using the ORM cache shell to clear the metadata cache if the migrations plugin is used during a deployment process.