### PR TITLE
give more TableRegistry::get() examples

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -34,6 +34,17 @@ passing it to the ``save()`` method in the ``Table`` class::
         // The $article entity contains the id now
         $id = $article->id;
     }
+    
+If your model (eg. ArticlesTable.php) is in a plugin you may find that TableRegistry::get() still works but that your validation rules or other callbacks in ArticlesTable.php may not be triggering because TableRegistry::get() builds a default model for the table. Here are some examples for TableRegistry::get() that you may use when the class is in a plugin::
+
+Plugin example (same as above except)::
+
+    $articlesTable = TableRegistry::get('PluginName.Articles');
+    
+Composer installed plugin example (same as above except)::
+
+    $articlesTable = TableRegistry::get('UserName/PluginName.Articles');
+
 
 Updating Data
 -------------

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -35,7 +35,7 @@ passing it to the ``save()`` method in the ``Table`` class::
         $id = $article->id;
     }
     
-If your model (eg. ArticlesTable.php) is in a plugin you may find that TableRegistry::get() still works but that your validation rules or other callbacks in ArticlesTable.php may not be triggering because TableRegistry::get() builds a default model for the table. Here are some examples for TableRegistry::get() that you may use when the class is in a plugin::
+If your model (eg. ArticlesTable.php) is in a plugin you may find that TableRegistry::get() still works but that your validation rules or other callbacks in ArticlesTable.php may not be triggering.  This is because TableRegistry::get() builds a default model for the table. Here are some examples for TableRegistry::get() that you may want to use when your class is in a plugin::
 
 Plugin example (same as above except)::
 
@@ -43,7 +43,7 @@ Plugin example (same as above except)::
     
 Composer installed plugin example (same as above except)::
 
-    $articlesTable = TableRegistry::get('UserName/PluginName.Articles');
+    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
 
 
 Updating Data


### PR DESCRIPTION
I had to dig through a bunch of cakedc plugins to try and find why my validation rules weren't being respected.  I think it will help other people to know that TableRegistry::get() works if you use the right convention for a table name, but that it won't find your plugin rules if you don't specify the correct path to the ArticlesTable.php file.