### PR TITLE
Add needed apostrophe

### DIFF
--- a/en/core-libraries/security.rst
+++ b/en/core-libraries/security.rst
@@ -75,7 +75,7 @@ Hashing Data
 .. php:staticmethod:: hash( $string, $type = NULL, $salt = false )
 
 Create a hash from string using given method. Fallback on next
-available method. If ``$salt`` is set to ``true``, the applications salt
+available method. If ``$salt`` is set to ``true``, the application's salt
 value will be used::
 
     // Using the application's salt value


### PR DESCRIPTION
The possessive "application's" needs an apostrophe.