### PR TITLE
Replace default templates with link to API

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1606,38 +1606,9 @@ You can also change the templates at runtime using the ``templates()`` method::
 List of Templates
 -----------------
 
-A list of the default templates, their default format and the variables they
-expect are:
-
-* ``button`` : ``<button{{attrs}}>{{text}}</button>``
-* ``checkbox`` : ``<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>``
-* ``checkboxFormGroup`` : ``{{label}}``
-* ``checkboxWrapper`` : ``<div class="checkbox">{{label}}</div>``
-* ``dateWidget`` : ``{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}``
-* ``error`` : ``<div class="error-message">{{content}}</div>``
-* ``errorList`` : ``<ul>{{content}}</ul>``
-* ``errorItem`` : ``<li>{{text}}</li>``
-* ``file`` : ``<input type="file" name="{{name}}"{{attrs}}>``
-* ``fieldset`` : ``<fieldset{{attrs}}>{{content}}</fieldset>``
-* ``formStart`` : ``<form{{attrs}}>``
-* ``formEnd`` : ``</form>``
-* ``formGroup`` : ``{{label}}{{input}}``
-* ``hiddenBlock`` : ``<div style="display:none;">{{content}}</div>``
-* ``input`` : ``<input type="{{type}}" name="{{name}}"{{attrs}}/>``
-* ``inputSubmit`` : ``<input type="{{type}}"{{attrs}}/>``
-* ``inputContainer`` : ``<div class="input {{type}}{{required}}">{{content}}</div>``
-* ``inputContainerError`` : ``<div class="input {{type}}{{required}} error">{{content}}{{error}}</div>``
-* ``label`` : ``<label{{attrs}}>{{text}}</label>``
-* ``nestingLabel`` : ``{{hidden}}<label{{attrs}}>{{input}}{{text}}</label>``
-* ``legend`` : ``<legend>{{text}}</legend>``
-* ``option`` : ``<option value="{{value}}"{{attrs}}>{{text}}</option>``
-* ``optgroup`` : ``<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>``
-* ``select`` : ``<select name="{{name}}"{{attrs}}>{{content}}</select>``
-* ``selectMultiple`` : ``<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>``
-* ``radio`` : ``<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>``
-* ``radioWrapper`` : ``{{label}}``
-* ``textarea`` : ``<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>``
-* ``submitContainer`` : ``<div class="submit">{{content}}</div>``
+The list of default templates, their default format and the variables they
+expect can be found at the
+`FormHelper API documentation <http://api.cakephp.org/3.2/class-Cake.View.Helper.FormHelper.html#%24_defaultConfig>`_.
 
 In addition to these templates, the ``input()`` method will attempt to use
 distinct templates for each input container. For example, when creating


### PR DESCRIPTION
Refs: https://github.com/cakephp/docs/pull/3791#issuecomment-192228516

Again, a URL endpoint for the last 3.x and 2.x API docs would help us to keep such links up to date.
But at least like this now, we only have to keep the link up to date.