### PR TITLE
Add use for EntityInterface in Behavior example.

### DIFF
--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -148,6 +148,7 @@ behavior should now look like::
 
     namespace App\Model\Behavior;
 
+    use Cake\Datasource\EntityInterface;
     use Cake\Event\Event;
     use Cake\ORM\Behavior;
     use Cake\ORM\Entity;

--- a/fr/orm/behaviors.rst
+++ b/fr/orm/behaviors.rst
@@ -150,6 +150,7 @@ behavior devrait maintenant ressembler à ceci::
 
     namespace App\Model\Behavior;
 
+    use Cake\Datasource\EntityInterface;
     use Cake\Event\Event;
     use Cake\ORM\Behavior;
     use Cake\ORM\Entity;


### PR DESCRIPTION
In the current documentation (http://book.cakephp.org/3.0/en/orm/behaviors.html#defining-event-listeners), there is a missing `use` for `EntityInterface`, which results in a PHP warning:

> Warning (4096): Argument 2 passed to App\Model\Behavior\SluggableBehavior::beforeSave() must be an instance of App\Model\Behavior\EntityInterface, instance of Cake\ORM\Entity given, called in /srv/www/typename.fr/public_html/vendor/cakephp/cakephp/src/Event/EventManager.php on line 390 and defined [APP/Model/Behavior/SluggableBehavior.php, line 27]