### PR TITLE
Fixed cors documentation

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -757,7 +757,7 @@ related headers with a fluent interface::
         ->allowOrigin(['*.cakephp.org'])
         ->allowMethods(['GET', 'POST'])
         ->allowHeaders(['X-CSRF-Token'])
-        ->allowAuthentication()
+        ->allowCredentials()
         ->exposeHeaders(['Link'])
         ->maxAge(300)
         ->build();


### PR DESCRIPTION
allowAuthentication() isn't a method on the class.