### PR TITLE
Lack equal symbol

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -610,7 +610,7 @@ Which would generate the SQL similar to::
     WHERE (
     (author_id = 2 OR author_id = 5)
     AND published = 1
-    AND view_count > 10)
+    AND view_count >= 10)
 
 The ``or_()`` and ``and_()`` methods also allow you to use functions as their
 parameters. This is often easier to read than method chaining::


### PR DESCRIPTION
At line 603: the query return "gte('view_count', 10)".
But at line 613: the condition is "view_count > 10".
It should be "view_count >= 10", i think.