### PR TITLE
get status results

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -494,7 +494,7 @@ status. You can use this command to determine which migrations have been run::
 You can also output the results as a JSON formatted string using the
 ``--format`` option (or ``-f`` for short)::
 
-    $ bin/cake migrations --format json
+    $ bin/cake migrations status --format json
 
 You can also use the ``--source``, ``--connection`` and ``--plugin`` option just
 like for the ``migrate`` command.


### PR DESCRIPTION
While getting migration statuses in json there should be a status keyword, which was missing.