### PR TITLE
Empty option wouldn't be printed

### DIFF
--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -1275,7 +1275,6 @@ Ex: name=data[User][username], id=UserUsername
     .. code-block:: html
 
         <select name="data[User][gender]" id="UserGender">
-        <option value=""></option>
         <option value="M">Male</option>
         <option value="F">Female</option>
         </select>


### PR DESCRIPTION
It's not in the `$options` array.