### PR TITLE
Added note about turning debug on for tests with tokens

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -945,10 +945,15 @@ token mismatches::
         $this->enableSecurityToken();
         $this->post('/posts/add', ['title' => 'Exciting news!']);
     }
+    
+It is also important to enable debug in tests that use tokens to prevent the
+SecurityComponent from thinking the debug token is being used in a non-debug
+environment.
 
 .. versionadded:: 3.1.2
     The ``enableCsrfToken()`` and ``enableSecurityToken()`` methods were added
     in 3.1.2
+
 
 
 Assertion methods


### PR DESCRIPTION
We started having failures on our CI server that I eventually traced down to [these lines][1] not being happy about our test environment not having `'debug' => true`. 

Let me know if these changes explain the issue well enough.

[1]: https://github.com/cakephp/cakephp/blob/3.2.6/src/Controller/Component/SecurityComponent.php#L361-L366