### PR TITLE
Add docs for epilog() and empty() recommendations

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -544,6 +544,72 @@ underscore character, for example::
 
     define('LONG_NAMED_CONSTANT', 2);
 
+Avoid empty()
+=============
+
+While ``empty()`` is an easy to use function it can mask errors and cause
+unintended effects when ``'0'`` and ``0`` are used. When variables or properties
+are already defined the usage of ``empty()`` is not recommended. When working
+with variables, it is better to rely on type-coercion to boolean instead of
+``empty()``::
+
+    function manipulate($var)
+    {
+        // not recommended, $var is already defined in the scope
+        if (empty($var)) {
+            // ...
+        }
+
+        // Use boolean type coercion
+        if (!$var) {
+            // ...
+        }
+        if ($var) {
+            // ...
+        }
+    }
+
+When dealing with defined properties you should favour ``null`` checks over
+``empty()``/``isset()`` checks::
+
+    class Thing
+    {
+        private $property; // defined
+
+        public function readProperty()
+        {
+            // not recommended as the property is defined in the class
+            if (!isset($this->property)) {
+                // ...
+            }
+            // recommended
+            if ($this->property === null) {
+
+            }
+        }
+    }
+
+When working with arrays, it is better to merge in defaults over using
+``empty()`` checks. By merging in defaults, you can ensure that required keys
+are defined::
+
+    function doWork(array $array)
+    {
+        // Merge defaults to remove need for empty checks.
+        $array += [
+            'key' => null,
+        ];
+
+        // not recommended, the key is already set
+        if (isset($array['key'])) {
+            // ...
+        }
+
+        // recommended
+        if ($array['key'] !== null) {
+            // ...
+        }
+    }
 
 .. meta::
     :title lang=en: Coding Standards

--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -544,8 +544,8 @@ underscore character, for example::
 
     define('LONG_NAMED_CONSTANT', 2);
 
-Avoid empty()
-=============
+Careful when using empty()/isset()
+==================================
 
 While ``empty()`` is an easy to use function it can mask errors and cause
 unintended effects when ``'0'`` and ``0`` are used. When variables or properties

--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -547,15 +547,15 @@ underscore character, for example::
 Careful when using empty()/isset()
 ==================================
 
-While ``empty()`` is an easy to use function it can mask errors and cause
-unintended effects when ``'0'`` and ``0`` are used. When variables or properties
-are already defined the usage of ``empty()`` is not recommended. When working
+While ``empty()`` is an easy to use function, it can mask errors and cause
+unintended effects when ``'0'`` and ``0`` are given. When variables or properties
+are already defined, the usage of ``empty()`` is not recommended. When working
 with variables, it is better to rely on type-coercion to boolean instead of
 ``empty()``::
 
     function manipulate($var)
     {
-        // not recommended, $var is already defined in the scope
+        // Not recommended, $var is already defined in the scope
         if (empty($var)) {
             // ...
         }
@@ -574,15 +574,15 @@ When dealing with defined properties you should favour ``null`` checks over
 
     class Thing
     {
-        private $property; // defined
+        private $property; // Defined
 
         public function readProperty()
         {
-            // not recommended as the property is defined in the class
+            // Not recommended as the property is defined in the class
             if (!isset($this->property)) {
                 // ...
             }
-            // recommended
+            // Recommended
             if ($this->property === null) {
 
             }
@@ -600,12 +600,12 @@ are defined::
             'key' => null,
         ];
 
-        // not recommended, the key is already set
+        // Not recommended, the key is already set
         if (isset($array['key'])) {
             // ...
         }
 
-        // recommended
+        // Recommended
         if ($array['key'] !== null) {
             // ...
         }

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -417,14 +417,20 @@ need to specific data based on a condition.
 
 If we wished to know how many published articles are in our database, we'd need to generate the following SQL::
 
-    SELECT SUM(CASE published = 'Y' THEN 1 ELSE 0) AS number_published, SUM(CASE published = 'N' THEN 1 ELSE 0) AS number_unpublished
+    SELECT
+    SUM(CASE published = 'Y' THEN 1 ELSE 0) AS number_published,
+    SUM(CASE published = 'N' THEN 1 ELSE 0) AS number_unpublished
     FROM articles GROUP BY published
 
 To do this with the query builder, we'd use the following code::
 
     $query = $articles->find();
-    $publishedCase = $query->newExpr()->addCase($query->newExpr()->add(['published' => 'Y']), 1, 'integer');
-    $notPublishedCase = $query->newExpr()->addCase($query->newExpr()->add(['published' => 'N']), 1, 'integer');
+    $publishedCase = $query->newExpr()
+        ->addCase($query->newExpr()
+        ->add(['published' => 'Y']), 1, 'integer');
+    $notPublishedCase = $query->newExpr()
+        ->addCase($query->newExpr()
+        ->add(['published' => 'N']), 1, 'integer');
 
     $query->select([
         'number_published' => $query->func()->sum($publishedCase),

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -1314,6 +1314,18 @@ subqueries::
 Subqueries are accepted anywhere a query expression can be used. For example, in
 the ``select()`` and ``join()`` methods.
 
+Adding Locking Statements
+-------------------------
+
+Most relational database vendors support taking out locks when doing select
+operations. You can use the ``epilog()`` method for this::
+
+    // In MySQL
+    $query->epilog('FOR UPDATE');
+
+The ``epilog()`` method allows you to append raw SQL to the end of queries. You
+should never put raw user data into ``epilog()``.
+
 Executing Complex Queries
 -------------------------
 


### PR DESCRIPTION
*  Document using locking statements with epilog() #3981
*  Add section on avoiding empty(). cakephp/cakephp#8397
* Reorder query builder post-processing section and wrap long lines.