### PR TITLE
Fixed custom logger info

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -111,6 +111,7 @@ properties are passed to the log adapter's constructor as an array. ::
     {
         public function __construct($options = [])
         {
+            parent::__construct($options);
             // ...
         }
 


### PR DESCRIPTION
To make a custom logger, you need to add the parent::__construct($options) call. 

 Otherwise everything borks.  At least it fixed the problem for me.