### PR TITLE
Adds note about Etag alternative for (most) proxy users

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -693,6 +693,11 @@ To take advantage of this header, you must either call the
         // ...
     }
 
+.. note::
+
+    Most proxy users should probably consider using the Last Modified Header
+    instead of Etags for performance and compatibility reasons.
+
 The Last Modified Header
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I found out the hard way that Etags do not play well with most proxies and I now feel are very understandable reasons. Hope this helps people out wondering why e.g. etags and nginx proxy don't work when developing.