### PR TITLE
Question about versions for calling Seeders

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -640,7 +640,7 @@ that the same seeder can be applied multiple times.
 
 Calling a Seeder from another Seeder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+## How is this possible? 1.6.1 is the most recent relase listed on https://github.com/cakephp/migrations/releases?
 .. versionadded:: cakephp/migrations 1.6.2
 
 Usually when seeding, the order in which to insert the data must be respected


### PR DESCRIPTION
The docs reference an apparently non-existent release of cakephp/migrations. (at least it hasn't been released on github). Is clarification / correction possible?