### PR TITLE
Documents nullable columns in baked migrations

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -204,13 +204,15 @@ Columns definition
 When using columns in the command line, it may be handy to remember that they
 follow the following pattern::
 
-    fieldName:fieldType[length]:indexType:indexName
+    fieldName:fieldType?[length]:indexType:indexName
 
 For instance, the following are all valid ways of specifying an email field:
 
 * ``email:string:unique``
 * ``email:string:unique:EMAIL_INDEX``
 * ``email:string[120]:unique:EMAIL_INDEX``
+
+The question mark following the fieldType will make the column nullable.
 
 The ``length`` parameter for the ``fieldType`` is optional and should always be
 written between bracket.

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -208,8 +208,8 @@ follow the following pattern::
 
 For instance, the following are all valid ways of specifying an email field:
 
+* ``description:string?``
 * ``email:string:unique``
-* ``email:string?:unique``
 * ``email:string:unique:EMAIL_INDEX``
 * ``email:string[120]:unique:EMAIL_INDEX``
 

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -209,6 +209,7 @@ follow the following pattern::
 For instance, the following are all valid ways of specifying an email field:
 
 * ``email:string:unique``
+* ``email:string?:unique``
 * ``email:string:unique:EMAIL_INDEX``
 * ``email:string[120]:unique:EMAIL_INDEX``
 

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -208,7 +208,7 @@ follow the following pattern::
 
 For instance, the following are all valid ways of specifying an email field:
 
-* ``description:string?``
+* ``email:string?``
 * ``email:string:unique``
 * ``email:string:unique:EMAIL_INDEX``
 * ``email:string[120]:unique:EMAIL_INDEX``


### PR DESCRIPTION
This feature is being introduced in cakephp/migrations v1.6.3.

Reference: Issue cakephp/migrations#203 / PR cakephp/migrations#249