### PR TITLE
Add a missing return statement

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -177,6 +177,8 @@ model fields, depending on a country, ie::
                 'rule' => 'phone',
                 'provider' => 'fr'
             ]);
+            
+            return $validator;
         }
     }
 


### PR DESCRIPTION
The return statement is required. If there is no "return $validator" an error is thrown.