### PR TITLE
Add a warning to the 1.3 docs

### DIFF
--- a/en/index.rst
+++ b/en/index.rst
@@ -1,9 +1,6 @@
 The Manual
 ##########
 
-`Click here for the CakePHP 1.2.x version of the
-manual </1.2/en/>`_
-
 Welcome to the Cookbook, the CakePHP documentation. The Cookbook is a
 wiki-like system allowing contributions from the public. With an open
 system, we hope to maintain a high level of quality, validity, and

--- a/themes/cakephp/layout.html
+++ b/themes/cakephp/layout.html
@@ -246,6 +246,9 @@
 				</div>
 			</div>
 		</section>
+		<p class="outdated-warning">
+			This document is for a version of CakePHP that is no longer supported. Please upgrade to a newer release!
+		</p>
 	</header>
 
 	{# Responsive grey bar navigation. This is outside of header so it scrolls with the page. #}

--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -42,7 +42,7 @@
 }
 
 .page-container {
-    padding-top: 160px;
+    padding-top: 185px;
     padding-bottom: 40px;
 }
 
@@ -792,3 +792,10 @@ dt tt {
     font-size: 14px;
 }
 
+
+.outdated-warning {
+    text-align: center;
+    background-color: #ffe4e4;
+    padding: 0.4em;
+    margin: 0;
+}


### PR DESCRIPTION
Add a bolder warning that the 1.3 docs are for an unsupported version. If people are 🆗 with this, I'll apply it to the 1.2 and 1.1 docs as well.

![screen shot 2016-07-03 at 11 45 47](https://cloud.githubusercontent.com/assets/24086/16546295/062c5928-4114-11e6-8450-fe3f4d57291a.png)

The banner is sticky with the grey nav bar.
