### PR TITLE
Add documentation for multiple pagination.

### DIFF
--- a/en/appendices/3-3-migration-guide.rst
+++ b/en/appendices/3-3-migration-guide.rst
@@ -89,6 +89,25 @@ ORM Improvements
 * The ``partialNullsPass`` option was added to the ``existsIn`` rule. This
   option allows rules to pass when some columns are null.
 
+Multiple Pagination Support Added
+=================================
+
+You can now paginate multiple queries in a single controller action/view
+template. See the :ref:`paginating-multiple-queries` section for more
+details.
+
+Cache Shell Added
+=================
+
+To help you better manage cached data from a CLI environment, a shell command
+has been added that exposes methods for clearing cached data::
+
+    // Clear one cache config
+    bin/cake cache clear <configname>
+
+    // Clear all cache configs
+    bin/cake cache clear_all
+
 FormHelper
 ==========
 
@@ -146,15 +165,3 @@ Debugging Functions
 
 * The ``pr()``, ``debug()``, and ``pj()`` functions now return the value being
   dumped. This makes them easier to use when values are being returned.
-
-Cache Shell Added
-=================
-
-To help you better manage cached data from a CLI environment, a shell command
-has been added that exposes methods for clearing cached data::
-
-    // Clear one cache config
-    bin/cake cache clear <configname>
-
-    // Clear all cache configs
-    bin/cake cache clear_all

--- a/en/appendices/3-3-migration-guide.rst
+++ b/en/appendices/3-3-migration-guide.rst
@@ -99,7 +99,7 @@ details.
 Cache Shell Added
 =================
 
-To help you better manage cached data from a CLI environment, a shell command
+To help you better manage cached data from the CLI environment, a shell command
 has been added that exposes methods for clearing cached data::
 
     // Clear one cache config

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -189,14 +189,14 @@ Paginating Multiple Queries
 ===========================
 
 You can paginate multiple models in a single controller action, using the
-``requestScope`` option::
+``scope`` option::
 
     // In a controller action
-    $articles = $this->paginate($this->Articles, ['requestScope' => 'article']);
-    $tags = $this->paginate($this->Tags, ['requestScope' => 'tag']);
+    $articles = $this->paginate($this->Articles, ['scope' => 'article']);
+    $tags = $this->paginate($this->Tags, ['scope' => 'tag']);
     $this->set(compact('articles', 'tags'));
 
-The ``requestScope`` option will result in ``PaginatorComponent`` looking in
+The ``scope`` option will result in ``PaginatorComponent`` looking in
 scoped query string parameters. For example, the following URL could be used to
 paginate both tags and articles at the same time::
 

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -183,6 +183,31 @@ settings to use for pagination. This array should have the same structure as the
 ``finder`` option will be ignored. It is assumed that you are passing in
 the query you want paginated.
 
+.. _paginating-multiple-queries:
+
+Paginating Multiple Queries
+===========================
+
+You can paginate multiple models in a single controller action, using the
+``requestScope`` option::
+
+    // In a controller action
+    $articles = $this->paginate($this->Articles, ['requestScope' => 'article']);
+    $tags = $this->paginate($this->Tags, ['requestScope' => 'tag']);
+    $this->set(compact('articles', 'tags'));
+
+The ``requestScope`` option will result in ``PaginatorComponent`` looking in
+scoped query string parameters. For example, the following URL could be used to
+paginate both tags and articles at the same time::
+
+    /dashboard?article[page]=1&tag[page]=3
+
+See the :ref:`paginator-helper-multiple` section for how to generate scoped HTML
+elements and URLs for pagination.
+
+.. versionadded:: 3.3.0
+    Multiple Pagination was added in 3.3.0
+
 Control which Fields Used for Ordering
 ======================================
 

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -506,6 +506,9 @@ option when generating pagination related elements. You can either use the
     $this->Paginator->options(['defaultModel' => 'title']);
     echo $this->Paginator->sort('title');
 
+By using the ``model`` option, ``PaginatorHelper`` will automatically use the
+``requestScope`` defined in when the query was paginated.
+
 .. versionadded:: 3.3.0
     Multiple Pagination was added in 3.3.0
 

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -503,11 +503,11 @@ option when generating pagination related elements. You can either use the
     echo $this->Paginator->sort('title', ['model' => 'Articles']);
 
     // Set the default model.
-    $this->Paginator->options(['defaultModel' => 'title']);
+    $this->Paginator->options(['defaultModel' => 'Articles']);
     echo $this->Paginator->sort('title');
 
 By using the ``model`` option, ``PaginatorHelper`` will automatically use the
-``requestScope`` defined in when the query was paginated.
+``scope`` defined in when the query was paginated.
 
 .. versionadded:: 3.3.0
     Multiple Pagination was added in 3.3.0

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -371,8 +371,8 @@ There are a number of options for ``counter()``. The supported ones are:
   :php:meth:`PaginatorHelper::defaultModel()`. This is used in
   conjunction with the custom string on 'format' option.
 
-Modifying the Options PaginatorHelper Uses
-==========================================
+Configuring Pagination Options
+==============================
 
 .. php:method:: options($options = [])
 
@@ -408,8 +408,8 @@ Sets all the options for the Paginator Helper. Supported options are:
 * ``model`` The name of the model being paginated, defaults to
   :php:meth:`PaginatorHelper::defaultModel()`.
 
-Pagination in Views
-===================
+Example Usage
+=============
 
 It's up to you to decide how to show records to the user, but most
 often this will be done inside HTML tables. The examples below
@@ -488,6 +488,26 @@ By default returns a full pagination URL string for use in non-standard
 contexts (i.e. JavaScript). ::
 
     echo $this->Paginator->generateUrl(['sort' => 'title']);
+
+.. _paginator-helper-multiple:
+
+Paginating Multiple Results
+===========================
+
+If you are :ref:`paginating-multiple-queries` you'll need to set the ``model``
+option when generating pagination related elements. You can either use the
+``model`` option on every method call you make to ``PaginatorHelper``, or use
+``options()`` to set the default model::
+
+    // Pass the model option
+    echo $this->Paginator->sort('title', ['model' => 'Articles']);
+
+    // Set the default model.
+    $this->Paginator->options(['defaultModel' => 'title']);
+    echo $this->Paginator->sort('title');
+
+.. versionadded:: 3.3.0
+    Multiple Pagination was added in 3.3.0
 
 .. meta::
     :title lang=en: PaginatorHelper

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -494,10 +494,10 @@ contexts (i.e. JavaScript). ::
 Paginating Multiple Results
 ===========================
 
-If you are :ref:`paginating-multiple-queries` you'll need to set the ``model``
-option when generating pagination related elements. You can either use the
-``model`` option on every method call you make to ``PaginatorHelper``, or use
-``options()`` to set the default model::
+If you are :ref:`paginating-multiple-queries <paginating multiple queries>`
+you'll need to set the ``model`` option when generating pagination related
+elements. You can either use the ``model`` option on every method call you make
+to ``PaginatorHelper``, or use ``options()`` to set the default model::
 
     // Pass the model option
     echo $this->Paginator->sort('title', ['model' => 'Articles']);


### PR DESCRIPTION
Add documentation using the proposed `requestScope` option name, instead of the more ambiguous `prefix` option.

Refs cakephp/cakephp#8488