### PR TITLE
Cake\Network\Http\Client API documentation contains a broken example

### DIFF
--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -108,7 +108,7 @@ the specific multipart HTTP request you want::
     $response = $http->post(
         'http://example.com/api',
         (string)$data,
-        ['headers' => ['Content-Type' => 'multipart/related']]
+        ['headers' => ['Content-Type' => $data->contentType()]]
     );
 
 Sending Request Bodies


### PR DESCRIPTION
The multipart request is required to contain a valid boundary within its `Content-Type` header.

Otherwise, overwriting request header using a fixed content type without a boundary makes the whole request payload to be non-parseable.

A valid boundary can be retrieve from `FormData->contentType()`, so the example code have to indicate that.