### PR TITLE
Texto Acrescentado

### DIFF
--- a/pt/index.rst
+++ b/pt/index.rst
@@ -1,6 +1,8 @@
 Bem-vindo
 #########
 
+CakePHP 3 é um framework de desenvolvimento web que funciona com o PHP 7 ou no mínimo PHP 5.5.9. Leia CakePHP num piscar de olhos para obter uma introdução aos fundamentos do CakePHP 3.
+
 O cookbook CakePHP é um projeto aberto de documentação editável pela comunidade.
 Esperamos manter um alto nível de qualidade, validade e precisão para a
 documentação do CakePHP. Observe o botão “Improve this Doc” no canto superior


### PR DESCRIPTION
O texto inicial foi acrescentado, onde explica que o CakePHP 3 funciona com a versão do php 7.