### PR TITLE
Restructure example code in 'Case statements' section of Query Builder

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -426,11 +426,17 @@ To do this with the query builder, we'd use the following code::
 
     $query = $articles->find();
     $publishedCase = $query->newExpr()
-        ->addCase($query->newExpr()
-        ->add(['published' => 'Y']), 1, 'integer');
+        ->addCase(
+            $query->newExpr()->add(['published' => 'Y']),
+            1,
+            'integer'
+        );
     $notPublishedCase = $query->newExpr()
-        ->addCase($query->newExpr()
-        ->add(['published' => 'N']), 1, 'integer');
+        ->addCase(
+            $query->newExpr()->add(['published' => 'N']),
+            1,
+            'integer'
+        );
 
     $query->select([
         'number_published' => $query->func()->sum($publishedCase),


### PR DESCRIPTION
The existing formatting makes it look like all the arguments are part of the call to add() until you follow through the brackets. This formatting is the same style as is used for the more complex example below.