### PR TITLE
[Typo] fixing bad string wrapping

### DIFF
--- a/fr/controllers/components/authentication.rst
+++ b/fr/controllers/components/authentication.rst
@@ -241,7 +241,7 @@ connexion pourrait ressembler à cela::
                 $this->Auth->setUser($user);
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
-                $this->Flash->error(__('Nom d'utilisateur ou mot de passe incorrect'), [
+                $this->Flash->error(__("Nom d'utilisateur ou mot de passe incorrect"), [
                     'key' => 'auth'
                 ]);
             }


### PR DESCRIPTION
`'nom d'utilisateurs [...]'` to `"nom d'utilisateurs [...]"`