### PR TITLE
Update Sphinx to 1.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,12 @@ To build the documentation you'll need the following for linux/OS X:
 
 * Make
 * Python
-* Sphinx 1.2.* (currently the make commands will not work with 1.3.* versions
-  and up)
+* Sphinx 1.4.5
 * PhpDomain for sphinx
 
 You can install sphinx using:
 
-    pip install sphinx==1.2.3
+    pip install sphinx==1.4.5
 
 You can install the phpdomain using:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To build the documentation you'll need the following for linux/OS X:
 * Make
 * Python
 * Sphinx 1.4.5
-* PhpDomain for sphinx
+* PhpDomain for sphinx 0.2.0
 
 You can install sphinx using:
 
@@ -98,7 +98,7 @@ You can install sphinx using:
 
 You can install the phpdomain using:
 
-    pip install sphinxcontrib-phpdomain
+    pip install sphinxcontrib-phpdomain==0.2.0
 
 *To run the pip command, python-pip package must be previously installed.*
 

--- a/config/cakebranch.py
+++ b/config/cakebranch.py
@@ -10,7 +10,6 @@ the GitHub branch name of the docs' version.
 def setup(app):
     app.connect('html-page-context', append_template_ctx)
     app.add_config_value('branch', '', True)
-    return app
 
 def append_template_ctx(app, pagename, templatename, ctx, event_arg):
     ctx['branch'] = app.config.branch

--- a/config/cakei18n.py
+++ b/config/cakei18n.py
@@ -10,7 +10,6 @@ i18n links to other sub doc projects.
 def setup(app):
     app.connect('html-page-context', append_template_ctx)
     app.add_config_value('languages', [], '')
-    return app
 
 def append_template_ctx(app, pagename, templatename, ctx, event_arg):
     def lang_dir(lang):

--- a/config/cakei18n.py
+++ b/config/cakei18n.py
@@ -35,7 +35,7 @@ def append_template_ctx(app, pagename, templatename, ctx, event_arg):
         Check to see if a language file exists for a given path/RST doc.:
         """
         folder = lang_dir(lang)
-        possible = '..' + SEP + folder +  SEP + path + app.config.source_suffix
+        possible = '..' + SEP + folder +  SEP + path + ''.join(app.config.source_suffix)
         full_path = os.path.realpath(os.path.join(os.getcwd(), possible))
 
         return os.path.isfile(full_path)

--- a/en/core-libraries/helpers/paginator.rst
+++ b/en/core-libraries/helpers/paginator.rst
@@ -163,7 +163,7 @@ In addition to generating links that go directly to specific page numbers,
 you'll often want links that go to the previous and next links, first and last
 pages in the paged data set.
 
-.. php:method:: prev($title = '<< Previous', $options = array(), $disabledTitle = null, $disabledOptions = array())
+.. php:method:: prev($title = '<?= __('<< previous') ?>', $options = array(), $disabledTitle = null, $disabledOptions = array())
 
     :param string $title: Title for the link.
     :param mixed $options: Options for pagination link.
@@ -196,7 +196,7 @@ pages in the paged data set.
 
         <span class="prev">
           <a rel="prev" href="/posts/index/page:1/sort:title/order:desc">
-            << previous
+            <?= __('<< previous') ?>
           </a>
         </span>
 
@@ -204,7 +204,7 @@ pages in the paged data set.
 
     .. code-block:: html
 
-        <span class="prev disabled"><< previous</span>
+        <span class="prev disabled"><?= __('<< previous') ?></span>
 
     You can change the wrapping tag using the ``tag`` option::
 

--- a/fr/core-libraries/helpers/js.rst
+++ b/fr/core-libraries/helpers/js.rst
@@ -594,7 +594,7 @@ méthode.
     .. code-block:: javascript
 
         $('#some-link').bind('click', function (event) {
-            alert(saperlipopette!');
+            alert('saperlipopette!');
             return false;
         });
 

--- a/fr/core-libraries/helpers/paginator.rst
+++ b/fr/core-libraries/helpers/paginator.rst
@@ -171,7 +171,7 @@ En plus de générer des liens qui vont directement sur des numéros de pages
 spécifiques, vous voudrez souvent des liens qui amènent vers le lien précédent
 ou suivant, première et dernière pages dans le jeu de données paginées.
 
-.. php:method:: prev($title = '<< Previous', $options = array(), $disabledTitle = null, $disabledOptions = array())
+.. php:method:: prev($title = '<?= __('<< previous') ?>', $options = array(), $disabledTitle = null, $disabledOptions = array())
 
     :param string $title: Titre du lien.
     :param mixed $options: Options pour le lien de pagination.
@@ -207,7 +207,7 @@ ou suivant, première et dernière pages dans le jeu de données paginées.
 
         <span class="prev">
           <a rel="prev" href="/posts/index/page:1/sort:title/order:desc">
-            << previous
+            <?= __('<< previous') ?>
           </a>
         </span>
 
@@ -215,7 +215,7 @@ ou suivant, première et dernière pages dans le jeu de données paginées.
 
     .. code-block:: html
 
-        <span class="prev disabled"><< previous</span>
+        <span class="prev disabled"><?= __('<< previous') ?></span>
 
     Vous pouvez changer la balise enveloppante en utilisant l'option ``tag``::
 

--- a/ja/core-libraries/helpers/paginator.rst
+++ b/ja/core-libraries/helpers/paginator.rst
@@ -161,7 +161,7 @@ first と last オプションを使って先頭ページと最終ページへ�
 特定のページ番号に直接行けるリンクを作れるだけでなく、現在の直前や直後、
 および先頭や末尾へのリンクを作りたくなる場合もあるでしょう。
 
-.. php:method:: prev($title = '<< Previous', $options = array(), $disabledTitle = null, $disabledOptions = array())
+.. php:method:: prev($title = '<?= __('<< previous') ?>', $options = array(), $disabledTitle = null, $disabledOptions = array())
 
     :param string $title: リンクのタイトル
     :param mixed $options: ページ制御用リンクのオプション
@@ -195,7 +195,7 @@ first と last オプションを使って先頭ページと最終ページへ�
 
         <span class="prev">
           <a rel="prev" href="/posts/index/page:1/sort:title/order:desc">
-            << previous
+            <?= __('<< previous') ?>
           </a>
         </span>
 
@@ -203,7 +203,7 @@ first と last オプションを使って先頭ページと最終ページへ�
 
     .. code-block:: html
 
-        <span class="prev disabled"><< previous</span>
+        <span class="prev disabled"><?= __('<< previous') ?></span>
 
     ``tag`` オプションによりラッピング用のタグを変更できます。 ::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==1.2.3
+sphinx==1.4.5
 sphinxcontrib-phpdomain

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 sphinx==1.4.5
-sphinxcontrib-phpdomain
+sphinxcontrib-phpdomain==0.2.0


### PR DESCRIPTION
This refers to https://github.com/cakephp/docs/issues/921.

Update sphinx to the latest 1.4.5 needs the following steps for the master branch (2.x) for now (3.x will follow):
- the [phpDomain](https://github.com/markstory/sphinxcontrib-phpdomain) need some fixes made on [branch sphinx-1.4.5](https://github.com/cakephp-fr/sphinxcontrib-phpdomain/tree/sphinx-1.4.5). I made this PR https://github.com/markstory/sphinxcontrib-phpdomain/pull/1 to solve this
- Then it should be updated on the [python package website](https://pypi.python.org/pypi) with new tag 0.2.0
- This PR needs to apply
- docker images in cakephpfr/docs will need some changes made on [branch sphinx-1.4.5](https://github.com/cakephp-fr/docker/tree/sphinx-1.4.5)

Travis build fails because sphinxcontrib-phpdomain needs the update proposed in  https://github.com/markstory/sphinxcontrib-phpdomain/pull/1

Let me know if something is missing