### PR TITLE
Add i18n error pages.

### DIFF
--- a/config/all.py
+++ b/config/all.py
@@ -54,7 +54,6 @@ release = '3.x'
 # directories to ignore when looking for source files.
 exclude_patterns = [
     'themes',
-    '404.rst'
 ]
 
 # The reST default role (used for this markup: `text`) to

--- a/en/404.rst
+++ b/en/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Not Found
 #########
 

--- a/es/404.rst
+++ b/es/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Not Found
 #########
 

--- a/fr/404.rst
+++ b/fr/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Not Found
 #########
 

--- a/ja/404.rst
+++ b/ja/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Not Found
 #########
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,10 +11,34 @@ server {
     gzip_types text/plain text/xml text/css application/x-javascript;
     gzip_vary on;
 
-    # Error pages not publically exposed
-    error_page 404 /404.html;
-    location = /404.html {
+    # Error handling
+    # error_page 404 /3.0/en/404.html;
+
+    error_page 404 @error_page;
+    location @error_page {
         root /var/www/html;
-        internal;
+        set $error404 /3.0/en/404.html;
+        if ($request_filename ~ "/3.0/fr") {
+            set $error404 /3.0/fr/404.html;
+        }
+        if ($request_filename ~ "/3.0/es") {
+            set $error404 /3.0/es/404.html;
+        }
+        if ($request_filename ~ "/3.0/fr") {
+            set $error404 /3.0/fr/404.html;
+        }
+        if ($request_filename ~ "/3.0/ja") {
+            set $error404 /3.0/ja/404.html;
+        }
+        if ($request_filename ~ "/3.0/pt") {
+            set $error404 /3.0/pt/404.html;
+        }
+        if ($request_filename ~ "/3.0/tr") {
+            set $error404 /3.0/tr/404.html;
+        }
+        if ($request_filename ~ "/3.0/zh") {
+            set $error404 /3.0/zh/404.html;
+        }
+        rewrite ^(.*)$ $error404 break;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,9 +18,6 @@ server {
     location @error_page {
         root /var/www/html;
         set $error404 /3.0/en/404.html;
-        if ($request_filename ~ "/3.0/fr") {
-            set $error404 /3.0/fr/404.html;
-        }
         if ($request_filename ~ "/3.0/es") {
             set $error404 /3.0/es/404.html;
         }

--- a/pt/404.rst
+++ b/pt/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Página não encontrada
 #####################
 

--- a/tr/404.rst
+++ b/tr/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Not Found
 #########
 

--- a/zh/404.rst
+++ b/zh/404.rst
@@ -1,3 +1,5 @@
+:orphan: True
+
 Not Found
 #########
 


### PR DESCRIPTION
The previous attempt at error pages didn't entirely work. Paths were wrong, and more importantly all languages would get english error pages with english nav. This wasn't great, but by making the nginx
configuration a bit more verbose we can redirect users to 404 pages in their language.

The `:orphan:` tags suppress the TOC warnings while still letting the pages be built.