### PR TITLE
added `Hash::combine` use-case

### DIFF
--- a/en/core-libraries/hash.rst
+++ b/en/core-libraries/hash.rst
@@ -217,6 +217,14 @@ Attribute Matching Types
                 [14] =>
             ]
         */
+        
+        $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data.user');
+        /* $result now looks like:
+            [
+                [2] => 'mariano.iglesias'
+                [14] => 'phpnut'
+            ]
+        */        
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data');
         /* $result now looks like:


### PR DESCRIPTION
Added a use-case for `Hash::combine` showing the (missing, imho) step of mapping a key to single value. The docs show how to get just the key and how to map the key to an array, but not to a single value. Might be obvious in hindsight but it cost me a few minutes and a slack chat today.