### PR TITLE
Loggin documentation mislead a bit about popularity of the LogTrait

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -13,9 +13,9 @@ of errors are my users being shown? How often is a particular query
 being executed?
 
 Logging data in CakePHP is easy - the log() function is provided by the
-``LogTrait``, which is the common ancestor for almost all CakePHP classes. If
-the context is a CakePHP class (Model, Controller, Component... almost
-anything), you can log your data.  You can also use ``Log::write()`` directly.
+``LogTrait``, which is the common ancestor for many CakePHP classes. If
+the context is a CakePHP class (Controller, Component),
+you can log your data.  You can also use ``Log::write()`` directly.
 See :ref:`writing-to-logs`.
 
 .. _log-configuration:

--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -14,7 +14,7 @@ being executed?
 
 Logging data in CakePHP is easy - the log() function is provided by the
 ``LogTrait``, which is the common ancestor for many CakePHP classes. If
-the context is a CakePHP class (Controller, Component),
+the context is a CakePHP class (Controller, Component, View,...),
 you can log your data.  You can also use ``Log::write()`` directly.
 See :ref:`writing-to-logs`.
 


### PR DESCRIPTION
I found it misleading, where the doc states that LogTrait is used almost everywhere. It is not available from Tables and Behaviours, which are one of the most popular classes.