### PR TITLE
[en] correct original text

### DIFF
--- a/en/core-libraries/components/pagination.rst
+++ b/en/core-libraries/components/pagination.rst
@@ -24,7 +24,7 @@ Query Setup
 
 In the controller, we start by defining the query conditions pagination will use
 by default in the ``$paginate`` controller variable. These conditions, serve as
-the basis of your pagination queries. They are augmented by the sort, direction
+the basis of your pagination queries. They are augmented by the sort, direction,
 limit, and page parameters passed in from the URL. It is important to note
 here that the order key must be defined in an array structure like below::
 

--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -887,16 +887,16 @@ Options for select, checkbox and  radio inputs
     If you need to set the default value in a password field to blank,
     use 'value' => '' instead.
 
-    A list of key-value pairs can be supplied for a date or datetime field::
+  A list of key-value pairs can be supplied for a date or datetime field::
 
-        echo $this->Form->dateTime('Contact.date', 'DMY', '12',
-        	array(
-        		'empty' => array(
-        			'day' => 'DAY', 'month' => 'MONTH', 'year' => 'YEAR',
-        			'hour' => 'HOUR', 'minute' => 'MINUTE', 'meridian' => false
-        		)
-        	)
-        );
+    echo $this->Form->dateTime('Contact.date', 'DMY', '12',
+        array(
+            'empty' => array(
+                'day' => 'DAY', 'month' => 'MONTH', 'year' => 'YEAR',
+                'hour' => 'HOUR', 'minute' => 'MINUTE', 'meridian' => false
+            )
+        )
+    );
 
   Output:
 


### PR DESCRIPTION
example should stay together with the output below, instead of be mixed up with the note above