### PR TITLE
Updated updateBuyStatistic example function

### DIFF
--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -181,7 +181,7 @@ as necessary. Our ``UserStatistics`` listener might start out like::
             ];
         }
 
-        public function updateBuyStatistic($event)
+        public function updateBuyStatistic($event, $order)
         {
             // Code to update statistics
         }


### PR DESCRIPTION
If the Event Model.Order.afterPlace is also passing the order entity, does it not make sense that the updateBuyStatistics also receive it?