### PR TITLE
Added style for current page in TOC

### DIFF
--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -172,6 +172,10 @@
     color: #2f85ae;
 }
 
+.sidebar a.current {
+    color: #d33c44;
+}
+
 #sidebar-navigation > ul {
     padding-left: 0;
 }


### PR DESCRIPTION
While browsing the documentation, one is unable to locate current page in TOC. Highlighting the current page will help that. I have used CakePHP default colour for highlighting. Designers can put in their inputs.