### PR TITLE
Fix download link alignment

### DIFF
--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -103,6 +103,9 @@
     margin-bottom: 5px;
     text-align: center;
 }
+.offline-download ul {
+    margin-left: 0;
+}
 .offline-download li {
     display: inline-block;
     list-style: none;


### PR DESCRIPTION
before
<img width="357" alt="capture d ecran 2016-09-01 a 17 29 59" src="https://cloud.githubusercontent.com/assets/4977112/18173405/c21dafd6-7069-11e6-93ab-01e494ec040e.png">

after
<img width="357" alt="capture d ecran 2016-09-01 a 17 29 38" src="https://cloud.githubusercontent.com/assets/4977112/18173418/cc284590-7069-11e6-8a5a-460f00b5fd90.png">
