### PR TITLE
Removing redundant doc section

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1696,7 +1696,8 @@ Generates a set of inputs for the given context wrapped in a fieldset. You can
 specify the generated fields by including them::
 
     echo $this->Form->inputs([
-        'name' => ['label' => 'custom label']
+        'name',
+        'email
     ]);
 
 You can customize the legend text using an option::


### PR DESCRIPTION
The code block after the next was identical to this code block, could be confusing. Not sure this is the best improvement, but it's certainly better than having the same code twice.