### PR TITLE
Fixed markup typo in autoParagraph example

### DIFF
--- a/en/views/helpers/text.rst
+++ b/en/views/helpers/text.rst
@@ -74,7 +74,7 @@ single-line returns are found. ::
 Output::
 
     <p>For more information<br />
-    regarding our world-famous pastries and desserts.<p>
+    regarding our world-famous pastries and desserts.</p>
     <p>contact info@example.com</p>
 
 .. include:: /core-libraries/text.rst


### PR DESCRIPTION
The HTML tags in the example code weren't closing.