### PR TITLE
Fixed markup typo in autoParagraph example (CakePHP 2.x)

### DIFF
--- a/en/core-libraries/helpers/text.rst
+++ b/en/core-libraries/helpers/text.rst
@@ -80,7 +80,7 @@ truncating long stretches of text.
     Output::
 
         <p>For more information<br />
-        regarding our world-famous pastries and desserts.<p>
+        regarding our world-famous pastries and desserts.</p>
         <p>contact info@example.com</p>
 
     .. versionadded:: 2.4


### PR DESCRIPTION
Same issue as this one https://github.com/cakephp/docs/pull/4322 for CakePHP 3.