### PR TITLE
Results buffering update

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -900,9 +900,7 @@ Turning buffering off has a few caveats:
 #. You will also not be able to iterate & cache the results.
 #. Buffering cannot be disabled for queries that eager load hasMany or
    belongsToMany associations, as these association types require eagerly
-   loading all results so that dependent queries can be generated. This
-   limitation is not present when using the ``subquery`` strategy for those
-   associations.
+   loading all results so that dependent queries can be generated.
 
 .. warning::
 


### PR DESCRIPTION
Following a comment https://github.com/cakephp/cakephp/issues/9509#issuecomment-249405661

Remove a suggestion that subquery strategy would enable result buffering for hasMany and belongsToMany association types.