### PR TITLE
Document the `--paths` option of the i18n extract shell

### DIFF
--- a/en/console-and-shells/i18n-shell.rst
+++ b/en/console-and-shells/i18n-shell.rst
@@ -34,6 +34,18 @@ You can generate a POT file for a specific plugin using::
 
 This will generate the required POT files used in the plugins.
 
+Extracting from multiple folders at once
+----------------------------------------
+
+Sometimes, you might need to extract strings from more than one directory of
+your application. For instance, if you are defining some strings in the
+``config`` directory of your application, you probably want to extract strings
+from this directory as well as from the ``src`` directory. You can do it by
+using the ``--paths`` option. It takes a comma-separated list of absolute paths
+to extract::
+
+    bin/cake i18n extract --paths /var/www/app/config,/var/www/app/src
+
 Excluding Folders
 -----------------
 

--- a/fr/console-and-shells/i18n-shell.rst
+++ b/fr/console-and-shells/i18n-shell.rst
@@ -38,6 +38,18 @@ Vous pouvez générer un fichier POT pour un plugin spécifique en faisant::
 
 Cela générera les fichiers POT requis utilisés dans les plugins.
 
+Extraire de plusieurs dossiers à la fois
+----------------------------------------
+
+Vous pouvez parfois avoir besoin d'extraire des chaînes depuis plus d'un
+dossier de votre application. Par exemple, si vous définissez des chaînes à
+traduire dans le dossier ``config`` de votre application, vous voudrez
+probablement extraire les chaînes de ce dossier en plus de celles du dossier
+``src``. Vous pouvez le faire en utilisant l'option ``--paths``. Elle accepte
+une liste de chemins absolus séparés par une virgule::
+
+    bin/cake i18n extract --paths /var/www/app/config,/var/www/app/src
+
 Exclure les fichiers
 --------------------
 


### PR DESCRIPTION
The I18N extract task has a useful ``--paths`` parameter that is not documented.