### PR TITLE
Make conventions chapter more consistent.

### DIFF
--- a/en/intro/conventions.rst
+++ b/en/intro/conventions.rst
@@ -11,33 +11,25 @@ Controller Conventions
 ======================
 
 Controller class names are plural, CamelCased, and end in ``Controller``.
-``PeopleController`` and ``LatestArticlesController`` are both examples of
+``UsersController`` and ``ArticleCategoriesController`` are both examples of
 conventional controller names.
 
 Public methods on Controllers are often exposed as 'actions' accessible through
-a web browser. For example the ``/articles/view`` maps to the ``view()`` method
-of the ``ArticlesController`` out of the box. Protected or private methods
+a web browser. For example the ``/users/view`` maps to the ``view()`` method
+of the ``UsersController`` out of the box. Protected or private methods
 cannot be accessed with routing.
 
 URL Considerations for Controller Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As you've just seen, single word controllers map to a simple lower case URL
-path. For example, ``ApplesController`` (which would be defined in the file name
-'ApplesController.php') is accessed from http://example.com/apples.
+path. For example, ``UsersController`` (which would be defined in the file name
+**UsersController.php**) is accessed from http://example.com/users.
 
-Multiple word controllers *can* be any "inflected" form which equals the
-controller name so:
-
-*  /redApples
-*  /RedApples
-*  /Red_apples
-*  /red_apples
-
-Will all resolve to the index of the RedApples controller. However, the
+While you can route multiple word controllers in any way you like, the
 convention is that your URLs are lowercase and dashed using the ``DashedRoute``
-class, therefore ``/red-apples/go-pick`` is the correct form to access the
-``RedApplesController::goPick()`` action.
+class, therefore ``/article-categories/view-all`` is the correct form to access the
+``ArticleCategoriesController::viewAll()`` action.
 
 When you create links using ``this->Html->link()``, you can use the following
 conventions for the url array::
@@ -61,19 +53,19 @@ In general, filenames match the class names, and follow the PSR-0 or PSR-4
 standards for autoloading. The following are some examples of class names and
 their filenames:
 
--  The Controller class **KissesAndHugsController** would be found in a file
-   named **KissesAndHugsController.php**
--  The Component class **MyHandyComponent** would be found in a file named
+-  The Controller class ``LatestArticlesController`` would be found in a file
+   named **LatestArticlesController.php**
+-  The Component class ``MyHandyComponent`` would be found in a file named
    **MyHandyComponent.php**
--  The Table class **OptionValuesTable** would be found in a file named
+-  The Table class ``OptionValuesTable`` would be found in a file named
    **OptionValuesTable.php**.
--  The Entity class **OptionValue** would be found in a file named
+-  The Entity class ``OptionValue`` would be found in a file named
    **OptionValue.php**.
--  The Behavior class **EspeciallyFunkableBehavior** would be found in a file
+-  The Behavior class ``EspeciallyFunkableBehavior`` would be found in a file
    named **EspeciallyFunkableBehavior.php**
--  The View class **SuperSimpleView** would be found in a file named
+-  The View class ``SuperSimpleView`` would be found in a file named
    **SuperSimpleView.php**
--  The Helper class **BestEverHelper** would be found in a file named
+-  The Helper class ``BestEverHelper`` would be found in a file named
    **BestEverHelper.php**
 
 Each file would be located in the appropriate folder/namespace in your app
@@ -84,44 +76,45 @@ folder.
 Model and Database Conventions
 ==============================
 
-Table class names are plural and CamelCased. People, BigPeople, and
-ReallyBigPeople are all examples of conventional model names.
+Table class names are plural and CamelCased. 'Users', 'ArticleCategories', and
+'UserFavoritePages' are all examples of conventional model names.
 
 Table names corresponding to CakePHP models are plural and underscored. The
-underlying tables for the above mentioned models would be ``people``,
-``big_people``, and ``really_big_people``, respectively.
+underlying tables for the above mentioned models would be ``users``,
+``article_categories``, and ``user_favorite_pages``, respectively.
 
 The convention is to use English words for table and column names. If you use
 words in another language, CakePHP might not be able to process the right
-inflections (from singular to plural and vice-versa).
-For some reason, if you need to add your own language rules for some words, you
-can use the utility class :php:class:`Cake\\Utility\\Inflector`. Besides
-defining those custom inflection rules, this class also allows you to check
-that CakePHP understands your custom syntax for plurals and singulars words. See
-the documentation about :doc:`/core-libraries/inflector` for more information.
+inflections (from singular to plural and vice-versa). If you need to add your
+own language rules for some words, you can use the utility class
+:php:class:`Cake\\Utility\\Inflector`. Besides defining those custom inflection
+rules, this class also allows you to check that CakePHP understands your custom
+syntax for plurals and singulars words. See the documentation about
+:doc:`/core-libraries/inflector` for more information.
 
-Field names with two or more words are underscored: first\_name.
+Field names with two or more words are underscored: ``first_name``.
 
-Foreign keys in hasMany, belongsTo or hasOne relationships are recognized by
-default as the (singular) name of the related table followed by \_id. So if
-Bakers hasMany Cakes, the cakes table will refer to the bakers table via a
-baker\_id foreign key. For a table like category\_types whose name contains
-multiple words, the foreign key would be category\_type\_id.
+Foreign keys in hasMany, belongsTo/hasOne relationships are recognized by
+default as the (singular) name of the related table followed by ``_id``. So if
+Users hasMany Articles, the articles table will refer to the users table via a
+``user_id`` foreign key. For a table like ``article_categories`` whose name contains
+multiple words, the foreign key would be ``article_category_id``.
 
 Join tables, used in BelongsToMany relationships between models, should be named
 after the model tables they will join, arranged in alphabetical order
-(apples\_zebras rather than zebras\_apples).
+(``articles_tags`` rather than ``tags_articles``).
 
-Rather than using an auto-increment key as the primary key, you may also use
-char(36). CakePHP will then use a unique 36 character UUID (Text::uuid) whenever
-you save a new record using the ``Table::save()`` method.
+In addition to use an auto-increment key as the primary key, you may also use
+UUID columns. CakePHP will create a unique 36 character UUID
+(:php:meth:`Cake\Utility\Text::uuid()`) whenever you save a new record using the
+``Table::save()`` method.
 
 View Conventions
 ================
 
 View template files are named after the controller functions they display, in an
-underscored form. The getReady() function of the PeopleController class will
-look for a view template in **src/Template/People/get_ready.ctp**.
+underscored form. The ``viewAll()`` function of the ``ArticlesController`` class
+will look for a view template in **src/Template/Articles/view_all.ctp**.
 
 The basic pattern is
 **src/Template/Controller/underscored_function_name.ctp**.
@@ -130,17 +123,17 @@ By naming the pieces of your application using CakePHP conventions, you gain
 functionality without the hassle and maintenance tethers of configuration.
 Here's a final example that ties the conventions together:
 
--  Database table: "people"
--  Table class: "PeopleTable", found at **src/Model/Table/PeopleTable.php**
--  Entity class: "Person", found at **src/Model/Entity/Person.php**
--  Controller class: "PeopleController", found at
-   **src/Controller/PeopleController.php**
--  View template, found at **src/Template/People/index.ctp**
+-  Database table: "articles"
+-  Table class: ``ArticlesTable``, found at **src/Model/Table/ArticlesTable.php**
+-  Entity class: ``Article``, found at **src/Model/Entity/Article.php**
+-  Controller class: ``ArticlesController``, found at
+   **src/Controller/ArticlesController.php**
+-  View template, found at **src/Template/Articles/index.ctp**
 
 Using these conventions, CakePHP knows that a request to
-http://example.com/people/ maps to a call on the ``index()`` function of the
-PeopleController, where the Person model is automatically available (and
-automatically tied to the 'people' table in the database), and renders to a
+http://example.com/articles/ maps to a call on the ``index()`` function of the
+ArticlesController, where the Articles model is automatically available (and
+automatically tied to the 'articles' table in the database), and renders to a
 file. None of these relationships have been configured by any means other than
 by creating classes and files that you'd need to create anyway.
 


### PR DESCRIPTION
* Use terms consistently throughout the document. This requires the
  reader to remember fewer terms and see how the conventions apply more
  holistically.
* Improve formatting to match current patterns around strong/code
  formatting.

Refs #4375