### PR TITLE
Remove warning message for consistency with English translation

### DIFF
--- a/es/index.rst
+++ b/es/index.rst
@@ -1,10 +1,6 @@
 Bienvenido
 ##########
 
-.. warning::
-    This version of the documentation is for CakePHP 3.0. Go `here for the
-    CakePHP 2.x documentation <http://book.cakephp.org/2.0/es>`_.
-
 El manual de CakePHP es un proyecto de documentación abierto, editable y
 mantenido por la comunidad. Toma en cuenta el botón de "Improve this doc"
 en la parte superior derecha; te llevará al editor online de Github de la

--- a/tr/index.rst
+++ b/tr/index.rst
@@ -1,10 +1,6 @@
 Hoşgeldiniz
 ###########
 
-.. warning::
-    This version of the documentation is for CakePHP 3.0. Go `here for the
-    CakePHP 2.x documentation <http://book.cakephp.org/2.0/tr>`_.
-
 CakePHP Yemekkitabı açık kaynaklı geliştirilen ve toplulukça düzenlenebilen
 dokümantasyon projesidir. Sağ üst köşede gördüğünüz
 "Improve this Doc" butonu sizi aktif sayfa üzerinde, eklemeler, silmeler ve

--- a/zh/index.rst
+++ b/zh/index.rst
@@ -1,10 +1,6 @@
 欢迎
 #######
 
-.. warning::
-    This version of the documentation is for CakePHP 3.0. Go `here for the
-    CakePHP 2.x documentation <http://book.cakephp.org/2.0/zh>`_.
-
 CakePHP CookBook 是一个公开地开发和社区可以编辑的文档项目。我们希望把文档的质量、有效性和准确性都保持在一个较高的水平。请注意在右上角的“改善本
 文档”按钮; 它会引导您进入当前页面的 GitHub 在线编辑器，让您可以轻松地为文档贡献任何添加、删除或更正。
 


### PR DESCRIPTION
The index page of the English translation (and most of the other translations as well) don't have the  "This version of the documentation is for CakePHP 3.0." anymore.  This PR brings the remaining translations in line with this.