### PR TITLE
Update documentation for security

### DIFF
--- a/en/core-utility-libraries/security.rst
+++ b/en/core-utility-libraries/security.rst
@@ -7,6 +7,11 @@ The `security library <http://api.cakephp.org/2.8/class-Security.html>`_
 handles basic security measures such as providing methods for
 hashing and encrypting data.
 
+.. warning::
+    The encryption features offered by Security rely on the deprecated
+    ``mcrypt`` extension. If you are using PHP>=7.1 you will need to install
+    mcrypt via pecl.
+
 Security API
 ============
 
@@ -96,18 +101,6 @@ Security API
 
     .. versionadded:: 2.5
 
-.. php:staticmethod:: generateAuthKey( )
-
-    :rtype: string
-
-    Generate authorization hash.
-
-.. php:staticmethod:: getInstance( )
-
-    :rtype: object
-
-    Singleton implementation to get object instance.
-
 .. php:staticmethod:: hash( $string, $type = NULL, $salt = false )
 
     :rtype: string
@@ -153,17 +146,6 @@ Security API
 
     Sets the default hash method for the Security object. This
     affects all objects using Security::hash().
-
-.. php:staticmethod:: validateAuthKey( $authKey )
-
-    :rtype: boolean
-
-    Validate authorization hash.
-
-.. todo::
-
-    Add more examples :|
-
 
 .. meta::
     :title lang=en: Security


### PR DESCRIPTION
* Mention that mcrypt is going away, and that a pecl extension will be
  required.
* Remove documentation for deprecated/non-existant methods.

Refs cakephp/cakephp#8834