### PR TITLE
Update documentation for PSR7 requests

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -716,7 +716,7 @@ calling ``$this->Auth->setUser()`` with the user data you want to 'login'::
 
     public function register()
     {
-        $user = $this->Users->newEntity($this->request->data);
+        $user = $this->Users->newEntity($this->request->data());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
             return $this->redirect([
@@ -987,12 +987,12 @@ checked::
         public function isAuthorized($user = null)
         {
             // Any registered user can access public functions
-            if (empty($this->request->params['prefix'])) {
+            if (!$this->request->param('prefix')) {
                 return true;
             }
 
             // Only admins can access admin functions
-            if ($this->request->params['prefix'] === 'admin') {
+            if ($this->request->param('prefix') === 'admin') {
                 return (bool)($user['role'] === 'admin');
             }
 

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -90,7 +90,7 @@ options into a custom finder method within the paginate property::
         // find articles by tag
         public function tags()
         {
-            $tags = $this->request->params['pass'];
+            $tags = $this->request->param('pass');
 
             $customFinderOptions = [
                 'tags' => $tags
@@ -130,7 +130,7 @@ Once the ``$paginate`` property has been defined, we can use the
 pagination data, and add the ``PaginatorHelper`` if it hasn't already been
 added. The controller's paginate method will return the result set of the
 paginated query, and set pagination metadata to the request. You can access the
-pagination metadata at ``$this->request->params['paging']``. A more complete
+pagination metadata at ``$this->request->param('paging')``. A more complete
 example of using ``paginate()`` would be::
 
     class ArticlesController extends AppController
@@ -278,7 +278,7 @@ block and take appropriate action when a ``NotFoundException`` is caught::
             $this->paginate();
         } catch (NotFoundException $e) {
             // Do something here like redirecting to first or last page.
-            // $this->request->params['paging'] will give you required info.
+            // $this->request->param('paging') will give you required info.
         }
     }
 

--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -15,7 +15,7 @@ RequestHandler will automatically switch the layout and template files to those
 that match non-HTML media types. Furthermore, if a helper with the same name as
 the requested extension exists, it will be added to the Controllers Helper
 array.  Lastly, if XML/JSON data is POST'ed to your Controllers, it will be
-parsed into an array which is assigned to ``$this->request->data``, and can then
+parsed into an array which is assigned to ``$this->request->data()``, and can then
 be accessed as you would standard POST data. In order to make use of
 RequestHandler it must be included in your ``initialize()`` method::
 
@@ -169,7 +169,7 @@ callbacks like ``json_decode``::
     // After 3.1.0 you should use
     $this->RequestHandler->config('inputTypeMap.json', ['json_decode', true]);
 
-The above will make ``$this->request->data`` an array of the JSON input data,
+The above will make ``$this->request->data()`` an array of the JSON input data,
 without the additional ``true`` you'd get a set of ``stdClass`` objects.
 
 .. deprecated:: 3.1.0

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -164,7 +164,7 @@ want and the Security Component will enforce them on its startup::
 
         public function beforeFilter(Event $event)
         {
-            if (isset($this->request->params['admin'])) {
+            if ($this->request->param('admin')) {
                 $this->Security->requireSecure();
             }
         }
@@ -196,7 +196,7 @@ require secure SSL requests::
 
         public function forceSSL()
         {
-            return $this->redirect('https://' . env('SERVER_NAME') . $this->request->here);
+            return $this->redirect('https://' . env('SERVER_NAME') . $this->request->here());
         }
     }
 

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -82,7 +82,7 @@ and validate request data::
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data)) {
+                if ($contact->execute($this->request->data())) {
                     $this->Flash->success('We will get back to you soon.');
                 } else {
                     $this->Flash->error('There was a problem submitting your form.');
@@ -97,13 +97,13 @@ In the above example, we use the ``execute()`` method to run our form's
 accordingly. We could have also used the ``validate()`` method to only validate
 the request data::
 
-    $isValid = $form->validate($this->request->data);
+    $isValid = $form->validate($this->request->data());
     
 Setting Form Values
 ===================
 
 In order to set the values for the fields of a modelless form, one can define
-the values using ``$this->request->data``, like in all other forms created by the FormHelper::
+the values using ``$this->request->data()``, like in all other forms created by the FormHelper::
 
     // In a controller
     namespace App\Controller;
@@ -117,23 +117,23 @@ the values using ``$this->request->data``, like in all other forms created by th
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data)) {
+                if ($contact->execute($this->request->data())) {
                     $this->Flash->success('We will get back to you soon.');
                 } else {
                     $this->Flash->error('There was a problem submitting your form.');
                 }
             }
-            
+
             if ($this->request->is('get')) {
-                //Values from the User Model e.g.
-                $this->request->data['name'] = 'John Doe';
-                $this->request->data['email'] = 'john.doe@example.com';
+                // Values from the User Model e.g.
+                $this->request->data('name', 'John Doe');
+                $this->request->data('email','john.doe@example.com');
             }
-            
+
             $this->set('contact', $contact);
         }
     }
-    
+
 Values should only be defined if the request method is GET, otherwise
 you will overwrite your previous POST Data which might have been incorrect
 and not been saved.

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -32,8 +32,8 @@ features that all applications are likely to need. The built-in filters are:
         DispatcherFactory::add('Asset', ['cacheTime' => '+24 hours']);
 
 * ``RoutingFilter`` applies application routing rules to the request URL.
-  Populates ``$request->params`` with the results of routing.
-* ``ControllerFactory`` uses ``$request->params`` to locate the controller that
+  Populates ``$request->param()`` with the results of routing.
+* ``ControllerFactory`` uses ``$request->param()`` to locate the controller that
   will handle the current request.
 * ``LocaleSelector`` enables automatic language switching from the ``Accept-Language``
   header sent by the browser.

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -51,7 +51,7 @@ controller might look something like this::
 
         public function add()
         {
-            $recipe = $this->Recipes->newEntity($this->request->data);
+            $recipe = $this->Recipes->newEntity($this->request->data());
             if ($this->Recipes->save($recipe)) {
                 $message = 'Saved';
             } else {
@@ -68,7 +68,7 @@ controller might look something like this::
         {
             $recipe = $this->Recipes->get($id);
             if ($this->request->is(['post', 'put'])) {
-                $recipe = $this->Recipes->patchEntity($recipe, $this->request->data);
+                $recipe = $this->Recipes->patchEntity($recipe, $this->request->data());
                 if ($this->Recipes->save($recipe)) {
                     $message = 'Saved';
                 } else {
@@ -148,9 +148,9 @@ as input. Not to worry, the
 :php:class:`Cake\\Routing\\Router` classes make things much easier. If a POST or
 PUT request has an XML content-type, then the input is run through  CakePHP's
 :php:class:`Xml` class, and the array representation of the data is assigned to
-``$this->request->data``.  Because of this feature, handling XML and POST data in
+``$this->request->data()``.  Because of this feature, handling XML and POST data in
 parallel is seamless: no changes are required to the controller or model code.
-Everything you need should end up in ``$this->request->data``.
+Everything you need should end up in ``$this->request->data()``.
 
 Accepting Input in Other Formats
 ================================
@@ -159,7 +159,7 @@ Typically REST applications not only output content in alternate data formats,
 but also accept data in different formats. In CakePHP, the
 :php:class:`RequestHandlerComponent` helps facilitate this. By default,
 it will decode any incoming JSON/XML input data for POST/PUT requests
-and supply the array version of that data in ``$this->request->data``.
+and supply the array version of that data in ``$this->request->data()``.
 You can also wire in additional deserializers for alternate formats if you
 need them, using :php:meth:`RequestHandler::addInputType()`.
 

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -218,7 +218,7 @@ Route Elements
 You can specify your own route elements and doing so gives you the
 power to define places in the URL where parameters for controller
 actions should lie. When a request is made, the values for these
-route elements are found in ``$this->request->params`` in the controller.
+route elements are found in ``$this->request->param()`` in the controller.
 When you define a custom route element, you can optionally specify a regular
 expression - this tells CakePHP how to know if the URL is correctly formed or
 not. If you choose to not provide a regular expression, any non ``/`` character
@@ -264,7 +264,7 @@ If you need lowercased and underscored URLs while migrating from a CakePHP
 
 Once this route has been defined, requesting ``/apples/5`` would call the view()
 method of the ApplesController. Inside the view() method, you would need to
-access the passed ID at ``$this->request->params['id']``.
+access the passed ID at ``$this->request->param('id')``.
 
 If you have a single controller in your application and you do not want the
 controller name to appear in the URL, you can map all URLs to actions in your
@@ -310,7 +310,7 @@ alternates, as above, but not grouped with parenthesis.
 Once defined, this route will match ``/articles/2007/02/01``,
 ``/articles/2004/11/16``, handing the requests to
 the index() actions of their respective controllers, with the date
-parameters in ``$this->request->params``.
+parameters in ``$this->request->param()``.
 
 There are several route elements that have special meaning in
 CakePHP, and should not be used unless you want the special meaning
@@ -533,7 +533,7 @@ The connected route would have the ``prefix`` route element set to
 ``manager/admin``.
 
 The current prefix will be available from the controller methods through
-``$this->request->params['prefix']``
+``$this->request->param('prefix')``
 
 When using prefix routes it's important to set the prefix option. Here's how to
 build this link using the HTML helper::
@@ -890,7 +890,7 @@ to your controller methods. ::
 In the above example, both ``recent`` and ``mark`` are passed arguments to
 ``CalendarsController::view()``. Passed arguments are given to your controllers
 in three ways. First as arguments to the action method called, and secondly they
-are available in ``$this->request->params['pass']`` as a numerically indexed
+are available in ``$this->request->param('pass')`` as a numerically indexed
 array. When using custom routes you can force particular parameters to go into
 the passed arguments as well.
 
@@ -913,12 +913,11 @@ You would get the following output::
         [1] => mark
     )
 
-This same data is also available at ``$this->request->params['pass']``
-and ``$this->passedArgs`` in your controllers, views, and helpers.
-The values in the pass array are numerically indexed based on the
-order they appear in the called URL::
+This same data is also available at ``$this->request->param('pass')`` in your
+controllers, views, and helpers.  The values in the pass array are numerically
+indexed based on the order they appear in the called URL::
 
-    debug($this->request->params['pass']);
+    debug($this->request->param('pass'));
 
 Either of the above would output::
 
@@ -1129,8 +1128,8 @@ The URL filter function should *always* return the params even if unmodified.
 URL filters allow you to implement features like persistent parameters::
 
     Router::addUrlFilter(function ($params, $request) {
-        if (isset($request->params['lang']) && !isset($params['lang'])) {
-            $params['lang'] = $request->params['lang'];
+        if ($request->param('lang') && !isset($params['lang'])) {
+            $params['lang'] = $request->param('lang');
         }
         return $params;
     });
@@ -1178,7 +1177,7 @@ arguments::
         Router::parseNamedParams($this->request);
     }
 
-This will populate ``$this->request->params['named']`` with any named parameters
+This will populate ``$this->request->param('named')`` with any named parameters
 found in the passed arguments.  Any passed argument that was interpreted as a
 named parameter, will be removed from the list of passed arguments.
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -787,7 +787,7 @@ controller code looks like::
         public function index($short = null)
         {
             if ($this->request->is('post')) {
-                $article = $this->Articles->newEntity($this->request->data);
+                $article = $this->Articles->newEntity($this->request->data());
                 if ($this->Articles->save($article)) {
                     // Redirect as per PRG pattern
                     return $this->redirect(['action' => 'index']);

--- a/en/elasticsearch.rst
+++ b/en/elasticsearch.rst
@@ -65,7 +65,7 @@ You can then use your type class in your controllers::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data);
+            $article = $this->Articles->patchEntity($article, $this->request->data());
             if ($this->Articles->save($article)) {
                 $this->Flash->success('It saved');
             }

--- a/en/intro.rst
+++ b/en/intro.rst
@@ -99,7 +99,7 @@ controller would be::
     {
         $user = $this->Users->newEntity();
         if ($this->request->is('post')) {
-            $user = $this->Users->patchEntity($user, $this->request->data);
+            $user = $this->Users->patchEntity($user, $this->request->data());
             if ($this->Users->save($user, ['validate' => 'registration'])) {
                 $this->Flash->success(__('You are now registered.'));
             } else {

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -435,7 +435,7 @@ create form inputs for your translated fields::
 In your controller, you can marshal the data as normal, but with the
 ``translations`` option enabled::
 
-    $article = $this->Articles->newEntity($this->request->data, [
+    $article = $this->Articles->newEntity($this->request->data(), [
         'translations' => true
     ]);
     $this->Articles->save($article);

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -667,7 +667,7 @@ sending an array in the request containing the ``user_id`` an attacker could
 change the owner of an article, causing undesirable effects::
 
     // Contains ['user_id' => 100, 'title' => 'Hacked!'];
-    $data = $this->request->data;
+    $data = $this->request->data();
     $entity = $this->patchEntity($entity, $data);
     $this->save($entity);
 
@@ -679,7 +679,7 @@ The second way is by using the ``fieldList`` option when creating or merging
 data into an entity::
 
     // Contains ['user_id' => 100, 'title' => 'Hacked!'];
-    $data = $this->request->data;
+    $data = $this->request->data();
 
     // Only allow title to be changed
     $entity = $this->patchEntity($entity, $data, [
@@ -716,7 +716,7 @@ using ``newEntity()`` for passing into ``save()``. For example::
 
   // In a controller
   $articles = TableRegistry::get('Articles');
-  $article = $articles->newEntity($this->request->data);
+  $article = $articles->newEntity($this->request->data());
   if ($articles->save($article)) {
       // ...
   }

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -21,7 +21,7 @@ will be validated before it is converted into entities.
 If any validation rules fail, the returned entity will contain errors. The
 fields with errors will not be present in the returned entity::
 
-    $article = $articles->newEntity($this->request->data);
+    $article = $articles->newEntity($this->request->data());
     if ($article->errors()) {
         // Entity failed validation.
     }
@@ -42,7 +42,7 @@ If you'd like to disable validation when converting request data, set the
 ``validate`` option to false::
 
     $article = $articles->newEntity(
-        $this->request->data,
+        $this->request->data(),
         ['validate' => false]
     );
 
@@ -100,7 +100,7 @@ In addition to disabling validation you can choose which validation rule set you
 want applied::
 
     $article = $articles->newEntity(
-        $this->request->data,
+        $this->request->data(),
         ['validate' => 'update']
     );
 

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -87,7 +87,7 @@ with CakePHP::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data);
+                $user = $this->Users->patchEntity($user, $this->request->data());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
                     return $this->redirect(['action' => 'add']);
@@ -309,7 +309,7 @@ currently logged in user as a reference for the created article::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data);
+            $article = $this->Articles->patchEntity($article, $this->request->data());
             // Added this line
             $article->user_id = $this->Auth->user('id');
             // You could also do the following
@@ -386,13 +386,13 @@ own.  Add the following content to your **ArticlesController.php**::
     public function isAuthorized($user)
     {
         // All registered users can add articles
-        if ($this->request->action === 'add') {
+        if ($this->request->param('action') === 'add') {
             return true;
         }
 
         // The owner of an article can edit and delete it
-        if (in_array($this->request->action, ['edit', 'delete'])) {
-            $articleId = (int)$this->request->params['pass'][0];
+        if (in_array($this->request->param('action'), ['edit', 'delete'])) {
+            $articleId = (int)$this->request->param('pass.0');
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;
             }

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -350,7 +350,7 @@ it::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data);
+                $article = $this->Articles->patchEntity($article, $this->request->data());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -296,7 +296,7 @@ First, start by creating an ``add()`` action in the
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data);
+                $article = $this->Articles->patchEntity($article, $this->request->data());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);
@@ -324,7 +324,7 @@ application.  In this case, we use the :php:meth:`Cake\\Network\\Request::is()`
 method to check that the request is a HTTP POST request.
 
 When a user uses a form to POST data to your application, that
-information is available in ``$this->request->data``. You can use the
+information is available in ``$this->request->data()``. You can use the
 :php:func:`pr()` or :php:func:`debug()` functions to print it out if you want to
 see what it looks like.
 
@@ -459,7 +459,7 @@ like::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            $this->Articles->patchEntity($article, $this->request->data);
+            $this->Articles->patchEntity($article, $this->request->data());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
                 return $this->redirect(['action' => 'index']);

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -323,7 +323,7 @@ add the following::
     {
         // The 'pass' key is provided by CakePHP and contains all
         // the passed URL path segments in the request.
-        $tags = $this->request->params['pass'];
+        $tags = $this->request->param('pass');
 
         // Use the BookmarksTable to find tagged bookmarks.
         $bookmarks = $this->Bookmarks->find('tagged', [

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -185,19 +185,19 @@ sense. First, we'll add the authorization logic for bookmarks. In your
 
     public function isAuthorized($user)
     {
-        $action = $this->request->params['action'];
+        $action = $this->request->param('action');
 
         // The add and index actions are always allowed.
         if (in_array($action, ['index', 'add', 'tags'])) {
             return true;
         }
         // All other actions require an id.
-        if (empty($this->request->params['pass'][0])) {
+        if (!$this->request->params('pass.0')) {
             return false;
         }
 
         // Check that the bookmark belongs to the current user.
-        $id = $this->request->params['pass'][0];
+        $id = $this->request->param('pass.0');
         $bookmark = $this->Bookmarks->get($id);
         if ($bookmark->user_id == $user['id']) {
             return true;
@@ -234,7 +234,7 @@ like::
     {
         $bookmark = $this->Bookmarks->newEntity();
         if ($this->request->is('post')) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data);
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
@@ -258,7 +258,7 @@ edit form and action. Your ``edit()`` action from
             'contain' => ['Tags']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data);
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -71,7 +71,7 @@ You can use the current action name to conditionally load helpers::
         public function initialize()
         {
             parent::initialize();
-            if ($this->request->action === 'index') {
+            if ($this->request->param('action') === 'index') {
                 $this->loadHelper('ListPage');
             }
         }

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -110,7 +110,7 @@ input-tags, receive their values from.
 
 By default FormHelper draws its values from the 'context'.  The default
 contexts, such as ``EntityContext``, will fetch data from the current entity, or
-from ``$request->data``.
+from ``$request->data()``.
 
 If however, you are building a form that needs to read from the query string,
 you can use ``valueSource()`` to change where ``FormHelper`` reads data input
@@ -549,7 +549,7 @@ common options shared by all input methods are as follows:
   .. note::
 
     You cannot use ``default`` to check a checkbox - instead you might
-    set the value in ``$this->request->data`` in your controller,
+    set the value in ``$this->request->data()`` in your controller,
     or set the input option ``checked`` to ``true``.
 
     Beware of using ``false`` to assign a default value. A ``false`` value is
@@ -558,10 +558,10 @@ common options shared by all input methods are as follows:
 
 * ``$options['value']`` Used to set a specific value for the input field. This
   will override any value that may else be injected from the context, such as
-  Form, Entity or ``request->data`` etc.
+  Form, Entity or ``request->data()`` etc.
 
   .. note::
-  
+
     If you want to set a field to not render its value fetched from
     context or valuesSource you will need to set ``$options['value']`` to ``''``
     (instead of setting it to ``null``).
@@ -629,7 +629,7 @@ Options for Select, Checkbox and Radio Inputs
   Options can also supplied as key-value pairs.
 
 * ``$options['hiddenField']`` For certain input types (checkboxes, radios) a
-  hidden input is created so that the key in $this->request->data will exist
+  hidden input is created so that the key in ``$this->request->data()`` will exist
   even without a value specified:
 
   .. code-block:: html
@@ -798,7 +798,7 @@ Will output:
 
     <textarea name="notes"></textarea>
 
-If the form is edited (that is, the array ``$this->request->data`` will
+If the form is edited (that is, the array ``$this->request->data()`` will
 contain the information saved for the ``User`` model), the value
 corresponding to ``notes`` field will automatically be added to the HTML
 generated. Example:
@@ -1178,7 +1178,7 @@ of options:
 * ``round`` - Set to ``up`` or ``down`` if you want to force rounding in either
   direction. Defaults to null.
 * ``default`` The default value to be used by the input. A value in
-  ``$this->request->data`` matching the field name will override this value. If
+  ``$this->request->data()`` matching the field name will override this value. If
   no default is provided ``time()`` will be used.
 * ``timeFormat`` The time format to use, either 12 or 24.
 * ``second`` Set to ``true`` to enable seconds drop down.
@@ -1232,7 +1232,7 @@ empty option:
 * ``empty`` - If ``true``, the empty select option is shown. If a string,
   that string is displayed as the empty element.
 * ``default`` | ``value`` The default value to be used by the input. A value in
-  ``$this->request->data`` matching the field name will override this value.
+  ``$this->request->data()`` matching the field name will override this value.
   If no default is provided ``time()`` will be used.
 * ``timeFormat`` The time format to use, either 12 or 24. Defaults to 24.
 * ``second`` Set to ``true`` to enable seconds drop down.
@@ -1839,7 +1839,7 @@ create the following inputs::
 The above inputs could then be marshalled into a completed entity graph using
 the following code in your controller::
 
-    $article = $this->Articles->patchEntity($article, $this->request->data, [
+    $article = $this->Articles->patchEntity($article, $this->request->data(), [
         'associated' => [
             'Authors',
             'Authors.Profiles',


### PR DESCRIPTION
* Stop using deprecated properties/methods in the examples.
* Document new methods.
* Remove outdated information about Apache.

Refs cakephp/cakephp#9325