### PR TITLE
Clarify usage of isUnique when passing in multiple fields

### DIFF
--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -361,7 +361,10 @@ allows you to define unique field sets::
     $rules->add($rules->isUnique(['email']));
 
     // A list of fields
-    $rules->add($rules->isUnique(['username', 'account_id']));
+    $rules->add($rules->isUnique(
+        ['username', 'account_id'],
+        'This username & account_id combination has already been used.'
+    ));
 
 When setting rules on foreign key fields it is important to remember, that
 only the fields listed are used in the rule. This means that setting


### PR DESCRIPTION
Multiple fields in an isUnique call creates a constraint across the fields, not a new constraint per field.

Closes cakephp/cakephp#9675