### PR TITLE
Added blank line before return

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -216,6 +216,7 @@ Example of a method definition::
         if (expr) {
             statement;
         }
+        
         return $var;
     }
 
@@ -234,6 +235,7 @@ it can be determined whether the function call was successful::
         if (!($dnsInfo) || !($dnsInfo['phpType'])) {
             return $this->addError();
         }
+        
         return true;
     }
 


### PR DESCRIPTION
The standards appear to enforce a blank line before a function `return`, so I've updated the method definition examples to show this correctly.