### PR TITLE
dropdown menu improvement: delay hide submenu on mouseout.

### DIFF
--- a/themes/cakephp/static/css/style.css
+++ b/themes/cakephp/static/css/style.css
@@ -1880,8 +1880,20 @@ header {
     transition: all .0s ease-out;
 }
 
+.dropdown > .dropdown-menu {
+    display: block;
+    visibility: hidden;
+    opacity: 0;
+    -webkit-transition: all 0s ease .5s;
+    transition: all 0s ease .5s;
+}
+
 .dropdown:hover > .dropdown-menu {
     display: block;
+    visibility: visible;
+    opacity: 1;
+    -webkit-transition: all 0s ease 0s;
+    transition: all 0s ease 0s;
 }
 
 .navbar-nav > li > .dropdown-menu {


### PR DESCRIPTION
related pull request: #4430 

0.5s delay hide submenu for unintentional mouseout.
(JavaScript Library's Behavior re-implement.)