### PR TITLE
Fix navigation menu doesn't display if short width

### DIFF
--- a/themes/cakephp/static/css/style.css
+++ b/themes/cakephp/static/css/style.css
@@ -1880,20 +1880,22 @@ header {
     transition: all .0s ease-out;
 }
 
-.dropdown > .dropdown-menu {
-    display: block;
-    visibility: hidden;
-    opacity: 0;
-    -webkit-transition: all 0s ease .5s;
-    transition: all 0s ease .5s;
-}
+@media (min-width:992px) {
+    .dropdown > .dropdown-menu {
+        display: block;
+        visibility: hidden;
+        opacity: 0;
+        -webkit-transition: all 0s ease .5s;
+        transition: all 0s ease .5s;
+    }
 
-.dropdown:hover > .dropdown-menu {
-    display: block;
-    visibility: visible;
-    opacity: 1;
-    -webkit-transition: all 0s ease 0s;
-    transition: all 0s ease 0s;
+    .dropdown:hover > .dropdown-menu {
+        display: block;
+        visibility: visible;
+        opacity: 1;
+        -webkit-transition: all 0s ease 0s;
+        transition: all 0s ease 0s;
+    }
 }
 
 .navbar-nav > li > .dropdown-menu {


### PR DESCRIPTION
Navigation menu doesn't display if short width that caused by #4442 's change.
Fixed Enable effect only work if width > 991px.

sorry.