### PR TITLE
Fix can't access navigation menu if short width (1.x book)

### DIFF
--- a/themes/cakephp/static/css/responsive.css
+++ b/themes/cakephp/static/css/responsive.css
@@ -133,7 +133,7 @@
     }
 
     .nav-btn {
-        padding-top: 73px;
+        padding-top: 136px;
         padding-bottom: 17px;
     }
 

--- a/themes/cakephp/static/css/style.css
+++ b/themes/cakephp/static/css/style.css
@@ -1916,7 +1916,7 @@ header {
 }
 
 .nav-btn {
-    padding-top: 88px;
+    padding-top: 125px;
     background: #ECECEC;
     padding-bottom: 14px;
 }


### PR DESCRIPTION
1.x book can't access nav menu if short window width.
(masked by version warning)

![navigation-issue](https://cloud.githubusercontent.com/assets/16202/20030069/8475ebac-a3a0-11e6-8b73-d908f5d9e1fe.png)

Tune padding.
I'll extract to 1.1, 1.2 branch if merged.