### PR TITLE
Fix component testing example code

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1297,6 +1297,7 @@ correctly by the ``adjust()`` method in our component. We create the file
     use App\Controller\Component\PagematronComponent;
     use Cake\Controller\Controller;
     use Cake\Controller\ComponentRegistry;
+    use Cake\Event\Event;
     use Cake\Network\Request;
     use Cake\Network\Response;
     use Cake\TestSuite\TestCase;
@@ -1313,13 +1314,15 @@ correctly by the ``adjust()`` method in our component. We create the file
             // Setup our component and fake test controller
             $request = new Request();
             $response = new Response();
-            $this->controller = $this->getMock(
-                'Cake\Controller\Controller',
-                null,
-                [$request, $response]
-            );
+
+            $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+                ->setConstructorArgs([$request, $response])
+                ->setMethods(null)
+                ->getMock();
             $registry = new ComponentRegistry($this->controller);
             $this->component = new PagematronComponent($registry);
+            $event = new Event('Controller.startup', $this->controller);
+            $this->component->startup($event);
         }
 
         public function testAdjust()

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1314,7 +1314,6 @@ correctly by the ``adjust()`` method in our component. We create the file
             // Setup our component and fake test controller
             $request = new Request();
             $response = new Response();
-
             $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
                 ->setConstructorArgs([$request, $response])
                 ->setMethods(null)


### PR DESCRIPTION
[Testing Components](http://book.cakephp.org/3.0/en/development/testing.html#testing-components)'s TestCase didn't pass to phpunit.

I find two problems in the `PagematronComponentTest` class.

* `PHPUnit_Framework_TestCase::getMock()` is deprecated PHPUnit >= 5.4.0([Release Announcement for PHPUnit 5.4.0](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0#changes)), then echo warning. replaced to `getMockBuilder()`.
* `component->startup()` didn't call. then `testAdjust()` fail.

fixed code passed follow environments.

* PHP 5.6.27 + CakePHP 3.3.8 + PHPUnit 5.6.2
* PHP 5.5.38 + CakePHP 3.3.8 + PHPUnit 4.8.27