### PR TITLE
Update docs for deprecations in cakephp/cakephp#9752

### DIFF
--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -44,6 +44,9 @@ elements will continue to function until 4.0.0 after which they will be removed.
 * ``Cake\Database\Schema\Table`` has been renamed to
   ``Cake\Database\Schema\TableSchema``. The previous name was confusing to a number
   of users.
+* The ``fieldList`` option for  ``Cake\ORM\Table::newEntity()`` and
+  ``patchEntity()`` has been renamed to ``fields`` to be more consistent with
+  other parts of the ORM.
 
 Deprecated Combined Get/Set Methods
 -----------------------------------

--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -49,7 +49,7 @@ Deprecated Combined Get/Set Methods
 -----------------------------------
 
 In the past CakePHP has leveraged 'modal' methods that operate as provide both
-a get/set mode. These methods are complicate IDE autocompletion and our ability
+a get/set mode. These methods complicate IDE autocompletion and our ability
 to add stricter return types in the future. For these reasons, combined get/set
 methods are being split into separate get and set methods.
 

--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -45,6 +45,26 @@ elements will continue to function until 4.0.0 after which they will be removed.
   ``Cake\Database\Schema\TableSchema``. The previous name was confusing to a number
   of users.
 
+Deprecated Combined Get/Set Methods
+-----------------------------------
+
+In the past CakePHP has leveraged 'modal' methods that operate as provide both
+a get/set mode. These methods are complicate IDE autocompletion and our ability
+to add stricter return types in the future. For these reasons, combined get/set
+methods are being split into separate get and set methods.
+
+The following is a list of methods that are deprecated and replaced with
+``getX`` and ``setX`` methods:
+
+Cake\Console\ConsoleOptionParse
+    * ``command()``
+    * ``description()``
+    * ``epliog()``
+Cake\Validation\Validator
+    * ``provider()``
+Cake\View\StringTemplateTrait
+    * ``templates()``
+
 Behavior Changes
 ================
 

--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -14,10 +14,10 @@ elements will continue to function until 4.0.0 after which they will be removed.
   been added to read/write the relevant properties.
 * Several properties on ``Cake\Network\Request`` have been deprecated:
 
-  * ``Request::$params`` is deprecated. Use ``Request::param()`` instead.
-  * ``Request::$data`` is deprecated. Use ``Request::data()`` instead.
-  * ``Request::$query`` is deprecated. Use ``Request::query()`` instead.
-  * ``Request::$cookies`` is deprecated. Use ``Request::cookie()`` instead.
+  * ``Request::$params`` is deprecated. Use ``Request::getParam()`` instead.
+  * ``Request::$data`` is deprecated. Use ``Request::getData()`` instead.
+  * ``Request::$query`` is deprecated. Use ``Request::getQuery()`` instead.
+  * ``Request::$cookies`` is deprecated. Use ``Request::getCookie()`` instead.
   * ``Request::$base`` is deprecated. Use ``Request::getAttribute('base')`` instead.
   * ``Request::$webroot`` is deprecated. Use ``Request::getAttribute('webroot')`` instead.
   * ``Request::$here`` is deprecated. Use ``Request::here()`` instead.
@@ -25,11 +25,14 @@ elements will continue to function until 4.0.0 after which they will be removed.
 
 * A number of methods on ``Cake\Network\Request`` have been deprecated:
 
-  * The setter modes for ``query()``, ``data()`` and ``param()`` are deprecated.
-  * ``__get()`` & ``__isset()`` methods are deprecated. Use ``param()`` instead.
+  * ``__get()`` & ``__isset()`` methods are deprecated. Use ``getParam()`` instead.
   * ``method()`` is deprecated. Use ``getMethod()`` instead.
   * ``setInput()`` is deprecated. Use ``withBody()`` instead.
   * The ``ArrayAccess`` methods have all been deprecated.
+  * ``Request::param()`` is deprecated. Use ``Request::getParam()`` instead.
+  * ``Request::data()`` is deprecated. Use ``Request::getData()`` instead.
+  * ``Request::query()`` is deprecated. Use ``Request::getQuery()`` instead.
+  * ``Request::cookie()`` is deprecated. Use ``Request::getCookie()`` instead.
 
 * The ``Auth.redirect`` session variable is no longer used. Instead a query
   string parameter is used to store the redirect URL.

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -648,21 +648,27 @@ The methods that allow chaining are:
 - addSubcommand()
 - addSubcommands()
 - command()
+- setCommand()
 - description()
-- epilog()
+- setDescription()
+- setEpilog()
 
-.. php:method:: description($text = null)
+Set the Description
+~~~~~~~~~~~~~~~~~~~
 
-Gets or sets the description for the option parser. The description displays
-above the argument and option information. By passing in either an array or a
-string, you can set the value of the description. Calling with no arguments will
-return the current value::
+.. php:method:: setDescription($text)
+
+The description displays above the argument and option information. By passing
+in either an array or a string, you can set the value of the description.
+Calling with no arguments will return the current value::
 
     // Set multiple lines at once
+    $parser->setDescription(['line one', 'line two']);
+    // Prior to 3.4
     $parser->description(['line one', 'line two']);
 
     // Read the current value
-    $parser->description();
+    $parser->getDescription();
 
 The **src/Shell/ConsoleShell.php** is a good example of the ``description()``
 method in action::
@@ -675,7 +681,7 @@ method in action::
     public function getOptionParser()
     {
         $parser = new ConsoleOptionParser('console');
-        $parser->description(
+        $parser->setDescription(
             'This shell provides a REPL that you can use to interact ' .
             'with your application in an interactive fashion. You can use ' .
             'it to run adhoc queries with your models, or experiment ' .
@@ -712,7 +718,10 @@ command::
     --verbose, -v  Enable verbose output.
     --quiet, -q    Enable quiet output.
 
-.. php:method:: epilog($text = null)
+Set the Epilog
+--------------
+
+.. php:method:: setEpilog($text)
 
 Gets or sets the epilog for the option parser. The epilog is displayed after the
 argument and option information. By passing in either an array or a string, you
@@ -720,10 +729,12 @@ can set the value of the epilog. Calling with no arguments will return the
 current value::
 
     // Set multiple lines at once
+    $parser->setEpilog(['line one', 'line two']);
+    // Prior to 3.4
     $parser->epilog(['line one', 'line two']);
 
     // Read the current value
-    $parser->epilog();
+    $parser->getEpilog();
 
 To illustrate the ``epilog()`` method in action lets add a call to the
 ``getOptionParser()`` method used above in the **src/Shell/ConsoleShell.php**::
@@ -736,7 +747,7 @@ To illustrate the ``epilog()`` method in action lets add a call to the
     public function getOptionParser()
     {
         $parser = new ConsoleOptionParser('console');
-        $parser->description(
+        $parser->setDescription(
             'This shell provides a REPL that you can use to interact ' .
             'with your application in an interactive fashion. You can use ' .
             'it to run adhoc queries with your models, or experiment ' .
@@ -744,11 +755,11 @@ To illustrate the ``epilog()`` method in action lets add a call to the
             "\n\n" .
             'You will need to have psysh installed for this Shell to work.'
         );
-        $parser->epilog('Thank you for baking with CakePHP!');
+        $parser->setEpilog('Thank you for baking with CakePHP!');
         return $parser;
     }
 
-The text added with the ``epilog()`` method can be seen in the output from
+The text added with the ``setEpilog()`` method can be seen in the output from
 the following console command::
 
     user@ubuntu:~/cakeblog$ bin/cake console --help

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -659,8 +659,7 @@ Set the Description
 .. php:method:: setDescription($text)
 
 The description displays above the argument and option information. By passing
-in either an array or a string, you can set the value of the description.
-Calling with no arguments will return the current value::
+in either an array or a string, you can set the value of the description::
 
     // Set multiple lines at once
     $parser->setDescription(['line one', 'line two']);

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -146,7 +146,7 @@ controller, you could access them like so::
 
         public function delete()
         {
-            if ($this->Post->delete($this->request->data('Post.id')) {
+            if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
                 return $this->redirect(['action' => 'index']);
             }

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -703,7 +703,7 @@ function accordingly::
                 $this->Auth->setUser($user);
                 if ($this->Auth->authenticationProvider()->needsPasswordRehash()) {
                     $user = $this->Users->get($this->Auth->user('id'));
-                    $user->password = $this->request->data('password');
+                    $user->password = $this->request->getData('password');
                     $this->Users->save($user);
                 }
                 return $this->redirect($this->Auth->redirectUrl());
@@ -727,7 +727,7 @@ calling ``$this->Auth->setUser()`` with the user data you want to 'login'::
 
     public function register()
     {
-        $user = $this->Users->newEntity($this->request->data());
+        $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
             return $this->redirect([

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -998,12 +998,12 @@ checked::
         public function isAuthorized($user = null)
         {
             // Any registered user can access public functions
-            if (!$this->request->param('prefix')) {
+            if (!$this->request->getParam('prefix')) {
                 return true;
             }
 
             // Only admins can access admin functions
-            if ($this->request->param('prefix') === 'admin') {
+            if ($this->request->getParam('prefix') === 'admin') {
                 return (bool)($user['role'] === 'admin');
             }
 

--- a/en/controllers/components/cookie.rst
+++ b/en/controllers/components/cookie.rst
@@ -107,7 +107,7 @@ The CookieComponent offers a number of methods for working with Cookies.
         CookieComponent cannot interact with bare strings values that contain
         ``,``. The component will attempt to interpret these values as
         arrays, leading to incorrect results. Instead you should use
-        ``$request->cookie()``.
+        ``$request->getCookie()``.
 
 .. php:method:: check($key)
 

--- a/en/controllers/components/csrf.rst
+++ b/en/controllers/components/csrf.rst
@@ -53,7 +53,7 @@ The available configuration options are:
 
 When enabled, you can access the current CSRF token on the request object::
 
-    $token = $this->request->param('_csrfToken');
+    $token = $this->request->getParam('_csrfToken');
 
 Integration with FormHelper
 ===========================

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -90,7 +90,7 @@ options into a custom finder method within the paginate property::
         // find articles by tag
         public function tags()
         {
-            $tags = $this->request->param('pass');
+            $tags = $this->request->getParam('pass');
 
             $customFinderOptions = [
                 'tags' => $tags
@@ -130,7 +130,7 @@ Once the ``$paginate`` property has been defined, we can use the
 pagination data, and add the ``PaginatorHelper`` if it hasn't already been
 added. The controller's paginate method will return the result set of the
 paginated query, and set pagination metadata to the request. You can access the
-pagination metadata at ``$this->request->param('paging')``. A more complete
+pagination metadata at ``$this->request->getParam('paging')``. A more complete
 example of using ``paginate()`` would be::
 
     class ArticlesController extends AppController
@@ -278,7 +278,7 @@ block and take appropriate action when a ``NotFoundException`` is caught::
             $this->paginate();
         } catch (NotFoundException $e) {
             // Do something here like redirecting to first or last page.
-            // $this->request->param('paging') will give you required info.
+            // $this->request->getParam('paging') will give you required info.
         }
     }
 

--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -15,7 +15,7 @@ RequestHandler will automatically switch the layout and template files to those
 that match non-HTML media types. Furthermore, if a helper with the same name as
 the requested extension exists, it will be added to the Controllers Helper
 array. Lastly, if XML/JSON data is POST'ed to your Controllers, it will be
-parsed into an array which is assigned to ``$this->request->data()``, and can then
+parsed into an array which is assigned to ``$this->request->getData()``, and can then
 be accessed as you would standard POST data. In order to make use of
 RequestHandler it must be included in your ``initialize()`` method::
 
@@ -169,7 +169,7 @@ callbacks like ``json_decode``::
     // After 3.1.0 you should use
     $this->RequestHandler->config('inputTypeMap.json', ['json_decode', true]);
 
-The above will make ``$this->request->data()`` an array of the JSON input data,
+The above will make ``$this->request->getData()`` an array of the JSON input data,
 without the additional ``true`` you'd get a set of ``stdClass`` objects.
 
 .. deprecated:: 3.1.0

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -164,7 +164,7 @@ want and the Security Component will enforce them on its startup::
 
         public function beforeFilter(Event $event)
         {
-            if ($this->request->param('admin')) {
+            if ($this->request->getParam('admin')) {
                 $this->Security->requireSecure();
             }
         }

--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -222,7 +222,7 @@ their own response. We can see both options in our simple middleware::
 
             // When modifying the response, you should do it
             // *after* calling next.
-            if (!$request->cookie('landing_page')) {
+            if (!$request->getCookie('landing_page')) {
                 $response->cookie([
                     'name' => 'landing_page',
                     'value' => $request->here(),

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -72,14 +72,17 @@ Query string parameters can be read using
 :php:attr:`~Cake\\Network\\Request::$query`::
 
     // URL is /posts/index?page=1&sort=title
-    $this->request->query('page');
+    $this->request->getQuery('page');
 
 You can either directly access the query property, or you can use
 ``query()`` method to read the URL query array in an error-free manner.
 Any keys that do not exist will return ``null``::
 
-    $foo = $this->request->query('value_that_does_not_exist');
+    $foo = $this->request->getQuery('value_that_does_not_exist');
     // $foo === null
+
+    // You can also provide default values
+    $foo = $this->request->getQuery('does_not_exist', 'default val');
 
 If you want to access all the query parameters you can use
 ``getQueryParams()``::

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -99,11 +99,11 @@ Any form data that contains a ``data`` prefix will have that data prefix
 removed. For example::
 
     // An input with a name attribute equal to 'MyModel[title]' is accessible at
-    $this->request->data('MyModel.title');
+    $this->request->getData('MyModel.title');
 
 Any keys that do not exist will return ``null``::
 
-    $foo = $this->request->data('Value.that.does.not.exist');
+    $foo = $this->request->getData('Value.that.does.not.exist');
     // $foo == null
 
 PUT, PATCH or DELETE Data

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -39,9 +39,9 @@ use libraries from outside of CakePHP.
 Request Parameters
 ------------------
 
-The request exposes the routing parameters through the ``param()`` method::
+The request exposes the routing parameters through the ``getParam()`` method::
 
-    $this->request->param('controller');
+    $this->request->getParam('controller');
 
 All :ref:`route-elements` are accessed through this interface.
 
@@ -50,7 +50,7 @@ In addition to :ref:`route-elements`, you also often need access to
 well::
 
     // Passed arguments
-    $this->request->param('pass');
+    $this->request->getParam('pass');
 
 Will all provide you access to the passed arguments. There
 are several important/useful parameters that CakePHP uses internally, these
@@ -242,7 +242,7 @@ Some examples would be::
     $this->request->addDetector(
         'awesome',
         function ($request) {
-            return $request->param('awesome');
+            return $request->getParam('awesome');
         }
     );
 
@@ -250,7 +250,7 @@ Some examples would be::
     $this->request->addDetector(
         'controller',
         function ($request, $name) {
-            return $request->param('controller') === $name;
+            return $request->getParam('controller') === $name;
         }
     );
 

--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -517,7 +517,7 @@ email we could do the following::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data())
+                $user = $this->Users->patchEntity($user, $this->request->getData())
                 if ($this->Users->save($user)) {
                     $this->getMailer('User')->send('welcome', [$user]);
                 }

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -98,12 +98,13 @@ accordingly. We could have also used the ``validate()`` method to only validate
 the request data::
 
     $isValid = $form->validate($this->request->getData());
-    
+
 Setting Form Values
 ===================
 
 In order to set the values for the fields of a modelless form, one can define
-the values using ``$this->request->getData()``, like in all other forms created by the FormHelper::
+the values using ``$this->request->data()``, like in all other forms created by
+the FormHelper::
 
     // In a controller
     namespace App\Controller;
@@ -126,8 +127,8 @@ the values using ``$this->request->getData()``, like in all other forms created 
 
             if ($this->request->is('get')) {
                 // Values from the User Model e.g.
-                $this->request->getData('name', 'John Doe');
-                $this->request->getData('email','john.doe@example.com');
+                $this->request->data('name', 'John Doe');
+                $this->request->data('email','john.doe@example.com');
             }
 
             $this->set('contact', $contact);

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -82,7 +82,7 @@ and validate request data::
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('We will get back to you soon.');
                 } else {
                     $this->Flash->error('There was a problem submitting your form.');
@@ -97,13 +97,13 @@ In the above example, we use the ``execute()`` method to run our form's
 accordingly. We could have also used the ``validate()`` method to only validate
 the request data::
 
-    $isValid = $form->validate($this->request->data());
+    $isValid = $form->validate($this->request->getData());
     
 Setting Form Values
 ===================
 
 In order to set the values for the fields of a modelless form, one can define
-the values using ``$this->request->data()``, like in all other forms created by the FormHelper::
+the values using ``$this->request->getData()``, like in all other forms created by the FormHelper::
 
     // In a controller
     namespace App\Controller;
@@ -117,7 +117,7 @@ the values using ``$this->request->data()``, like in all other forms created by 
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('We will get back to you soon.');
                 } else {
                     $this->Flash->error('There was a problem submitting your form.');
@@ -126,8 +126,8 @@ the values using ``$this->request->data()``, like in all other forms created by 
 
             if ($this->request->is('get')) {
                 // Values from the User Model e.g.
-                $this->request->data('name', 'John Doe');
-                $this->request->data('email','john.doe@example.com');
+                $this->request->getData('name', 'John Doe');
+                $this->request->getData('email','john.doe@example.com');
             }
 
             $this->set('contact', $contact);

--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -74,14 +74,14 @@ and will be removed in a future version. Until that happens, user data being pas
 to the Http Client must be sanitized as follows::
 
     $response = $http->post('http://example.com/api', [
-        'search' => ltrim($this->request->data('search'), '@'),
+        'search' => ltrim($this->request->getData('search'), '@'),
     ]);
 
 If it is necessary to preserve leading ``@`` characters in query strings, you can pass
 a pre-encoded query string from ``http_build_query()``::
 
     $response = $http->post('http://example.com/api', http_build_query([
-        'search' => $this->request->data('search'),
+        'search' => $this->request->getData('search'),
     ]));
 
 Building Multipart Request Bodies by Hand

--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -431,7 +431,7 @@ sending an email you could do the following::
         ->requirePresence('comment')
         ->notEmpty('comment', 'You need to give a comment.');
 
-    $errors = $validator->errors($this->request->data());
+    $errors = $validator->errors($this->request->getData());
     if (empty($errors)) {
         // Send an email.
     }
@@ -448,7 +448,7 @@ be returned per field. By default the ``errors()`` method applies rules for
 the 'create' mode. If you'd like to apply 'update' rules you can do the
 following::
 
-    $errors = $validator->errors($this->request->data(), false);
+    $errors = $validator->errors($this->request->getData(), false);
     if (empty($errors)) {
         // Send an email.
     }
@@ -471,7 +471,7 @@ saving is done automatically when using the ``newEntity()``, ``newEntities()``,
 ``patchEntity()`` or ``patchEntities()``::
 
     // In the ArticlesController class
-    $article = $this->Articles->newEntity($this->request->data());
+    $article = $this->Articles->newEntity($this->request->getData());
     if ($article->errors()) {
         // Do work to show error messages.
     }
@@ -480,7 +480,7 @@ Similarly, when you need to pre-validate multiple entities at a time, you can
 use the ``newEntities()`` method::
 
     // In the ArticlesController class
-    $entities = $this->Articles->newEntities($this->request->data());
+    $entities = $this->Articles->newEntities($this->request->getData());
     foreach ($entities as $entity) {
         if (!$entity->errors()) {
                 $this->Articles->save($entity);

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -119,7 +119,7 @@ page. First, create the file. Its contents should look like::
         {
             $request = $event->data['request'];
             $response = $event->data['response'];
-            if (!$request->cookie('landing_page')) {
+            if (!$request->getCookie('landing_page')) {
                 $response->cookie([
                     'name' => 'landing_page',
                     'value' => $request->here(),

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -32,8 +32,8 @@ features that all applications are likely to need. The built-in filters are:
         DispatcherFactory::add('Asset', ['cacheTime' => '+24 hours']);
 
 * ``RoutingFilter`` applies application routing rules to the request URL.
-  Populates ``$request->param()`` with the results of routing.
-* ``ControllerFactory`` uses ``$request->param()`` to locate the controller that
+  Populates ``$request->getParam()`` with the results of routing.
+* ``ControllerFactory`` uses ``$request->getParam()`` to locate the controller that
   will handle the current request.
 * ``LocaleSelector`` enables automatic language switching from the ``Accept-Language``
   header sent by the browser.

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -51,7 +51,7 @@ controller might look something like this::
 
         public function add()
         {
-            $recipe = $this->Recipes->newEntity($this->request->data());
+            $recipe = $this->Recipes->newEntity($this->request->getData());
             if ($this->Recipes->save($recipe)) {
                 $message = 'Saved';
             } else {
@@ -68,7 +68,7 @@ controller might look something like this::
         {
             $recipe = $this->Recipes->get($id);
             if ($this->request->is(['post', 'put'])) {
-                $recipe = $this->Recipes->patchEntity($recipe, $this->request->data());
+                $recipe = $this->Recipes->patchEntity($recipe, $this->request->getData());
                 if ($this->Recipes->save($recipe)) {
                     $message = 'Saved';
                 } else {
@@ -148,9 +148,9 @@ as input. Not to worry, the
 :php:class:`Cake\\Routing\\Router` classes make things much easier. If a POST or
 PUT request has an XML content-type, then the input is run through  CakePHP's
 :php:class:`Xml` class, and the array representation of the data is assigned to
-``$this->request->data()``.  Because of this feature, handling XML and POST data in
+``$this->request->getData()``.  Because of this feature, handling XML and POST data in
 parallel is seamless: no changes are required to the controller or model code.
-Everything you need should end up in ``$this->request->data()``.
+Everything you need should end up in ``$this->request->getData()``.
 
 Accepting Input in Other Formats
 ================================
@@ -159,7 +159,7 @@ Typically REST applications not only output content in alternate data formats,
 but also accept data in different formats. In CakePHP, the
 :php:class:`RequestHandlerComponent` helps facilitate this. By default,
 it will decode any incoming JSON/XML input data for POST/PUT requests
-and supply the array version of that data in ``$this->request->data()``.
+and supply the array version of that data in ``$this->request->getData()``.
 You can also wire in additional deserializers for alternate formats if you
 need them, using :php:meth:`RequestHandler::addInputType()`.
 

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -218,7 +218,7 @@ Route Elements
 You can specify your own route elements and doing so gives you the
 power to define places in the URL where parameters for controller
 actions should lie. When a request is made, the values for these
-route elements are found in ``$this->request->param()`` in the controller.
+route elements are found in ``$this->request->getParam()`` in the controller.
 When you define a custom route element, you can optionally specify a regular
 expression - this tells CakePHP how to know if the URL is correctly formed or
 not. If you choose to not provide a regular expression, any non ``/`` character
@@ -264,7 +264,7 @@ If you need lowercased and underscored URLs while migrating from a CakePHP
 
 Once this route has been defined, requesting ``/apples/5`` would call the view()
 method of the ApplesController. Inside the view() method, you would need to
-access the passed ID at ``$this->request->param('id')``.
+access the passed ID at ``$this->request->getParam('id')``.
 
 If you have a single controller in your application and you do not want the
 controller name to appear in the URL, you can map all URLs to actions in your
@@ -310,7 +310,7 @@ alternates, as above, but not grouped with parenthesis.
 Once defined, this route will match ``/articles/2007/02/01``,
 ``/articles/2004/11/16``, handing the requests to
 the index() actions of their respective controllers, with the date
-parameters in ``$this->request->param()``.
+parameters in ``$this->request->getParam()``.
 
 There are several route elements that have special meaning in
 CakePHP, and should not be used unless you want the special meaning
@@ -533,7 +533,7 @@ The connected route would have the ``prefix`` route element set to
 ``manager/admin``.
 
 The current prefix will be available from the controller methods through
-``$this->request->param('prefix')``
+``$this->request->getParam('prefix')``
 
 When using prefix routes it's important to set the prefix option. Here's how to
 build this link using the HTML helper::
@@ -749,7 +749,7 @@ comments routes will look like::
 
 You can get the ``article_id`` in ``CommentsController`` by::
 
-    $this->request->param('article_id');
+    $this->request->getParam('article_id');
 
 By default resource routes map to the same prefix as the containing scope. If
 you have both nested and non-nested resource controllers you can use a different
@@ -890,7 +890,7 @@ to your controller methods. ::
 In the above example, both ``recent`` and ``mark`` are passed arguments to
 ``CalendarsController::view()``. Passed arguments are given to your controllers
 in three ways. First as arguments to the action method called, and secondly they
-are available in ``$this->request->param('pass')`` as a numerically indexed
+are available in ``$this->request->getParam('pass')`` as a numerically indexed
 array. When using custom routes you can force particular parameters to go into
 the passed arguments as well.
 
@@ -913,11 +913,11 @@ You would get the following output::
         [1] => mark
     )
 
-This same data is also available at ``$this->request->param('pass')`` in your
+This same data is also available at ``$this->request->getParam('pass')`` in your
 controllers, views, and helpers.  The values in the pass array are numerically
 indexed based on the order they appear in the called URL::
 
-    debug($this->request->param('pass'));
+    debug($this->request->getParam('pass'));
 
 Either of the above would output::
 
@@ -1128,8 +1128,8 @@ The URL filter function should *always* return the params even if unmodified.
 URL filters allow you to implement features like persistent parameters::
 
     Router::addUrlFilter(function ($params, $request) {
-        if ($request->param('lang') && !isset($params['lang'])) {
-            $params['lang'] = $request->param('lang');
+        if ($request->getParam('lang') && !isset($params['lang'])) {
+            $params['lang'] = $request->getParam('lang');
         }
         return $params;
     });
@@ -1177,7 +1177,7 @@ arguments::
         Router::parseNamedParams($this->request);
     }
 
-This will populate ``$this->request->param('named')`` with any named parameters
+This will populate ``$this->request->getParam('named')`` with any named parameters
 found in the passed arguments.  Any passed argument that was interpreted as a
 named parameter, will be removed from the list of passed arguments.
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -787,7 +787,7 @@ controller code looks like::
         public function index($short = null)
         {
             if ($this->request->is('post')) {
-                $article = $this->Articles->newEntity($this->request->data());
+                $article = $this->Articles->newEntity($this->request->getData());
                 if ($this->Articles->save($article)) {
                     // Redirect as per PRG pattern
                     return $this->redirect(['action' => 'index']);

--- a/en/elasticsearch.rst
+++ b/en/elasticsearch.rst
@@ -65,7 +65,7 @@ You can then use your type class in your controllers::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success('It saved');
             }

--- a/en/intro.rst
+++ b/en/intro.rst
@@ -99,7 +99,7 @@ controller would be::
     {
         $user = $this->Users->newEntity();
         if ($this->request->is('post')) {
-            $user = $this->Users->patchEntity($user, $this->request->data());
+            $user = $this->Users->patchEntity($user, $this->request->getData());
             if ($this->Users->save($user, ['validate' => 'registration'])) {
                 $this->Flash->success(__('You are now registered.'));
             } else {

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -435,7 +435,7 @@ create form inputs for your translated fields::
 In your controller, you can marshal the data as normal, but with the
 ``translations`` option enabled::
 
-    $article = $this->Articles->newEntity($this->request->data(), [
+    $article = $this->Articles->newEntity($this->request->getData(), [
         'translations' => true
     ]);
     $this->Articles->save($article);

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -173,7 +173,7 @@ one or many entities from request data. You can convert a single entity using::
     $articles = TableRegistry::get('Articles');
 
     // Validate and convert to an Entity object
-    $entity = $articles->newEntity($this->request->data());
+    $entity = $articles->newEntity($this->request->getData());
 
 .. note::
 
@@ -211,7 +211,7 @@ associations should be marshalled::
     $articles = TableRegistry::get('Articles');
 
     // New entity with nested associations
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags', 'Comments' => ['associated' => ['Users']]
         ]
@@ -230,7 +230,7 @@ should be marshalled. Alternatively, you can use dot notation for brevity::
     $articles = TableRegistry::get('Articles');
 
     // New entity with nested associations using dot notation
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => ['Tags', 'Comments.Users']
     ]);
 
@@ -242,7 +242,7 @@ change the validation set to be used per association::
 
     // Bypass validation on Tags association and
     // Designate 'signup' validation set for Comments.Users
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags' => ['validate' => false],
             'Comments.Users' => ['validate' => 'signup']
@@ -348,7 +348,7 @@ When creating forms that create/update multiple records at once you can use
 
     // In a controller.
     $articles = TableRegistry::get('Articles');
-    $entities = $articles->newEntities($this->request->data());
+    $entities = $articles->newEntities($this->request->getData());
 
 In this situation, the request data for multiple articles should look like::
 
@@ -399,7 +399,7 @@ ids of associated entities::
 
     // In a controller
     $articles = TableRegistry::get('Articles');
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags', 'Comments' => [
                 'associated' => [
@@ -432,7 +432,7 @@ persisted. You can merge an array of raw data into an existing entity using the
     // In a controller.
     $articles = TableRegistry::get('Articles');
     $article = $articles->get(1);
-    $articles->patchEntity($article, $this->request->data());
+    $articles->patchEntity($article, $this->request->getData());
     $articles->save($article);
 
 
@@ -452,7 +452,7 @@ patching an entity, pass the ``validate`` option as follows::
 You may also change the validation set used for the entity or any of the
 associations::
 
-    $articles->patchEntity($article, $this->request->data(), [
+    $articles->patchEntity($article, $this->request->getData(), [
         'validate' => 'custom',
         'associated' => ['Tags', 'Comments.Users' => ['validate' => 'signup']]
     ]);
@@ -469,7 +469,7 @@ merge deeper to deeper levels, you can use the third parameter of the method::
     // In a controller.
     $associated = ['Tags', 'Comments.Users'];
     $article = $articles->get(1, ['contain' => $associated]);
-    $articles->patchEntity($article, $this->request->data(), [
+    $articles->patchEntity($article, $this->request->getData(), [
         'associated' => $associated
     ]);
     $articles->save($article);
@@ -585,7 +585,7 @@ the original entities array will be removed and not present in the result::
     // In a controller.
     $articles = TableRegistry::get('Articles');
     $list = $articles->find('popular')->toArray();
-    $patched = $articles->patchEntities($list, $this->request->data());
+    $patched = $articles->patchEntities($list, $this->request->getData());
     foreach ($patched as $entity) {
         $articles->save($entity);
     }
@@ -597,7 +597,7 @@ array::
     // In a controller.
     $patched = $articles->patchEntities(
         $list,
-        $this->request->data(),
+        $this->request->getData(),
         ['associated' => ['Tags', 'Comments.Users']]
     );
 
@@ -673,7 +673,7 @@ sending an array in the request containing the ``user_id`` an attacker could
 change the owner of an article, causing undesirable effects::
 
     // Contains ['user_id' => 100, 'title' => 'Hacked!'];
-    $data = $this->request->data();
+    $data = $this->request->getData();
     $entity = $this->patchEntity($entity, $data);
     $this->save($entity);
 
@@ -685,7 +685,7 @@ The second way is by using the ``fieldList`` option when creating or merging
 data into an entity::
 
     // Contains ['user_id' => 100, 'title' => 'Hacked!'];
-    $data = $this->request->data();
+    $data = $this->request->getData();
 
     // Only allow title to be changed
     $entity = $this->patchEntity($entity, $data, [
@@ -722,7 +722,7 @@ using ``newEntity()`` for passing into ``save()``. For example::
 
   // In a controller
   $articles = TableRegistry::get('Articles');
-  $article = $articles->newEntity($this->request->data());
+  $article = $articles->newEntity($this->request->getData());
   if ($articles->save($article)) {
       // ...
   }

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -21,7 +21,7 @@ will be validated before it is converted into entities.
 If any validation rules fail, the returned entity will contain errors. The
 fields with errors will not be present in the returned entity::
 
-    $article = $articles->newEntity($this->request->data());
+    $article = $articles->newEntity($this->request->getData());
     if ($article->errors()) {
         // Entity failed validation.
     }
@@ -42,7 +42,7 @@ If you'd like to disable validation when converting request data, set the
 ``validate`` option to false::
 
     $article = $articles->newEntity(
-        $this->request->data(),
+        $this->request->getData(),
         ['validate' => false]
     );
 
@@ -100,7 +100,7 @@ In addition to disabling validation you can choose which validation rule set you
 want applied::
 
     $article = $articles->newEntity(
-        $this->request->data(),
+        $this->request->getData(),
         ['validate' => 'update']
     );
 

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -386,13 +386,13 @@ own.  Add the following content to your **ArticlesController.php**::
     public function isAuthorized($user)
     {
         // All registered users can add articles
-        if ($this->request->param('action') === 'add') {
+        if ($this->request->getParam('action') === 'add') {
             return true;
         }
 
         // The owner of an article can edit and delete it
-        if (in_array($this->request->param('action'), ['edit', 'delete'])) {
-            $articleId = (int)$this->request->param('pass.0');
+        if (in_array($this->request->getParam('action'), ['edit', 'delete'])) {
+            $articleId = (int)$this->request->getParam('pass.0');
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;
             }

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -87,7 +87,7 @@ with CakePHP::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data());
+                $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
                     return $this->redirect(['action' => 'add']);
@@ -309,7 +309,7 @@ currently logged in user as a reference for the created article::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Added this line
             $article->user_id = $this->Auth->user('id');
             // You could also do the following

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -350,7 +350,7 @@ it::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -296,7 +296,7 @@ First, start by creating an ``add()`` action in the
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);
@@ -324,7 +324,7 @@ application.  In this case, we use the :php:meth:`Cake\\Network\\Request::is()`
 method to check that the request is a HTTP POST request.
 
 When a user uses a form to POST data to your application, that
-information is available in ``$this->request->data()``. You can use the
+information is available in ``$this->request->getData()``. You can use the
 :php:func:`pr()` or :php:func:`debug()` functions to print it out if you want to
 see what it looks like.
 
@@ -459,7 +459,7 @@ like::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            $this->Articles->patchEntity($article, $this->request->data());
+            $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
                 return $this->redirect(['action' => 'index']);

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -323,7 +323,7 @@ add the following::
     {
         // The 'pass' key is provided by CakePHP and contains all
         // the passed URL path segments in the request.
-        $tags = $this->request->param('pass');
+        $tags = $this->request->getParam('pass');
 
         // Use the BookmarksTable to find tagged bookmarks.
         $bookmarks = $this->Bookmarks->find('tagged', [

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -186,19 +186,19 @@ sense. First, we'll add the authorization logic for bookmarks. In your
 
     public function isAuthorized($user)
     {
-        $action = $this->request->param('action');
+        $action = $this->request->getParam('action');
 
         // The add and index actions are always allowed.
         if (in_array($action, ['index', 'add', 'tags'])) {
             return true;
         }
         // All other actions require an id.
-        if (!$this->request->param('pass.0')) {
+        if (!$this->request->getParam('pass.0')) {
             return false;
         }
 
         // Check that the bookmark belongs to the current user.
-        $id = $this->request->param('pass.0');
+        $id = $this->request->getParam('pass.0');
         $bookmark = $this->Bookmarks->get($id);
         if ($bookmark->user_id == $user['id']) {
             return true;

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -234,7 +234,7 @@ like::
     {
         $bookmark = $this->Bookmarks->newEntity();
         if ($this->request->is('post')) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
@@ -258,7 +258,7 @@ edit form and action. Your ``edit()`` action from
             'contain' => ['Tags']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -71,7 +71,7 @@ You can use the current action name to conditionally load helpers::
         public function initialize()
         {
             parent::initialize();
-            if ($this->request->param('action') === 'index') {
+            if ($this->request->getParam('action') === 'index') {
                 $this->loadHelper('ListPage');
             }
         }

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -110,7 +110,7 @@ input-tags, receive their values from.
 
 By default FormHelper draws its values from the 'context'.  The default
 contexts, such as ``EntityContext``, will fetch data from the current entity, or
-from ``$request->data()``.
+from ``$request->getData()``.
 
 If however, you are building a form that needs to read from the query string,
 you can use ``valueSource()`` to change where ``FormHelper`` reads data input
@@ -549,7 +549,7 @@ common options shared by all input methods are as follows:
   .. note::
 
     You cannot use ``default`` to check a checkbox - instead you might
-    set the value in ``$this->request->data()`` in your controller,
+    set the value in ``$this->request->getData()`` in your controller,
     or set the input option ``checked`` to ``true``.
 
     Beware of using ``false`` to assign a default value. A ``false`` value is
@@ -558,7 +558,7 @@ common options shared by all input methods are as follows:
 
 * ``$options['value']`` Used to set a specific value for the input field. This
   will override any value that may else be injected from the context, such as
-  Form, Entity or ``request->data()`` etc.
+  Form, Entity or ``request->getData()`` etc.
 
   .. note::
 
@@ -629,7 +629,7 @@ Options for Select, Checkbox and Radio Inputs
   Options can also supplied as key-value pairs.
 
 * ``$options['hiddenField']`` For certain input types (checkboxes, radios) a
-  hidden input is created so that the key in ``$this->request->data()`` will exist
+  hidden input is created so that the key in ``$this->request->getData()`` will exist
   even without a value specified:
 
   .. code-block:: html
@@ -798,7 +798,7 @@ Will output:
 
     <textarea name="notes"></textarea>
 
-If the form is edited (that is, the array ``$this->request->data()`` will
+If the form is edited (that is, the array ``$this->request->getData()`` will
 contain the information saved for the ``User`` model), the value
 corresponding to ``notes`` field will automatically be added to the HTML
 generated. Example:
@@ -1178,7 +1178,7 @@ of options:
 * ``round`` - Set to ``up`` or ``down`` if you want to force rounding in either
   direction. Defaults to null.
 * ``default`` The default value to be used by the input. A value in
-  ``$this->request->data()`` matching the field name will override this value. If
+  ``$this->request->getData()`` matching the field name will override this value. If
   no default is provided ``time()`` will be used.
 * ``timeFormat`` The time format to use, either 12 or 24.
 * ``second`` Set to ``true`` to enable seconds drop down.
@@ -1232,7 +1232,7 @@ empty option:
 * ``empty`` - If ``true``, the empty select option is shown. If a string,
   that string is displayed as the empty element.
 * ``default`` | ``value`` The default value to be used by the input. A value in
-  ``$this->request->data()`` matching the field name will override this value.
+  ``$this->request->getData()`` matching the field name will override this value.
   If no default is provided ``time()`` will be used.
 * ``timeFormat`` The time format to use, either 12 or 24. Defaults to 24.
 * ``second`` Set to ``true`` to enable seconds drop down.
@@ -1841,7 +1841,7 @@ create the following inputs::
 The above inputs could then be marshalled into a completed entity graph using
 the following code in your controller::
 
-    $article = $this->Articles->patchEntity($article, $this->request->data(), [
+    $article = $this->Articles->patchEntity($article, $this->request->getData(), [
         'associated' => [
             'Authors',
             'Authors.Profiles',

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1647,11 +1647,13 @@ contain an array of templates indexed by name::
 
 Any templates you define will replace the default ones included in the helper.
 Templates that are not replaced, will continue to use the default values.
-You can also change the templates at runtime using the ``templates()`` method::
+You can also change the templates at runtime using the ``setTemplates()`` method::
 
     $myTemplates = [
         'inputContainer' => '<div class="form-control">{{content}}</div>',
     ];
+    $this->Form->setTemplates($myTemplates);
+    // Prior to 3.4
     $this->Form->templates($myTemplates);
 
 .. warning::
@@ -1675,7 +1677,7 @@ If that container is missing the ``inputContainer`` template will be used. For
 example::
 
     // Add custom radio wrapping HTML
-    $this->Form->templates([
+    $this->Form->setTemplates([
         'radioContainer' => '<div class="form-radio">{{content}}</div>'
     ]);
 
@@ -1689,7 +1691,7 @@ used if it is present. If that template is missing by default each set of label
 & input is rendered using the ``formGroup`` template. For example::
 
     // Add custom radio form group
-    $this->Form->templates([
+    $this->Form->setTemplates([
         'radioFormGroup' => '<div class="radio">{{label}}{{input}}</div>'
     ]);
 
@@ -1700,7 +1702,7 @@ You can add additional template placeholders in custom templates, and populate
 those placeholders when generating inputs::
 
     // Add a template with the help placeholder.
-    $this->Form->templates([
+    $this->Form->setTemplates([
         'inputContainer' => '<div class="input {{type}}{{required}}">
             {{content}} <span class="help">{{help}}</span></div>'
     ]);
@@ -1721,7 +1723,7 @@ This helps make it easier to integrate popular CSS frameworks. If you need to
 place checkbox/radio inputs outside of the label you can do so by modifying the
 templates::
 
-    $this->Form->templates([
+    $this->Form->setTemplates([
         'nestingLabel' => '{{input}}<label{{attrs}}>{{text}}</label>',
         'formGroup' => '{{input}}{{label}}',
     ]);

--- a/en/views/helpers/html.rst
+++ b/en/views/helpers/html.rst
@@ -765,10 +765,10 @@ file containing the tags you want to load, or an array of templates to
 add/replace::
 
     // Load templates from config/my_html.php
-    $this->Html->templates('my_html.php');
+    $this->Html->setTemplates('my_html.php');
 
     // Load specific templates.
-    $this->Html->templates([
+    $this->Html->setTemplates([
         'javascriptlink' => '<script src="{{url}}" type="text/javascript"{{attrs}}></script>'
     ]);
 

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -59,17 +59,19 @@ templates file should look something like::
 Changing Templates at Run-time
 ------------------------------
 
-.. php:method:: templates($templates = null)
+.. php:method:: setTemplates($templates)
 
 This method allows you to change the templates used by PaginatorHelper at
 runtime. This can be useful when you want to customize templates for a
 particular method call::
 
     // Read the current template value.
+    $result = $this->Paginator->setTemplates('number');
+    // Prior to 3.4
     $result = $this->Paginator->templates('number');
 
     // Change a template
-    $this->Paginator->templates([
+    $this->Paginator->setTemplates([
         'number' => '<em><a href="{{url}}">{{text}}</a></em>'
     ]);
 

--- a/es/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/es/tutorials-and-examples/blog-auth-example/auth.rst
@@ -317,13 +317,13 @@ Esto no es exactamente lo que queriamos, por lo que tendremos que agregar mas re
     public function isAuthorized($user)
     {
         // All registered users can add articles
-        if ($this->request->param('action') === 'add') {
+        if ($this->request->getParam('action') === 'add') {
             return true;
         }
 
         // The owner of an article can edit and delete it
-        if (in_array($this->request->param('action'), ['edit', 'delete'])) {
-            $articleId = (int)$this->request->param('pass.0');
+        if (in_array($this->request->getParam('action'), ['edit', 'delete'])) {
+            $articleId = (int)$this->request->getParam('pass.0');
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;
             }

--- a/es/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/es/tutorials-and-examples/blog-auth-example/auth.rst
@@ -82,7 +82,7 @@ También vamos a crear UsersController; el siguiente contenido fue generado usan
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data());
+                $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
                     return $this->redirect(['action' => 'add']);
@@ -259,7 +259,7 @@ También, un pequeño cambio en ArticlesController es necesario para guardar el 
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Added this line
             $article->user_id = $this->Auth->user('id');
             // You could also do the following

--- a/es/tutorials-and-examples/blog/part-three.rst
+++ b/es/tutorials-and-examples/blog/part-three.rst
@@ -244,7 +244,7 @@ Esto nos permitirá elegir una categoría para un Article al momento de crearlo 
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);

--- a/es/tutorials-and-examples/blog/part-two.rst
+++ b/es/tutorials-and-examples/blog/part-two.rst
@@ -269,7 +269,7 @@ ArticlesController::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);
@@ -298,7 +298,7 @@ de nuestra aplicación. En este caso, utilizamos el método
 petición HTTP POST.
 
 Cuando un usuario utiliza un formulario y efectúa un POST a la aplicación, esta
-información está disponible en ``$this->request->data()``. Puedes usar la función
+información está disponible en ``$this->request->getData()``. Puedes usar la función
 :php:func:`pr()` o :php:func:`debug()` para mostrar el contenido de esa variable
 y ver la pinta que tiene.
 
@@ -424,7 +424,7 @@ ser la acción ``edit()`` del controlador ``ArticlesController``::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            $this->Articles->patchEntity($article, $this->request->data());
+            $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Tu artículo ha sido actualizado.'));
                 return $this->redirect(['action' => 'index']);

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -15,10 +15,10 @@ version 4.0.0 à partir de laquelle ils seront supprimés.
   méthodes ont été ajoutées pour lire et écrire ces propriétés.
 * Plusieurs propriétés de ``Cake\Network\Request`` ont été dépréciées :
 
-  * ``Request::$params`` est dépréciée. Utilisez ``Request::param()`` à la place.
-  * ``Request::$data`` est dépréciée. Utilisez ``Request::data()`` à la place.
-  * ``Request::$query`` est dépréciée. Utilisez ``Request::query()`` à la place.
-  * ``Request::$cookies`` est dépréciée. Utilisez ``Request::cookie()`` à la place.
+  * ``Request::$params`` est dépréciée. Utilisez ``Request::getParam()`` à la place.
+  * ``Request::$data`` est dépréciée. Utilisez ``Request::getData()`` à la place.
+  * ``Request::$query`` est dépréciée. Utilisez ``Request::getQuery()`` à la place.
+  * ``Request::$cookies`` est dépréciée. Utilisez ``Request::getCookie()`` à la place.
   * ``Request::$base`` est dépréciée. Utilisez ``Request::getAttribute('base')`` à la place.
   * ``Request::$webroot`` est dépréciée. Utilisez ``Request::getAttribute('webroot')`` à la place.
   * ``Request::$here`` est dépréciée. Utilisez ``Request::here()`` à la place.
@@ -26,9 +26,8 @@ version 4.0.0 à partir de laquelle ils seront supprimés.
 
 * Certaines méthodes de ``Cake\Network\Request`` ont été dépréciées :
 
-  * Les méthodes ``query()``, ``data()`` et ``param()`` ne peuvent plus _setter_ les valeurs des propriétés
-    correspondantes.
-  * Les méthodes ``__get()`` & ``__isset()`` sont dépréciées. Utilisez ``param()`` à la place.
+  * Les méthodes ``__get()`` & ``__isset()`` sont dépréciées. Utilisez
+    ``getParam()`` à la place.
   * ``method()`` est dépréciée. Utilisez ``getMethod()`` plutôt.
   * ``setInput()`` est dépréciée. Utilisez ``withBody()`` plutôt.
   * Les méthodes ``ArrayAccess`` ont toutes été dépréciées.

--- a/fr/controllers/components.rst
+++ b/fr/controllers/components.rst
@@ -150,7 +150,7 @@ vous pouvez y accéder comme ceci::
 
         public function delete()
         {
-            if ($this->Post->delete($this->request->data('Post.id')) {
+            if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
                 return $this->redirect(['action' => 'index']);
             }

--- a/fr/controllers/components/authentication.rst
+++ b/fr/controllers/components/authentication.rst
@@ -753,7 +753,7 @@ pouvez changer la fonction login selon::
                 $this->Auth->setUser($user);
                 if ($this->Auth->authenticationProvider()->needsPasswordRehash()) {
                     $user = $this->Users->get($this->Auth->user('id'));
-                    $user->password = $this->request->data('password');
+                    $user->password = $this->request->getData('password');
                     $this->Users->save($user);
                 }
                 return $this->redirect($this->Auth->redirectUrl());
@@ -824,7 +824,7 @@ utilisateur que vous voulez pour la 'connexion'::
 
     public function register()
     {
-        $user = $this->Users->newEntity($this->request->data());
+        $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
             return $this->redirect([

--- a/fr/controllers/components/authentication.rst
+++ b/fr/controllers/components/authentication.rst
@@ -1102,12 +1102,12 @@ il peut donc être vérifié::
         public function isAuthorized($user = null)
         {
             // Chacun des utilisateurs enregistrés peut accéder aux fonctions publiques
-            if (!$this->request->param('prefix')) {
+            if (!$this->request->getParam('prefix')) {
                 return true;
             }
 
             // Seulement les administrateurs peuvent accéder aux fonctions d'administration
-            if ($this->request->param('prefix') === 'admin') {
+            if ($this->request->getParam('prefix') === 'admin') {
                 return (bool)($user['role'] === 'admin');
             }
 

--- a/fr/controllers/components/cookie.rst
+++ b/fr/controllers/components/cookie.rst
@@ -111,7 +111,7 @@ Le Component Cookie offre plusieurs méthodes pour travailler avec les Cookies.
         CookieComponent ne peut pas intéragir avec les valeurs de chaînes vides
         qui contiennent ``,``. Le component va tenter d'interpreter ces valeurs
         en tableaux, ce qui conduit à des résultats incorrects. A la place, vous
-        devez utiliser ``$request->cookie()``.
+        devez utiliser ``$request->getCookie()``.
 
 .. php:method:: check($key)
 

--- a/fr/controllers/components/csrf.rst
+++ b/fr/controllers/components/csrf.rst
@@ -57,7 +57,7 @@ Les options de configuration disponibles sont les suivants:
 Lorsqu'il est activé, vous pouvez accéder au jeton CSRF actuel sur l'objet
 request::
 
-    $token = $this->request->param('_csrfToken');
+    $token = $this->request->getParam('_csrfToken');
 
 Intégration avec le FormHelper
 ==============================

--- a/fr/controllers/components/pagination.rst
+++ b/fr/controllers/components/pagination.rst
@@ -94,7 +94,7 @@ personnalisée dans la propriété paginate::
         // trouve les articles selon les tags
         public function tags()
         {
-            $tags = $this->request->param('pass');
+            $tags = $this->request->getParam('pass');
 
             $customFinderOptions = [
                 'tags' => $tags
@@ -138,7 +138,7 @@ créer les données paginées et ajouter le ``PaginatorHelper`` s'il n'a pas dé
 été ajouté. La méthode paginate du controller va retourner l'ensemble des
 résultats de la requête paginée, et définir les meta-données de pagination de
 la requête. Vous pouvez accéder aux meta-données de pagination avec
-``$this->request->param('paging')``. un exemple plus complet de l'utilisation
+``$this->request->getParam('paging')``. un exemple plus complet de l'utilisation
 de ``paginate()`` serait::
 
     class ArticlesController extends AppController
@@ -291,7 +291,7 @@ utiliser un bloc try catch et faire des actions appropriées quand une
             $this->paginate();
         } catch (NotFoundException $e) {
             // Faire quelque chose ici comme rediriger vers la première ou dernière page.
-            // $this->request->param('paging') vous donnera les infos demandées.
+            // $this->request->getParam('paging') vous donnera les infos demandées.
         }
     }
 

--- a/fr/controllers/components/request-handling.rst
+++ b/fr/controllers/components/request-handling.rst
@@ -19,7 +19,7 @@ de média non-HTML.
 En outre, s'il existe un helper avec le même nom que l'extension demandée,
 il sera ajouté au tableau des helpers des Controllers. Enfin, si une donnée
 XML/JSON est POST'ée vers vos Controllers, elle sera décomposée dans un
-tableau qui est assigné à ``$this->request->data()``, et pourra alors être
+tableau qui est assigné à ``$this->request->getData()``, et pourra alors être
 accessible comme vous le feriez pour n'importe quelle donnée POST.
 Afin d'utiliser le Request Handler, il doit être chargé depuis la méthode
 ``initialize()``::
@@ -175,7 +175,7 @@ au callback, c'est très utile pour les callbacks comme ``json_decode``::
     // Depuis 3.1.0, vous devez utiliser
     $this->RequestHandler->config('inputTypeMap.json', ['json_decode', true]);
 
-Le contenu ci-dessus créera ``$this->request->data()`` un tableau des données
+Le contenu ci-dessus créera ``$this->request->getData()`` un tableau des données
 d'entrées JSON, sans le ``true`` supplémentaire vous obtiendrez un jeu
 d'objets ``stdClass``.
 

--- a/fr/controllers/components/security.rst
+++ b/fr/controllers/components/security.rst
@@ -177,7 +177,7 @@ de sécurité que vous voulez et le component Security les forcera au démarrage
 
         public function beforeFilter(Event $event)
         {
-            if ($this->request->param('admin')) {
+            if ($this->request->getParam('admin')) {
                 $this->Security->requireSecure();
             }
         }

--- a/fr/controllers/middleware.rst
+++ b/fr/controllers/middleware.rst
@@ -233,7 +233,7 @@ their own response. We can see both options in our simple middleware::
 
             // When modifying the response, you should do it
             // *after* calling next.
-            if (!$request->cookie('landing_page')) {
+            if (!$request->getCookie('landing_page')) {
                 $response->cookie([
                     'name' => 'landing_page',
                     'value' => $request->here(),

--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -75,13 +75,13 @@ Les paramètres Querystring peuvent être lus en utilisant
 :php:attr:`~Cake\\Network\\Request::$query`::
 
     // l'URL est /posts/index?page=1&sort=title
-    $this->request->query('page');
+    $this->request->getQuery('page');
 
 Vous pouvez soit directement accéder à la propriété demandée, soit vous pouvez
 utiliser ``query()`` pour lire l'URL requêtée sans erreur. Toute clé qui
 n'existe pas va retourner ``null``::
 
-    $foo = $this->request->query('valeur_qui_n_existe_pas');
+    $foo = $this->request->getQuery('valeur_qui_n_existe_pas');
     // $foo === null
 
 Si vous souhaitez accéder à tous les paramètres de requête, vous pouvez utiliser

--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -41,9 +41,9 @@ l'utilisation des librairies en-dehors de CakePHP.
 Paramètres de la Requête
 ------------------------
 
-``Request`` propose les paramètres de routing avec la méthode ``param()``::
+``Request`` propose les paramètres de routing avec la méthode ``getParam()``::
 
-    $this->request->param('controller');
+    $this->request->getParam('controller');
 
 Tous les éléments de route :ref:`route-elements` sont accessibles à travers
 cette interface.
@@ -53,7 +53,7 @@ d'accéder aux arguments passés :ref:`passed-arguments`. Ceux-ci sont aussi tou
 les deux disponibles dans l'objet ``request``::
 
     // Arguments passés
-    $this->request->param('pass');
+    $this->request->getParam('pass');
 
 Tous vous fournissent un accès aux arguments passés. Il y a de nombreux
 paramètres importants et utiles que CakePHP utilise en interne qu'on peut aussi
@@ -251,7 +251,7 @@ Quelques exemples seraient::
     $this->request->addDetector(
         'awesome',
         function ($request) {
-            return $request->param('awesome');
+            return $request->getParam('awesome');
         }
     );
 
@@ -259,7 +259,7 @@ Quelques exemples seraient::
     $this->request->addDetector(
         'controller',
         function ($request, $name) {
-            return $request->param('controller') === $name;
+            return $request->getParam('controller') === $name;
         }
     );
 

--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -102,11 +102,11 @@ Toutes les données POST sont accessibles en utilisant
 contient un préfix ``data`` aura ce préfixe supprimé. Par exemple::
 
     // Un input avec un attribut de nom égal à 'MyModel[title]' est accessible
-    dans $this->request->data('MyModel.title');
+    dans $this->request->getData('MyModel.title');
 
 Toute clé qui n'existe pas va retourner ``null``::
 
-    $foo = $this->request->data('Valeur.qui.n.existe.pas');
+    $foo = $this->request->getData('Valeur.qui.n.existe.pas');
     // $foo == null
 
 Accéder aux Données PUT, PATCH ou DELETE

--- a/fr/core-libraries/email.rst
+++ b/fr/core-libraries/email.rst
@@ -555,7 +555,7 @@ chose suivante::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data())
+                $user = $this->Users->patchEntity($user, $this->request->getData())
                 if ($this->Users->save($user)) {
                     $this->getMailer('User')->send('welcome', [$user]);
                 }

--- a/fr/core-libraries/form.rst
+++ b/fr/core-libraries/form.rst
@@ -89,7 +89,7 @@ votre controller pour traiter et valider les données de la requête::
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('Nous reviendrons vers vous rapidement.');
                 } else {
                     $this->Flash->error('Il y a eu un problème lors de la soumission de votre formulaire.');
@@ -105,13 +105,13 @@ sont valides, et définissons un message flash en conséquence. Nous aurions
 aussi pu utiliser la méthode ``validate()`` pour valider uniquement les données
 de requête::
 
-    $isValid = $form->validate($this->request->data());
+    $isValid = $form->validate($this->request->getData());
 
 Définir des Valeurs pour le Formulaire
 ======================================
 
 Pour définir les valeurs d'un formulaire sans model, vous pouvez utiliser
-``$this->request->data()`` comme dans tous formulaires créés par le FormHelper::
+``$this->request->getData()`` comme dans tous formulaires créés par le FormHelper::
 
     // Dans uncontroller
     namespace App\Controller;
@@ -125,7 +125,7 @@ Pour définir les valeurs d'un formulaire sans model, vous pouvez utiliser
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('Nous reviendrons vers vous rapidement.');
                 } else {
                     $this->Flash->error('Il y a eu un problème lors de la soumission de votre formulaire.');
@@ -134,8 +134,8 @@ Pour définir les valeurs d'un formulaire sans model, vous pouvez utiliser
 
             if ($this->request->is('get')) {
                 //Values from the User Model e.g.
-                $this->request->data('name', 'John Doe');
-                $this->request->data('email','john.doe@example.com');
+                $this->request->getData('name', 'John Doe');
+                $this->request->getData('email','john.doe@example.com');
             }
 
             $this->set('contact', $contact);

--- a/fr/core-libraries/form.rst
+++ b/fr/core-libraries/form.rst
@@ -111,7 +111,7 @@ Définir des Valeurs pour le Formulaire
 ======================================
 
 Pour définir les valeurs d'un formulaire sans model, vous pouvez utiliser
-``$this->request->getData()`` comme dans tous formulaires créés par le FormHelper::
+``$this->request->data()`` comme dans tous formulaires créés par le FormHelper::
 
     // Dans uncontroller
     namespace App\Controller;
@@ -134,8 +134,8 @@ Pour définir les valeurs d'un formulaire sans model, vous pouvez utiliser
 
             if ($this->request->is('get')) {
                 //Values from the User Model e.g.
-                $this->request->getData('name', 'John Doe');
-                $this->request->getData('email','john.doe@example.com');
+                $this->request->data('name', 'John Doe');
+                $this->request->data('email','john.doe@example.com');
             }
 
             $this->set('contact', $contact);

--- a/fr/core-libraries/httpclient.rst
+++ b/fr/core-libraries/httpclient.rst
@@ -77,7 +77,7 @@ version future. Avant que cela n'arrive, les données d'utilisateur passées
 au Client Http devront être nettoyées comme suit::
 
     $response = $http->post('http://example.com/api', [
-        'search' => ltrim($this->request->data('search'), '@'),
+        'search' => ltrim($this->request->getData('search'), '@'),
     ]);
 
 S'il est nécessaire de garder les caractères du début ``@`` dans les chaînes
@@ -85,7 +85,7 @@ de la requête, vous pouvez passer une chaîne de requête pré-encodée avec
 ``http_build_query()``::
 
     $response = $http->post('http://example.com/api', http_build_query([
-        'search' => $this->request->data('search'),
+        'search' => $this->request->getData('search'),
     ]));
 
 Construire des Corps de Requête Multipart à la Main

--- a/fr/core-libraries/validation.rst
+++ b/fr/core-libraries/validation.rst
@@ -457,7 +457,7 @@ d'envoyer un email, vous pouvez faire ce qui suit::
         ->requirePresence('comment')
         ->allowEmpty('comment', false, 'You need to give a comment.');
 
-    $errors = $validator->errors($this->request->data());
+    $errors = $validator->errors($this->request->getData());
     if (empty($errors)) {
         // Envoi d'un email.
     }
@@ -474,7 +474,7 @@ d'erreur va être retourné par champ. Par défaut la méthode ``errors()`` appl
 les règles pour le mode 'create' mode. Si vous voulez appliquer les règles
 'update' vous pouvez faire ce qui suit::
 
-    $errors = $validator->errors($this->request->data(), false);
+    $errors = $validator->errors($this->request->getData(), false);
     if (empty($errors)) {
         // Envoi d'un email.
     }
@@ -499,7 +499,7 @@ on utilise ``newEntity()``, ``newEntities()``, ``patchEntity()`` ou
 ``patchEntities()``::
 
     // Dans la classe ArticlesController
-    $article = $this->Articles->newEntity($this->request->data());
+    $article = $this->Articles->newEntity($this->request->getData());
     if ($article->errors()) {
         // Afficher les messages d'erreur ici.
     }
@@ -508,7 +508,7 @@ De la même manière, quand vous avez besoin de pré-valider plusieurs entities
 en une fois, vous pouvez utiliser la méthode ``newEntities()``::
 
     // Dans la classe ArticlesController
-    $entities = $this->Articles->newEntities($this->request->data());
+    $entities = $this->Articles->newEntities($this->request->getData());
     foreach ($entities as $entity) {
         if (!$entity->errors()) {
                 $this->Articles->save($entity);

--- a/fr/development/dispatch-filters.rst
+++ b/fr/development/dispatch-filters.rst
@@ -35,8 +35,8 @@ Les filtres intégrés sont:
         DispatcherFactory::add('Asset', ['cacheTime' => '+24 hours']);
 
 * ``RoutingFilter`` applique les règles de routing de l'application pour l'URL
-  de la requête. Remplit ``$request->param()`` avec les résultats de routing.
-* ``ControllerFactory`` utilise ``$request->param()`` pour localiser le
+  de la requête. Remplit ``$request->getParam()`` avec les résultats de routing.
+* ``ControllerFactory`` utilise ``$request->getParam()`` pour localiser le
   controller qui gère la requête courante.
 * ``LocaleSelector`` active le langage automatiquement en changeant le header
   ``Accept-Language`` envoyé par le navigateur.

--- a/fr/development/dispatch-filters.rst
+++ b/fr/development/dispatch-filters.rst
@@ -128,7 +128,7 @@ la page d'accueil. Premièrement, créez le fichier. Son contenu doit ressembler
         {
             $request = $event->data['request'];
             $response = $event->data['response'];
-            if (!$request->cookie('landing_page')) {
+            if (!$request->getCookie('landing_page')) {
                 $response->cookie([
                     'name' => 'landing_page',
                     'value' => $request->here(),

--- a/fr/development/rest.rst
+++ b/fr/development/rest.rst
@@ -55,7 +55,7 @@ dans nos actions de controller. Un controller basique pourrait ressembler
 
         public function add()
         {
-            $recipe = $this->Recipes->newEntity($this->request->data());
+            $recipe = $this->Recipes->newEntity($this->request->getData());
             if ($this->Recipes->save($recipe)) {
                 $message = 'Saved';
             } else {
@@ -72,7 +72,7 @@ dans nos actions de controller. Un controller basique pourrait ressembler
         {
             $recipe = $this->Recipes->get($id);
             if ($this->request->is(['post', 'put'])) {
-                $recipe = $this->Recipes->patchEntity($recipe, $this->request->data());
+                $recipe = $this->Recipes->patchEntity($recipe, $this->request->getData());
                 if ($this->Recipes->save($recipe)) {
                     $message = 'Saved';
                 } else {
@@ -156,7 +156,7 @@ classe :php:class:`Xml` de CakePHP, et la representation en tableau des données
 est assigné à `$this->request->data`. Avec cette fonctionnalité, la gestion
 de XML et les données POST en parallèle est seamless: aucun changement n'est
 nécessaire pour le code du controller ou du model.
-Tout ce dont vous avez besoin devrait se trouver dans ``$this->request->data()``.
+Tout ce dont vous avez besoin devrait se trouver dans ``$this->request->getData()``.
 
 Accepter l'Input dans d'Autres Formats
 ======================================

--- a/fr/development/routing.rst
+++ b/fr/development/routing.rst
@@ -230,7 +230,7 @@ Vous pouvez spécifier vos propres éléments de route et ce faisant
 cela vous donne le pouvoir de définir des places dans l'URL où les
 paramètres pour les actions du controller doivent se trouver. Quand
 une requête est faite, les valeurs pour ces éléments de route se
-trouvent dans ``$this->request->param()`` dans le controller. Quand vous
+trouvent dans ``$this->request->getParam()`` dans le controller. Quand vous
 définissez un élément de route personnalisé, vous pouvez spécifier en option
 une expression régulière - ceci dit à CakePHP comment savoir si l'URL est
 correctement formée ou non. Si vous choisissez de ne pas fournir une expression
@@ -279,7 +279,7 @@ d'une application CakePHP 2.x, vous pouvez utiliser à la place la classe
 Une fois que cette route a été définie, la requête ``/apples/5`` est la même
 que celle requêtant ``/apples/view/5``. Les deux appelleraient la méthode view()
 de ApplesController. A l'intérieur de la méthode view(), vous aurez besoin
-d'accéder à l'ID passé à ``$this->request->param('id')``.
+d'accéder à l'ID passé à ``$this->request->getParam('id')``.
 
 Si vous avez un unique controller dans votre application et que vous ne
 voulez pas que le nom du controller apparaisse dans l'URL, vous pouvez mapper
@@ -327,7 +327,7 @@ dessus, mais ne pas grouper avec les parenthèses.
 Une fois définie, cette route va matcher ``/articles/2007/02/01``,
 ``/posts/2004/11/16``, gérant les requêtes
 pour les actions index() de ses controllers respectifs, avec les paramètres de
-date dans ``$this->request->param()``.
+date dans ``$this->request->getParam()``.
 
 Il y a plusieurs éléments de route qui ont une signification spéciale dans
 CakePHP, et ne devraient pas être utilisés à moins que vous souhaitiez
@@ -559,7 +559,7 @@ Ce qui est au-dessus va créer un template de route de type
 route ``prefix`` défini à ``manager/admin``.
 
 Le préfixe actuel sera disponible à partir des méthodes du controller avec
-``$this->request->param('prefix')``
+``$this->request->getParam('prefix')``
 
 Quand vous utilisez les routes préfixées, il est important de définir l'option
 prefix. Voici comment construire ce lien en utilisant le helper HTML::
@@ -781,7 +781,7 @@ Le code ci-dessus va générer une ressource de routes pour ``articles`` et
 
 You can get the ``article_id`` in ``CommentsController`` by::
 
-    $this->request->param('article_id');
+    $this->request->getParam('article_id');
 
 By default resource routes map to the same prefix as the containing scope. If
 you have both nested and non-nested resource controllers you can use a different
@@ -929,9 +929,9 @@ Dans l'exemple ci-dessus, ``recent`` et ``mark`` sont tous deux des arguments
 passés à ``CalendarsController::view()``. Les arguments passés sont transmis aux
 contrôleurs de trois manières. D'abord comme arguments de la méthode de
 l'action appelée, deuxièmement en étant accessibles dans
-``$this->request->param('pass')`` sous la forme d'un tableau indexé
+``$this->request->getParam('pass')`` sous la forme d'un tableau indexé
 numériquement. Enfin, il y a ``$this->passedArgs`` disponible de la même
-façon que par ``$this->request->param('pass')``. Lorsque vous utilisez des
+façon que par ``$this->request->getParam('pass')``. Lorsque vous utilisez des
 routes personnalisées il est possible de forcer des paramètres particuliers
 comme étant des paramètres passés également.
 
@@ -954,12 +954,12 @@ Vous auriez le résultat suivant::
         [1] => mark
     )
 
-La même donnée est aussi disponible dans ``$this->request->param('pass')`` dans
+La même donnée est aussi disponible dans ``$this->request->getParam('pass')`` dans
 vos controllers, vues, et helpers. Les valeurs dans le tableau pass sont
 indicées numériquement basé sur l'ordre dans lequel elles apparaissent dans
 l'URL appelé::
 
-    debug($this->request->param('pass'));
+    debug($this->request->getParam('pass'));
 
 Le résultat des 2 debug() du dessus serait::
 
@@ -1188,8 +1188,8 @@ Les filtres d'URL vous permettent d'implémenter des fonctionnalités telles que
 l'utilisation de paramètres d'URL persistants::
 
     Router::addUrlFilter(function ($params, $request) {
-        if ($request->param('lang') && !isset($params['lang'])) {
-            $params['lang'] = $request->param('lang');
+        if ($request->getParam('lang') && !isset($params['lang'])) {
+            $params['lang'] = $request->getParam('lang');
         }
         return $params;
     });
@@ -1230,7 +1230,7 @@ passés::
         Router::parseNamedParams($this->request);
     }
 
-Ceci va remplir ``$this->request->param('named')`` avec tout paramètre nommé
+Ceci va remplir ``$this->request->getParam('named')`` avec tout paramètre nommé
 trouvé dans les arguments passés. Tout argument passé qui a été interprété comme
 un paramètre nommé, sera retiré de la liste des arguments passés.
 

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -845,7 +845,7 @@ correspondant. Le code du controller ressemble à ceci::
         public function index($short = null)
         {
             if ($this->request->is('post')) {
-                $article = $this->Articles->newEntity($this->request->data());
+                $article = $this->Articles->newEntity($this->request->getData());
                 if ($this->Articles->save($article)) {
                     // Redirige selon le pattern PRG
                     return $this->redirect(['action' => 'index']);

--- a/fr/elasticsearch.rst
+++ b/fr/elasticsearch.rst
@@ -65,7 +65,7 @@ Vous pouvez utiliser votre classe type dans vos controllers::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success('It saved');
             }

--- a/fr/intro.rst
+++ b/fr/intro.rst
@@ -113,7 +113,7 @@ serait::
     {
         $user = $this->Users->newEntity();
         if ($this->request->is('post')) {
-            $user = $this->Users->patchEntity($user, $this->request->data());
+            $user = $this->Users->patchEntity($user, $this->request->getData());
             if ($this->Users->save($user, ['validate' => 'registration'])) {
                 $this->Flash->success(__('Vous êtes maintenant enregistré.'));
             } else {

--- a/fr/orm/saving-data.rst
+++ b/fr/orm/saving-data.rst
@@ -174,7 +174,7 @@ Convertir les Données Requêtées en Entities
 
 Avant de modifier et sauvegarder à nouveau les données dans la base de données,
 vous devrez convertir les données requêtées (qui se trouvent dans
-$this->request->data()) à partir du format de tableau
+$this->request->getData()) à partir du format de tableau
 qui se trouvent dans la requête, et les entities que l'ORM utilise. La classe
 Table facilite la conversion d'une ou de plusieurs entities à partir des
 données requêtées. Vous pouvez convertir une entity unique en utilisant::
@@ -182,7 +182,7 @@ données requêtées. Vous pouvez convertir une entity unique en utilisant::
     // Dans un controller.
     $articles = TableRegistry::get('Articles');
     // Valide et convertit en un objet Entity
-    $entity = $articles->newEntity($this->request->data());
+    $entity = $articles->newEntity($this->request->getData());
 
 Les données requêtées doivent suivre la structure de vos entities. Par
 exemple si vous avez un article qui appartient à un utilisateur, et si vous
@@ -216,7 +216,7 @@ compte::
     $articles = TableRegistry::get('Articles');
 
     // Nouvelle entity avec des associations imbriquées
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags', 'Comments' => ['associated' => ['Users']]
         ]
@@ -238,7 +238,7 @@ la notation par point pour être plus bref::
 
     // Nouvelle entity avec des associations imbriquées en utilisant
     // la notation par point
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => ['Tags', 'Comments.Users']
     ]);
 
@@ -251,7 +251,7 @@ de validation utilisé par association::
 
     // Ne fait pas la validation pour l'association Tags et
     // appelle l'ensemble de validation 'signup' pour Comments.Users
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags' => ['validate' => false],
             'Comments.Users' => ['validate' => 'signup']
@@ -361,7 +361,7 @@ multiples en une seule opération vous pouvez utiliser ``newEntities()``::
 
     // Dans un controller.
     $articles = TableRegistry::get('Articles');
-    $entities = $articles->newEntities($this->request->data());
+    $entities = $articles->newEntities($this->request->getData());
 
 Dans cette situation, les données de requête pour plusieurs articles doivent
 ressembler à ceci::
@@ -413,7 +413,7 @@ associations existantes entre certaines entities::
 
     // Dans un controller.
     $articles = TableRegistry::get('Articles');
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags', 'Comments' => [
                 'associated' => [
@@ -448,7 +448,7 @@ méthode ``patchEntity()``::
     // Dans un controller.
     $articles = TableRegistry::get('Articles');
     $article = $articles->get(1);
-    $articles->patchEntity($article, $this->request->data());
+    $articles->patchEntity($article, $this->request->getData());
     $articles->save($article);
 
 Validation et patchEntity
@@ -468,7 +468,7 @@ montré ci-dessous::
 Vous pouvez également changer l'ensemble de validation utilisé pour l'entity
 ou n'importe qu'elle association::
 
-    $articles->patchEntity($article, $this->request->data(), [
+    $articles->patchEntity($article, $this->request->getData(), [
         'validate' => 'custom',
         'associated' => ['Tags', 'Comments.Users' => ['validate' => 'signup']]
     ]);
@@ -486,7 +486,7 @@ pouvez utiliser le troisième paramètre de la méthode::
     // Dans un controller.
     $associated = ['Tags', 'Comments.Users'];
     $article = $articles->get(1, ['contain' => $associated]);
-    $articles->patchEntity($article, $this->request->data(), [
+    $articles->patchEntity($article, $this->request->getData(), [
         'associated' => $associated
     ]);
     $articles->save($article);
@@ -617,7 +617,7 @@ présentes dans les résultats::
     // Dans un controller.
     $articles = TableRegistry::get('Articles');
     $list = $articles->find('popular')->toArray();
-    $patched = $articles->patchEntities($list, $this->request->data());
+    $patched = $articles->patchEntities($list, $this->request->getData());
     foreach ($patched as $entity) {
         $articles->save($entity);
     }
@@ -629,7 +629,7 @@ fusionnées dans chacune des entities du tableau::
     // Dans un controller.
     $patched = $articles->patchEntities(
         $list,
-        $this->request->data(),
+        $this->request->getData(),
         ['associated' => ['Tags', 'Comments.Users']]
     );
 
@@ -759,7 +759,7 @@ passer dans ``save()``. Pare exemple::
 
   // Dans un controller
   $articles = TableRegistry::get('Articles');
-  $article = $articles->newEntity($this->request->data());
+  $article = $articles->newEntity($this->request->getData());
   if ($articles->save($article)) {
       // ...
   }

--- a/fr/orm/validation.rst
+++ b/fr/orm/validation.rst
@@ -24,7 +24,7 @@ Si aucune règle de validation n'échoue, l'entity retournée va contenir les
 erreurs. Les champs avec des erreurs ne seront pas présents dans l'entity
 retournée::
 
-    $article = $articles->newEntity($this->request->data());
+    $article = $articles->newEntity($this->request->getData());
     if ($article->errors()) {
         // validation de l'entity a échouée.
     }

--- a/fr/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/fr/tutorials-and-examples/blog-auth-example/auth.rst
@@ -395,13 +395,13 @@ Ajoutez le contenu suivant à votre ``ArticlesController.php``::
     public function isAuthorized($user)
     {
         // Tous les utilisateurs enregistrés peuvent ajouter des articles
-        if ($this->request->param('action') === 'add') {
+        if ($this->request->getParam('action') === 'add') {
             return true;
         }
 
         // Le propriétaire d'un article peut l'éditer et le supprimer
-        if (in_array($this->request->param('action'), ['edit', 'delete'])) {
-            $articleId = (int)$this->request->param('pass.0');
+        if (in_array($this->request->getParam('action'), ['edit', 'delete'])) {
+            $articleId = (int)$this->request->getParam('pass.0');
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;
             }

--- a/fr/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/fr/tutorials-and-examples/blog-auth-example/auth.rst
@@ -89,7 +89,7 @@ classe obtenue grâce à l'utilitaire de génération de code fournis par CakePH
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data());
+                $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__("L'utilisateur a été sauvegardé."));
                     return $this->redirect(['action' => 'index']);
@@ -316,7 +316,7 @@ l'utilisateur connecté courant en référence pour l'article créé::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Ajout de cette ligne
             $article->user_id = $this->Auth->user('id');
             // Vous pourriez aussi faire ce qui suit

--- a/fr/tutorials-and-examples/blog/part-three.rst
+++ b/fr/tutorials-and-examples/blog/part-three.rst
@@ -361,7 +361,7 @@ lorsque l'on va le créer ou le modifier::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);

--- a/fr/tutorials-and-examples/blog/part-two.rst
+++ b/fr/tutorials-and-examples/blog/part-two.rst
@@ -310,7 +310,7 @@ Premièrement, commençons par créer une action ``add()`` dans le
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Votre article a été sauvegardé.'));
                     return $this->redirect(['action' => 'index']);
@@ -341,7 +341,7 @@ application. Dans ce cas, nous utilisons la méthode
 type POST.
 
 Lorsqu'un utilisateur utilise un formulaire pour poster des données dans votre
-application, ces informations sont disponibles dans ``$this->request->data()``.
+application, ces informations sont disponibles dans ``$this->request->getData()``.
 Vous pouvez utiliser les fonctions :php:func:`pr()` ou :php:func:`debug()` pour
 les afficher si vous voulez voir à quoi cela ressemble.
 
@@ -483,7 +483,7 @@ devrait ressembler::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            $this->Articles->patchEntity($article, $this->request->data());
+            $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Votre article a été mis à jour.'));
                 return $this->redirect(['action' => 'index']);

--- a/fr/tutorials-and-examples/bookmarks/intro.rst
+++ b/fr/tutorials-and-examples/bookmarks/intro.rst
@@ -342,7 +342,7 @@ suit::
     {
         // La clé 'pass' est fournie par CakePHP et contient tous les segments
         // d'URL de la "request" (instance de \Cake\Network\Request)
-        $tags = $this->request->param('pass');
+        $tags = $this->request->getParam('pass');
 
         // On utilise l'objet "Bookmarks" (une instance de
         // \App\Model\Table\BookmarksTable) pour récupérer les bookmarks avec

--- a/fr/tutorials-and-examples/bookmarks/part-two.rst
+++ b/fr/tutorials-and-examples/bookmarks/part-two.rst
@@ -205,12 +205,12 @@ les bookmarks. Dans notre ``BookmarksController``, ajoutez ce qui suit::
             return true;
         }
         // Tout autre action nécessite un id.
-        if (!$this->request->param('pass.0')) {
+        if (!$this->request->getParam('pass.0')) {
             return false;
         }
 
         // Vérifie que le bookmark appartient à l'utilisateur courant.
-        $id = $this->request->param('pass.0');
+        $id = $this->request->getParam('pass.0');
         $bookmark = $this->Bookmarks->get($id);
         if ($bookmark->user_id == $user['id']) {
             return true;

--- a/fr/tutorials-and-examples/bookmarks/part-two.rst
+++ b/fr/tutorials-and-examples/bookmarks/part-two.rst
@@ -247,7 +247,7 @@ ressembler à ceci::
     {
         $bookmark = $this->Bookmarks->newEntity();
         if ($this->request->is('post')) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('Le bookmark a été sauvegardé.');
@@ -272,7 +272,7 @@ ceci::
             'contain' => ['Tags']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('Le bookmark a été sauvegardé.');

--- a/fr/views/helpers.rst
+++ b/fr/views/helpers.rst
@@ -75,7 +75,7 @@ conditionnellement des helpers::
         public function initialize()
         {
             parent::initialize();
-            if ($this->request->param('action') === 'index') {
+            if ($this->request->getParam('action') === 'index') {
                 $this->loadHelper('ListPage');
             }
         }

--- a/fr/views/helpers/form.rst
+++ b/fr/views/helpers/form.rst
@@ -577,7 +577,7 @@ répétitions, les options communes partagées par toutes les méthodes input so
   .. note::
 
     Vous ne pouvez pas utiliser ``default`` pour sélectionner une chekbox -
-    vous devez plutôt définir cette valeur dans ``$this->request->data()`` dans
+    vous devez plutôt définir cette valeur dans ``$this->request->getData()`` dans
     votre controller, ou définir l'option ``checked`` de l'input à ``true``.
 
     Attention à l'utilisation de ``false`` pour assigner une valeur par défaut.
@@ -838,7 +838,7 @@ Affichera:
 
     <textarea name="notes"></textarea>
 
-Si le form est édité (ainsi, le tableau ``$this->request->data()`` va contenir
+Si le form est édité (ainsi, le tableau ``$this->request->getData()`` va contenir
 les informations sauvegardées pour le model ``User``), la valeur
 correspondant au champs ``notes`` sera automatiquement ajoutée au HTML
 généré. Exemple:
@@ -1225,7 +1225,7 @@ un certain nombre d'options:
 * ``round`` - Mettre à ``up`` ou ``down`` pour forcer l'arrondi
   dans une direction. Par défaut à null.
 * ``default`` Le valeur par défaut à utiliser par l'input. Une valeur dans
-  ``$this->request->data()`` correspondante au nom du l'input écrasera cette
+  ``$this->request->getData()`` correspondante au nom du l'input écrasera cette
   valeur. Si aucune valeur par défaut n'est définie, ``time()`` sera utilisé.
 * ``timeFormat`` Le format d'heure à utiliser, soit 12 soit 24.
 * ``second`` Mettre à ``true`` to activer l'affichage des secondes.
@@ -1279,7 +1279,7 @@ n'inclura pas une option vide:
 * ``empty`` - Si ``true``, l'option select vide est montrée. Si c'est une
   chaîne, cette chaîne sera affichée en tant qu'élément vide.
 * ``default`` | ``value`` La valeur par défaut à utiliser pour l'input. Une
-  valeur dans ``$this->request->data()`` qui correspond au nom du champ va écraser
+  valeur dans ``$this->request->getData()`` qui correspond au nom du champ va écraser
   cette valeur.
   Si aucune valeur par défaut n'est fournie, ``time()`` sera utilisée.
 * ``timeFormat`` Le format de time à utiliser, soit 12 soit 24. Par défaut à 24.
@@ -1894,7 +1894,7 @@ créer les inputs suivantes::
 Le code ci-dessus pourrait ensuite être converti en un graph d'entity en
 utilisant le code suivant dans votre controller::
 
-    $article = $this->Articles->patchEntity($article, $this->request->data(), [
+    $article = $this->Articles->patchEntity($article, $this->request->getData(), [
         'associated' => [
             'Authors',
             'Authors.Profiles',

--- a/ja/controllers/components.rst
+++ b/ja/controllers/components.rst
@@ -144,7 +144,7 @@ CakePHP の中に含まれるコンポーネントの詳細については、各
 
         public function delete()
         {
-            if ($this->Post->delete($this->request->data('Post.id')) {
+            if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
                 return $this->redirect(['action' => 'index']);
             }

--- a/ja/controllers/components/authentication.rst
+++ b/ja/controllers/components/authentication.rst
@@ -661,7 +661,7 @@ CakePHP は、1つのアルゴリズムから別のユーザーのパスワー�
                 $this->Auth->setUser($user);
                 if ($this->Auth->authenticationProvider()->needsPasswordRehash()) {
                     $user = $this->Users->get($this->Auth->user('id'));
-                    $user->password = $this->request->data('password');
+                    $user->password = $this->request->getData('password');
                     $this->Users->save($user);
                 }
                 return $this->redirect($this->Auth->redirectUrl());
@@ -684,7 +684,7 @@ CakePHP は、1つのアルゴリズムから別のユーザーのパスワー�
 
     public function register()
     {
-        $user = $this->Users->newEntity($this->request->data());
+        $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
             return $this->redirect([

--- a/ja/controllers/middleware.rst
+++ b/ja/controllers/middleware.rst
@@ -217,7 +217,7 @@ PSR7 リクエストとレスポンス
 
             // レスポンスを変更する時には、 next を呼んだ *後に*
             // それを行うべきです。
-            if (!$request->cookie('landing_page')) {
+            if (!$request->getCookie('landing_page')) {
                 $response->cookie([
                     'name' => 'landing_page',
                     'value' => $request->here(),

--- a/ja/controllers/request-response.rst
+++ b/ja/controllers/request-response.rst
@@ -64,12 +64,12 @@ Request はリクエストパラメータにアクセスするためのいくつ
 読み取ることができます。 ::
 
     // URL は /posts/index?page=1&sort=title
-    $this->request->query('page');
+    $this->request->getQuery('page');
 
 query プロパティに直接アクセスするか、エラーが発生しない方法で URL クエリ配列を読むために
 ``query()`` メソッドを使用することができます。キーが存在しない場合、 ``null`` が返ります。 ::
 
-    $foo = $this->request->query('value_that_does_not_exist');
+    $foo = $this->request->getQuery('value_that_does_not_exist');
     // $foo === null
 
 リクエストのボディデータ

--- a/ja/controllers/request-response.rst
+++ b/ja/controllers/request-response.rst
@@ -81,11 +81,11 @@ query プロパティに直接アクセスするか、エラーが発生しな�
 フォームデータが ``data`` 接頭辞を含んでいる場合、接頭辞は取り除かれるでしょう。例えば::
 
     // name 属性が 'MyModel[title]' の入力は次のようにアクセスします。
-    $this->request->data('MyModel.title');
+    $this->request->getData('MyModel.title');
 
 キーが存在しない場合、 ``null`` が返ります。 ::
 
-    $foo = $this->request->data('Value.that.does.not.exist');
+    $foo = $this->request->getData('Value.that.does.not.exist');
     // $foo == null
 
 また、データの配列に配列としてアクセスすることができます。 ::

--- a/ja/core-libraries/form.rst
+++ b/ja/core-libraries/form.rst
@@ -98,7 +98,7 @@
 
 モデルのないフォームのフィールドに値を設定するために、
 FormHelperによって作成される他のすべてのフォームのように
-``$this->request->getData()`` を使って値を定義することができます::
+``$this->request->data()`` を使って値を定義することができます::
 
     // 何らかのコントローラ中で
     namespace App\Controller;
@@ -121,8 +121,8 @@ FormHelperによって作成される他のすべてのフォームのように
             
             if ($this->request->is('get')) {
                 // たとえばユーザーモデルの値
-                $this->request->getData('name', 'John Doe');
-                $this->request->getData('email','john.doe@example.com');
+                $this->request->data('name', 'John Doe');
+                $this->request->data('email','john.doe@example.com');
             }
             
             $this->set('contact', $contact);

--- a/ja/core-libraries/form.rst
+++ b/ja/core-libraries/form.rst
@@ -78,7 +78,7 @@
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('すぐにご連絡いたします。');
                 } else {
                     $this->Flash->error('フォーム送信に問題がありました。');
@@ -91,14 +91,14 @@
 上の例では、データが有効な時にのみフォームの ``_execute()`` を走らせるために ``execute()`` メソッドを実行し、それに応じたフラッシュメッセージを設定しています。
 データ検証のみ行うために ``validate()`` を使うこともできます::
 
-    $isValid = $form->validate($this->request->data());
+    $isValid = $form->validate($this->request->getData());
     
 フォーム値の設定
 ================
 
 モデルのないフォームのフィールドに値を設定するために、
 FormHelperによって作成される他のすべてのフォームのように
-``$this->request->data()`` を使って値を定義することができます::
+``$this->request->getData()`` を使って値を定義することができます::
 
     // 何らかのコントローラ中で
     namespace App\Controller;
@@ -112,7 +112,7 @@ FormHelperによって作成される他のすべてのフォームのように
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('すぐにご連絡いたします。');
                 } else {
                     $this->Flash->error('フォーム送信に問題がありました。');
@@ -121,8 +121,8 @@ FormHelperによって作成される他のすべてのフォームのように
             
             if ($this->request->is('get')) {
                 // たとえばユーザーモデルの値
-                $this->request->data('name', 'John Doe');
-                $this->request->data('email','john.doe@example.com');
+                $this->request->getData('name', 'John Doe');
+                $this->request->getData('email','john.doe@example.com');
             }
             
             $this->set('contact', $contact);

--- a/ja/core-libraries/validation.rst
+++ b/ja/core-libraries/validation.rst
@@ -425,7 +425,7 @@ Localized プラグインは、バリデーションのための国の２文字�
         ->requirePresence('comment')
         ->notEmpty('comment', 'You need to give a comment.');
 
-    $errors = $validator->errors($this->request->data());
+    $errors = $validator->errors($this->request->getData());
     if (empty($errors)) {
         // email を送る。
     }
@@ -442,7 +442,7 @@ Localized プラグインは、バリデーションのための国の２文字�
 適用されますが、 'update' を実行する際のルールを適用したい場合は、
 以下のことが可能となります。 ::
 
-    $errors = $validator->errors($this->request->data(), false);
+    $errors = $validator->errors($this->request->getData(), false);
     if (empty($errors)) {
         // email を送る。
     }
@@ -466,7 +466,7 @@ Localized プラグインは、バリデーションのための国の２文字�
 保存前のエンティティのバリデーションは自動的に実行されます。 ::
 
     // ArticlesController クラスにおいて
-    $article = $this->Articles->newEntity($this->request->data());
+    $article = $this->Articles->newEntity($this->request->getData());
     if ($article->errors()) {
         // エラーメッセージが表示されるためのコードを書く
 
@@ -476,7 +476,7 @@ Localized プラグインは、バリデーションのための国の２文字�
 ``newEntities()`` メソッドを用いることができます。 ::
 
     // ArticlesControllerクラスにおいて
-    $entities = $this->Articles->newEntities($this->request->data());
+    $entities = $this->Articles->newEntities($this->request->getData());
     foreach ($entities as $entity) {
         if (!$entity->errors()) {
                 $this->Articles->save($entity);

--- a/ja/development/dispatch-filters.rst
+++ b/ja/development/dispatch-filters.rst
@@ -113,7 +113,7 @@ CakePHP はきれいなディスパッチサイクルに使う強固なフィル
         {
             $request = $event->data['request'];
             $response = $event->data['response'];
-            if (!$request->cookie('landing_page')) {
+            if (!$request->getCookie('landing_page')) {
                 $response->cookie([
                     'name' => 'landing_page',
                     'value' => $request->here(),

--- a/ja/development/rest.rst
+++ b/ja/development/rest.rst
@@ -52,7 +52,7 @@ REST を動かすための手っ取り早い方法は、 config/routes.php フ�
 
         public function add()
         {
-            $recipe = $this->Recipes->newEntity($this->request->data());
+            $recipe = $this->Recipes->newEntity($this->request->getData());
             if ($this->Recipes->save($recipe)) {
                 $message = 'Saved';
             } else {
@@ -69,7 +69,7 @@ REST を動かすための手っ取り早い方法は、 config/routes.php フ�
         {
             $recipe = $this->Recipes->get($id);
             if ($this->request->is(['post', 'put'])) {
-                $recipe = $this->Recipes->patchEntity($recipe, $this->request->data());
+                $recipe = $this->Recipes->patchEntity($recipe, $this->request->getData());
                 if ($this->Recipes->save($recipe)) {
                     $message = 'Saved';
                 } else {
@@ -145,9 +145,9 @@ edit アクションのロジックを作るのは少しだけトリッキーで
 :php:class:`Cake\\Controller\\Component\\RequestHandler` と
 :php:class:`Cake\\Routing\\Router` クラスが取り計らってくれます。
 POST もしくは PUT リクエストのコンテンツタイプが XML であれば、入力データは CakePHP の
-:php:class:`Xml` クラスに渡され、配列に変換され、 ``$this->request->data()`` に入ります。
+:php:class:`Xml` クラスに渡され、配列に変換され、 ``$this->request->getData()`` に入ります。
 この機能によって、XML と POST データの処理はシームレスになるのです。コントローラもモデルも
-XML の入力を気にせずに、 ``$this->request->data()`` のみを扱えば良いのです。
+XML の入力を気にせずに、 ``$this->request->getData()`` のみを扱えば良いのです。
 
 他のフォーマットのインプットデータ
 ============================================
@@ -155,7 +155,7 @@ XML の入力を気にせずに、 ``$this->request->data()`` のみを扱えば
 REST アプリケーションの場合、様々なフォーマットのデータを扱います。
 CakePHP では、 :php:class:`RequestHandlerComponent` クラスが助けてくれます。
 デフォルトでは、POST や PUT で送られてくる JSON/XML の入力データはデコードされ、
-配列に変換されてから ``$this->request->data()`` に格納されます。独自のデコード処理も
+配列に変換されてから ``$this->request->getData()`` に格納されます。独自のデコード処理も
 :php:meth:`RequestHandler::addInputType()` を利用すれば追加可能です。
 
 

--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -757,7 +757,7 @@ CakePHP は特殊な ``IntegrationTestCase`` クラスを提供しています�
         public function index($short = null)
         {
             if ($this->request->is('post')) {
-                $article = $this->Articles->newEntity($this->request->data());
+                $article = $this->Articles->newEntity($this->request->getData());
                 if ($this->Articles->save($article)) {
                     // Redirect as per PRG pattern
                     return $this->redirect(['action' => 'index']);

--- a/ja/elasticsearch.rst
+++ b/ja/elasticsearch.rst
@@ -62,7 +62,7 @@ ElasticSearch プラグインは elasticsearch インデックスと作用する
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                 $this->Flash->success('It saved');
             }

--- a/ja/intro.rst
+++ b/ja/intro.rst
@@ -92,7 +92,7 @@ XML 形式の結果をレンダリングできます。 ::
     {
         $user = $this->Users->newEntity();
         if ($this->request->is('post')) {
-            $user = $this->Users->patchEntity($user, $this->request->data());
+            $user = $this->Users->patchEntity($user, $this->request->getData());
             if ($this->Users->save($user, ['validate' => 'registration'])) {
                 $this->Flash->success(__('You are now registered.'));
             } else {

--- a/ja/orm/saving-data.rst
+++ b/ja/orm/saving-data.rst
@@ -171,7 +171,7 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
     $articles = TableRegistry::get('Articles');
 
     // 検証して Entity オブジェクトに変換します。
-    $entity = $articles->newEntity($this->request->data());
+    $entity = $articles->newEntity($this->request->getData());
 
 .. note::
 
@@ -210,7 +210,7 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
     $articles = TableRegistry::get('Articles');
 
     // 入れ子になったアソシエーション付きの新しいエンティティ
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags', 'Comments' => ['associated' => ['Users']]
         ]
@@ -229,7 +229,7 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
     $articles = TableRegistry::get('Articles');
 
     // ドット記法を用いた、入れ子になったアソシエーション付きの新しいエンティティ
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => ['Tags', 'Comments.Users']
     ]);
 
@@ -241,7 +241,7 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
 
     // Tags アソシエーションの検証を回避して
     // Comments.Users 用に 'signup' の検証セットを指定します
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags' => ['validate' => false],
             'Comments.Users' => ['validate' => 'signup']
@@ -346,7 +346,7 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 
     // コントローラの中で。
     $articles = TableRegistry::get('Articles');
-    $entities = $articles->newEntities($this->request->data());
+    $entities = $articles->newEntities($this->request->getData());
 
 この場合には、複数の記事用のリクエストデータはこうなるべきです。 ::
 
@@ -396,7 +396,7 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 
     // コントローラの中で
     $articles = TableRegistry::get('Articles');
-    $entity = $articles->newEntity($this->request->data(), [
+    $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
             'Tags', 'Comments' => [
                 'associated' => [
@@ -429,7 +429,7 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
     // コントローラの中で。
     $articles = TableRegistry::get('Articles');
     $article = $articles->get(1);
-    $articles->patchEntity($article, $this->request->data());
+    $articles->patchEntity($article, $this->request->getData());
     $articles->save($article);
 
 
@@ -449,7 +449,7 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 当該のエンティティ、または何らかのアソシエーションに対して使われる検証セットを
 変更することもできます。 ::
 
-    $articles->patchEntity($article, $this->request->data(), [
+    $articles->patchEntity($article, $this->request->getData(), [
         'validate' => 'custom',
         'associated' => ['Tags', 'Comments.Users' => ['validate' => 'signup']]
     ]);
@@ -465,7 +465,7 @@ HasMany と BelongsToMany へのパッチ
     // コントローラの中で。
     $associated = ['Tags', 'Comments.Users'];
     $article = $articles->get(1, ['contain' => $associated]);
-    $articles->patchEntity($article, $this->request->data(), [
+    $articles->patchEntity($article, $this->request->getData(), [
         'associated' => $associated
     ]);
     $articles->save($article);
@@ -581,7 +581,7 @@ hasMany と belongsToMany アソシエーションに対してのパッチのた
     // コントローラの中で。
     $articles = TableRegistry::get('Articles');
     $list = $articles->find('popular')->toArray();
-    $patched = $articles->patchEntities($list, $this->request->data());
+    $patched = $articles->patchEntities($list, $this->request->getData());
     foreach ($patched as $entity) {
         $articles->save($entity);
     }
@@ -592,7 +592,7 @@ hasMany と belongsToMany アソシエーションに対してのパッチのた
     // コントローラの中で。
     $patched = $articles->patchEntities(
         $list,
-        $this->request->data(),
+        $this->request->getData(),
         ['associated' => ['Tags', 'Comments.Users']]
     );
 
@@ -715,7 +715,7 @@ CakePHP の検証機能をどう使うかについてより詳しい情報があ
 
   // コントローラのの中で
   $articles = TableRegistry::get('Articles');
-  $article = $articles->newEntity($this->request->data());
+  $article = $articles->newEntity($this->request->getData());
   if ($articles->save($article)) {
       // ...
   }

--- a/ja/orm/validation.rst
+++ b/ja/orm/validation.rst
@@ -22,7 +22,7 @@ CakePHP ではデータの検証には二つの段階があります:
 返されたエンティティはエラーを含んだ状態になります。
 エラーのあるフィールドは返されたエンティティには含まれません。 ::
 
-    $article = $articles->newEntity($this->request->data());
+    $article = $articles->newEntity($this->request->getData());
     if ($article->errors()) {
         // エンティティ検証失敗。
     }

--- a/ja/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/ja/tutorials-and-examples/blog-auth-example/auth.rst
@@ -80,7 +80,7 @@ CakePHP にバンドルされているコード生成ユーティリティを利
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data());
+                $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
                     return $this->redirect(['action' => 'add']);
@@ -279,7 +279,7 @@ AppController の ``beforeFilter()`` ですでに許可されている ``index()
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Added this line
             $article->user_id = $this->Auth->user('id');
             // You could also do the following

--- a/ja/tutorials-and-examples/blog/part-three.rst
+++ b/ja/tutorials-and-examples/blog/part-three.rst
@@ -329,7 +329,7 @@ Articles コントローラを編集する
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);

--- a/ja/tutorials-and-examples/blog/part-two.rst
+++ b/ja/tutorials-and-examples/blog/part-two.rst
@@ -272,7 +272,7 @@ Articlesテーブルに対して ``get()`` を用いるとき、存在するレ�
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);
@@ -299,7 +299,7 @@ POST なら、Articles モデルを使ってデータの保存を試みます。
 リクエストが HTTP POST かどうかの確認に :php:meth:`Cake\\Network\\Request::is()` メソッドを
 使用しています。
 
-ユーザがフォームを使ってデータを POST した場合、その情報は、 ``$this->request->data()``
+ユーザがフォームを使ってデータを POST した場合、その情報は、 ``$this->request->getData()``
 の中に入ってきます。 :php:func:`pr()` や :php:func:`debug()` を使うと、
 内容を画面に表示させて、確認することができます。
 
@@ -425,7 +425,7 @@ Article モデルを見直して、幾つか修正してみましょう。 ::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            $this->Articles->patchEntity($article, $this->request->data());
+            $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
                 return $this->redirect(['action' => 'index']);

--- a/ja/tutorials-and-examples/bookmarks/part-two.rst
+++ b/ja/tutorials-and-examples/bookmarks/part-two.rst
@@ -229,7 +229,7 @@ AppController に追加しましょう。 ::
     {
         $bookmark = $this->Bookmarks->newEntity();
         if ($this->request->is('post')) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('ブックマークを保存しました。');
@@ -252,7 +252,7 @@ AppController に追加しましょう。 ::
             'contain' => ['Tags']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('ブックマークを保存しました。');

--- a/pt/core-libraries/form.rst
+++ b/pt/core-libraries/form.rst
@@ -82,7 +82,7 @@ e validar os dados::
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('We will get back to you soon.');
                 } else {
                     $this->Flash->error('There was a problem submitting your form.');
@@ -97,14 +97,14 @@ No exemplo acima, usamos o método ``execute()`` para chamar o nosso método
 adequadas. Poderíamos também ter usado o método ``validate()`` apenas para validar
 a requisição de dados::
 
-    $isValid = $form->validate($this->request->data());
+    $isValid = $form->validate($this->request->getData());
     
 
 Definindo os Valores do Formulário
 ==================================
 
 Na sequência para definir os valores para os campos do formulário sem modelo, basta apenas definir
-os valores usando ``$this->request->data()``, como em todos os outros formulários criados pelo FormHelper::
+os valores usando ``$this->request->getData()``, como em todos os outros formulários criados pelo FormHelper::
 
     // Em um controller
     namespace App\Controller;
@@ -118,7 +118,7 @@ os valores usando ``$this->request->data()``, como em todos os outros formulári
         {
             $contact = new ContactForm();
             if ($this->request->is('post')) {
-                if ($contact->execute($this->request->data())) {
+                if ($contact->execute($this->request->getData())) {
                     $this->Flash->success('Retornaremos o contato em breve.');
                 } else {
                     $this->Flash->error('Houve um problema ao enviar seu formulário.');
@@ -127,8 +127,8 @@ os valores usando ``$this->request->data()``, como em todos os outros formulári
             
             if ($this->request->is('get')) {
                 //Values from the User Model e.g.
-                $this->request->data('name', 'John Doe');
-                $this->request->data('email','john.doe@example.com');
+                $this->request->getData('name', 'John Doe');
+                $this->request->getData('email','john.doe@example.com');
             }
             
             $this->set('contact', $contact);

--- a/pt/elasticsearch.rst
+++ b/pt/elasticsearch.rst
@@ -67,7 +67,7 @@ Você pode então usar a sua classe *type* nos seus *controllers*::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success('It saved');
             }

--- a/pt/intro.rst
+++ b/pt/intro.rst
@@ -104,7 +104,7 @@ camada View. Um exemplo de controller para registro de usuário seria::
     {
         $user = $this->Users->newEntity();
         if ($this->request->is('post')) {
-            $user = $this->Users->patchEntity($user, $this->request->data());
+            $user = $this->Users->patchEntity($user, $this->request->getData());
             if ($this->Users->save($user, ['validate' => 'registration'])) {
                 $this->Flash->success(__('Você está registrado.'));
             } else {

--- a/pt/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/pt/tutorials-and-examples/blog-auth-example/auth.rst
@@ -377,13 +377,13 @@ o seguinte conteúdo::
     public function isAuthorized($user)
     {
         // Todos os usuários registrados podem adicionar artigos
-        if ($this->request->param('action') === 'add') {
+        if ($this->request->getParam('action') === 'add') {
             return true;
         }
 
         // Apenas o proprietário do artigo pode editar e excluí
-        if (in_array($this->request->param('action'), ['edit', 'delete'])) {
-            $articleId = (int)$this->request->param('pass.0');
+        if (in_array($this->request->getParam('action'), ['edit', 'delete'])) {
+            $articleId = (int)$this->request->getParam('pass.0');
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;
             }

--- a/pt/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/pt/tutorials-and-examples/blog-auth-example/auth.rst
@@ -88,7 +88,7 @@ geração de código ``bake`` fornecido com CakePHP::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                $user = $this->Users->patchEntity($user, $this->request->data());
+                $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('O usuário foi salvo.'));
                     return $this->redirect(['action' => 'add']);
@@ -304,7 +304,7 @@ criado::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            $article = $this->Articles->patchEntity($article, $this->request->data());
+            $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Adicione esta linha
             $article->user_id = $this->Auth->user('id');
             // Você também pode fazer o seguinte

--- a/pt/tutorials-and-examples/blog/part-three.rst
+++ b/pt/tutorials-and-examples/blog/part-three.rst
@@ -352,7 +352,7 @@ ele:
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);

--- a/pt/tutorials-and-examples/blog/part-two.rst
+++ b/pt/tutorials-and-examples/blog/part-two.rst
@@ -277,7 +277,7 @@ Primeiro, comece criando a action ``add()`` no ``ArticlesController``::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                $article = $this->Articles->patchEntity($article, $this->request->data());
+                $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Seu artigo foi salvo.'));
                     return $this->redirect(['action' => 'index']);
@@ -307,7 +307,7 @@ caso, nós usamos o método :php:meth:`Cake\\Network\\Request::is()` para checar
 se a requisição é do tipo HTTP POST.
 
 Quando se usa um formulário para postar dados, essa informação fica disponível
-em ``$this->request->data()``. Você pode usar as funções :php:func:`pr()` ou
+em ``$this->request->getData()``. Você pode usar as funções :php:func:`pr()` ou
 :php:func:`debug()` caso queira verificar esses dados.
 
 Usamos os métodos ``success()`` e ``error()`` do ``FlashComponent`` para definir
@@ -436,7 +436,7 @@ a action ``edit()`` que deverá ser inserida no ``ArticlesController``::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            $this->Articles->patchEntity($article, $this->request->data());
+            $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Seu artigo foi atualizado.'));
                 return $this->redirect(['action' => 'index']);

--- a/pt/tutorials-and-examples/bookmarks/intro.rst
+++ b/pt/tutorials-and-examples/bookmarks/intro.rst
@@ -274,7 +274,7 @@ informativa do CakePHP. Vamos implementar esse método ausente agora. Em
 
     public function tags()
     {
-        $tags = $this->request->param('pass');
+        $tags = $this->request->getParam('pass');
         $bookmarks = $this->Bookmarks->find('tagged', [
             'tags' => $tags
         ]);

--- a/pt/tutorials-and-examples/bookmarks/part-two.rst
+++ b/pt/tutorials-and-examples/bookmarks/part-two.rst
@@ -191,12 +191,12 @@ para os bookmarks. Em seu ``BookmarksController`` adicione o seguinte::
             return true;
         }
         // Todas as outras ações requerem um id.
-        if (!$this->request->param('pass.0')) {
+        if (!$this->request->getParam('pass.0')) {
             return false;
         }
 
         // Checa se o bookmark pertence ao user atual.
-        $id = $this->request->param('pass.0');
+        $id = $this->request->getParam('pass.0');
         $bookmark = $this->Bookmarks->get($id);
         if ($bookmark->user_id == $user['id']) {
             return true;

--- a/pt/tutorials-and-examples/bookmarks/part-two.rst
+++ b/pt/tutorials-and-examples/bookmarks/part-two.rst
@@ -233,7 +233,7 @@ Com isso removido, nós também vamos atualizar o método add::
     {
         $bookmark = $this->Bookmarks->newEntity();
         if ($this->request->is('post')) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
@@ -256,7 +256,7 @@ ação edit deve ficar assim::
             'contain' => ['Tags']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->data());
+            $bookmark = $this->Bookmarks->patchEntity($bookmark, $this->request->getData());
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');

--- a/zh/development/rest.rst
+++ b/zh/development/rest.rst
@@ -46,7 +46,7 @@ REST可以帮你有效地向他人提供在你的应用中已创建的逻辑（�
 
         public function add()
         {
-            $recipe = $this->Recipes->newEntity($this->request->data());
+            $recipe = $this->Recipes->newEntity($this->request->getData());
             if ($this->Recipes->save($recipe)) {
                 $message = 'Saved';
             } else {
@@ -63,7 +63,7 @@ REST可以帮你有效地向他人提供在你的应用中已创建的逻辑（�
         {
             $recipe = $this->Recipes->get($id);
             if ($this->request->is(['post', 'put'])) {
-                $recipe = $this->Recipes->patchEntity($recipe, $this->request->data());
+                $recipe = $this->Recipes->patchEntity($recipe, $this->request->getData());
                 if ($this->Recipes->save($recipe)) {
                     $message = 'Saved';
                 } else {
@@ -134,16 +134,16 @@ index方法的REST视图的简单的代码::
 由于你提供的API输出的是XML，自然来说你的第一选择是接收XML格式的数据。
 不需要担心的是，由于有了:php:class:`Cake\\Controller\\Component\\RequestHandler` 和
 :php:class:`Cake\\Routing\\Router` 可以让事情更简单。
-如果一个POST/PUT请求发送了XML格式的数据，那么数据会经过CakePHP的:php:class:`Xml` 类的处理，所有数据都会合并到``$this->request->data()`` 中
+如果一个POST/PUT请求发送了XML格式的数据，那么数据会经过CakePHP的:php:class:`Xml` 类的处理，所有数据都会合并到``$this->request->getData()`` 中
 因为这些特性，处理和发送XML数据是毫无阻碍的，你完全不必去修改控制器或者模型的任何代码。
-所有你需要的都会合并到``$this->request->data()`` 中。
+所有你需要的都会合并到``$this->request->getData()`` 中。
 
 接收其他格式的数据
 ==================
 
 典型的REST应用不仅可以输出不同格式的数据，同时也可以接收不同格式的数据
 在CakePHP中:php:class:`RequestHandlerComponent` 帮助我们实现了这个目标。
-一般来说，它会解码通过POST/PUT请求所接收到的JSON/XML的任何数据并且在``$this->request->data()`` 中告诉你数据的格式。
+一般来说，它会解码通过POST/PUT请求所接收到的JSON/XML的任何数据并且在``$this->request->getData()`` 中告诉你数据的格式。
 当然如果你需要的话，你也可以自定义其他的反序列化方法以此丰富你的数据接收/发送格式（通过:php:meth:`RequestHandler::addInputType()` 来添加）。
 
 具有REST特性的路由


### PR DESCRIPTION
I'm wondering if its a good idea to update all the documentation to the non-deprecated APIs. While it makes our lives easier in the future, it makes using the documentation harder for people on older versions as we always have to include both old & new in examples.

ping @dereuromark 