### PR TITLE
Fix strategy option description and add missing ones.

### DIFF
--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -204,7 +204,7 @@ Possible keys for hasOne association arrays include:
   associated table into the source table results. By default this is the
   underscored & singular name of the association so ``address`` in our example.
 - **strategy**: Defines the query strategy to use. Defaults to 'join'. The other
-  valid value is 'select', which utilizes sub-queries instead.
+  valid value is 'select', which utilizes a separate query instead.
 - **finder**: The finder method to use when loading associated records.
 
 Once this association has been defined, find operations on the Users table can
@@ -291,6 +291,8 @@ Possible keys for belongsTo association arrays include:
 - **propertyName**: The property name that should be filled with data from the
   associated table into the source table results. By default this is the
   underscored & singular name of the association so ``user`` in our example.
+- **strategy**: Defines the query strategy to use. Defaults to 'join'. The other
+  valid value is 'select', which utilizes a separate query instead.
 - **finder**: The finder method to use when loading associated records.
 
 Once this association has been defined, find operations on the User table can

--- a/fr/orm/associations.rst
+++ b/fr/orm/associations.rst
@@ -213,8 +213,8 @@ Les clés possibles pour une association hasOne sont:
   un nom en underscore et singulier de l'association, donc ``address`` dans
   notre exemple.
 - **strategy**: Définit la stratégie de requête à utiliser. Par défaut à
-  'join'. L'autre valeur valide est 'select', qui utilise les sous-requêtes à la
-  place.
+  'join'. L'autre valeur valide est 'select', qui utilise une requête distincte
+  à la place.
 - **finder**: La méthode finder à utiliser lors du chargement des
   enregistrements associés.
 
@@ -306,6 +306,9 @@ Les clés possibles pour les tableaux d'association belongsTo sont:
   données de la table associée dans les résultats de la table source. Par défaut
   il s'agit du nom singulier avec des underscores de l'association donc
   ``user`` dans notre exemple.
+- **strategy**: Définit la stratégie de requête à utiliser. Par défaut à
+  'join'. L'autre valeur valide est 'select', qui utilise une requête distincte
+  à la place.
 - **finder**: La méthode finder à utiliser lors du chargement des
   enregistrements associés.
 


### PR DESCRIPTION
The `select` strategy uses a separate querey, and `belongsTo` associations support the `strategy` option too.