### PR TITLE
resolve ambiguity of returning result set or data

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -114,7 +114,7 @@ execute until you start fetching rows, convert it to an array, or when the
     $data = $results->toArray();
 
     // Converting the query to an array will execute it.
-    $results = $query->toArray();
+    $data = $query->toArray();
 
 .. note::
 


### PR DESCRIPTION
Using $results variable in previous case with all() method call, we did not have the actual data