### PR TITLE
Restore formatting of code blocks.

### DIFF
--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -436,6 +436,7 @@ h6:hover .headerlink {
 
 
 /* inline code */
+code,
 tt {
     font-family: "Roboto Mono", "Consolas", "Monaco", monospace;
     font-size: 105%;
@@ -443,9 +444,11 @@ tt {
     padding: 0px 2px;
     color: #363637;
 }
+a code,
 a tt {
     color: #428bca;
 }
+dl code,
 dl tt {
     border-bottom: none;
 }
@@ -643,6 +646,7 @@ dl.const em.property {
     font-size: 14px;
     margin-bottom: 5px;
 }
+dt code,
 dt tt {
     background: none;
 }


### PR DESCRIPTION
A recent sphinx/docutils upgrade has resulted in inline code blocks being marked up as `code` instead of `tt`. This has resulted in the book being ugly. Restore the book to its former glory.