### PR TITLE
Clarify where/how escaping is done in flash templates.

### DIFF
--- a/en/controllers/components/flash.rst
+++ b/en/controllers/components/flash.rst
@@ -87,11 +87,11 @@ message.
 
 .. note::
 
-    By default, CakePHP escapes the content in flash messages for security
-    reasons. If you are using any request or user data in your flash messages
-    those are escaped and therefore safe to be printed. If you want to output
-    HTML, you need to pass in an ``escape`` param and also adjust the templates
-    to allow disabling escaping when such a param is passed.
+    By default, CakePHP escapes the content in flash messages to prevent cross
+    site scripting. User data in your flash messages will be HTML encoded and
+    safe to be printed. If you want to include HTML in your flash messages, you
+    need to pass the ``escape`` option and adjust your flash message templates
+    to allow disabling escaping when the escape option is passed.
 
 HTML in Flash Messages
 ======================

--- a/en/views/helpers/flash.rst
+++ b/en/views/helpers/flash.rst
@@ -41,9 +41,8 @@ You can also override any of the options that were set in FlashComponent::
 
 .. note::
 
-    By default, CakePHP does not escape the HTML in flash messages. If you are
-    using any request or user data in your flash messages, you should escape it
-    with :php:func:`h` when formatting your messages.
+    When building custom flash message templates, be sure to properly HTML
+    encode any user data. CakePHP won't escape flash message parameters for you.
 
 .. versionadded:: 3.1
 


### PR DESCRIPTION
Refs #4483