### PR TITLE
Update form.rst

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -187,7 +187,7 @@ rules that only apply when an account is being registered::
         'context' => ['validator' => 'register']
     ]);
 
-The above will use the ``register`` validator for the ``$user`` and all related
+The above will use the ``register`` validator(the rules defined within UsersTable::validationRegister()) for the ``$user`` and all related
 associations. If you are creating a form for associated entities, you can define
 validation rules for each association by using an array::
 


### PR DESCRIPTION
Documentation shall be more clear about validation sets and what they are. It is not too obvious in the validation section either, but I think it is better to mention it in FormHelper manual page, where we define which set of rules we want to use. 
At least here it will be apparent for developer what manual is talking about.