### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/en/models/virtual-fields.rst
+++ b/en/models/virtual-fields.rst
@@ -99,7 +99,7 @@ Pagination and virtual fields
 -----------------------------
 
 Since virtual fields behave much like regular fields when doing
-find's, ``Controller::paginate()`` will be able to sort by virtual fields too.
+finds, ``Controller::paginate()`` will be able to sort by virtual fields too.
 
 Virtual fields and model aliases
 ================================


### PR DESCRIPTION
A simple plural like "finds" does not need an apostrophe