### PR TITLE
Align Inflector table cell

### DIFF
--- a/en/core-libraries/inflector.rst
+++ b/en/core-libraries/inflector.rst
@@ -42,7 +42,7 @@ when provided a multi-word argument:
 +-------------------+---------------+---------------+
 | ``humanize()``    | big_apples    | Big Apples    |
 +                   +---------------+---------------+
-|                   | bigApple     | BigApple       |
+|                   | bigApple      | BigApple      |
 +-------------------+---------------+---------------+
 | ``classify()``    | big_apples    | BigApple      | 
 +                   +---------------+---------------+


### PR DESCRIPTION
The second line of the humanize() method, in the table, was a bit broken as it had the reST cell border markups slightly misaligned.
Fixed now.