### PR TITLE
updated chronos with missing method calls

### DIFF
--- a/en/chronos.rst
+++ b/en/chronos.rst
@@ -138,8 +138,10 @@ It is also possible to make big jumps to defined points in time::
 
     $time = Chronos::create();
     $time->startOfDay();
+    $time->endOfDay();
     $time->startOfMonth();
     $time->endOfMonth();
+    $time->startOfYear();    
     $time->endOfYear();
     $time->startOfWeek();
     $time->endOfWeek();


### PR DESCRIPTION
Added $time->endOfDay(), $time->startOfYear() method calls to documentation.