### PR TITLE
Note on overriding plugins views in vendor

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -480,6 +480,14 @@ Contacts controller you could make the following file::
 Creating this file would allow you to override
 **plugins/ContactManager/src/Template/Contacts/index.ctp**.
 
+If your plugin is in a composer dependency (ie: 'TheVendor/ThePlugin'), the path to
+the 'index' view of the Custom controller will be
+
+    src/Template/Plugin/TheVendor/ThePlugin/Custom/index.ctp
+
+Creating this file would allow you to override
+**vendor/thevendor/theplugin/src/Template/Custom/index.ctp**.
+
 .. _plugin-assets:
 
 

--- a/fr/plugins.rst
+++ b/fr/plugins.rst
@@ -492,10 +492,10 @@ votre app en utilisant des chemins spéciaux. Si vous avez un plugin appelé
 'ContactManager', vous pouvez redéfinir les fichiers de template du plugin avec
 une logique de vue de l'application plus spécifique, en créant des fichiers en
 utilisant le template suivant
-**src/Template/plugins/[Plugin]/[Controller]/[view].ctp**. Pour le controller
+**src/Template/Plugin/[Plugin]/[Controller]/[view].ctp**. Pour le controller
 Contacts, vous pouvez faire le fichier suivant::
 
-    src/Template/plugins/src/ContactManager/Contacts/index.ctp
+    src/Template/Plugin/ContactManager/Contacts/index.ctp
 
 Créer ce fichier vous permettra de redéfinir
 **plugins/ContactManager/src/Template/Contacts/index.ctp**.

--- a/fr/plugins.rst
+++ b/fr/plugins.rst
@@ -500,6 +500,14 @@ Contacts, vous pouvez faire le fichier suivant::
 Créer ce fichier vous permettra de redéfinir
 **plugins/ContactManager/src/Template/Contacts/index.ctp**.
 
+Si votre plugin est dans une dépendence de Composer (ex: 'LeVendor/LePlugin), le
+chemin vers la vue 'index' du controlleur Custom sera
+
+    src/Template/Plugin/LeVendor/LePlugin/Custom/index.ctp
+
+Créer ce fichier vous permettra de redéfinir
+**vendor/levendor/leplugin/src/Template/Custom/index.ctp**.
+
 .. _plugin-assets:
 
 


### PR DESCRIPTION
Plugins in vendor are prefixed with the vendor name, and we should have this name in the path to override it.
(I spent an hour figuring why `src/Template/Plugin/Users/Users/<view>.ctp` wasn't working for plugin CakeDC/Users)