### PR TITLE
Rebuild the left nav menus to use captions

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -9,12 +9,17 @@ Contents
 
 .. toctree::
     :maxdepth: 3
+    :caption: Preface
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Getting Started
 
     installation
     development/configuration
@@ -24,6 +29,10 @@ Contents
     controllers
     views
     orm
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Using CakePHP
 
     controllers/components/authentication
     bake
@@ -45,6 +54,10 @@ Contents
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: Utility Classes
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -57,12 +70,21 @@ Contents
     core-libraries/time
     core-libraries/xml
 
-    core-libraries/global-constants-and-functions
+.. toctree::
+    :maxdepth: 3
+    :caption: Plugins
+
     chronos
     debug-kit
     migrations
     elasticsearch
     upgrade-tool
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Other
+
+    core-libraries/global-constants-and-functions
     appendices
 
 .. todolist::

--- a/es/contents.rst
+++ b/es/contents.rst
@@ -9,12 +9,17 @@ Contenidos
 
 .. toctree::
     :maxdepth: 3
+    :caption: Preface
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Getting Started
 
     installation
     development/configuration
@@ -24,6 +29,10 @@ Contenidos
     controllers
     views
     orm
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Using CakePHP
 
     controllers/components/authentication
     bake
@@ -45,6 +54,10 @@ Contenidos
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: Utility Classes
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -57,12 +70,21 @@ Contenidos
     core-libraries/time
     core-libraries/xml
 
-    core-libraries/global-constants-and-functions
+.. toctree::
+    :maxdepth: 3
+    :caption: Plugins
+
     chronos
     debug-kit
     migrations
     elasticsearch
     upgrade-tool
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Other
+
+    core-libraries/global-constants-and-functions
     appendices
 
 .. todolist::

--- a/fr/contents.rst
+++ b/fr/contents.rst
@@ -9,12 +9,17 @@ Contenu
 
 .. toctree::
     :maxdepth: 3
+    :caption: Préface
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Pour Commencer
 
     installation
     development/configuration
@@ -24,6 +29,11 @@ Contenu
     controllers
     views
     orm
+
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Généralités
 
     controllers/components/authentication
     bake
@@ -45,6 +55,10 @@ Contenu
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: Utilitaires
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -56,6 +70,11 @@ Contenu
     core-libraries/text
     core-libraries/time
     core-libraries/xml
+
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Divers
 
     core-libraries/global-constants-and-functions
     chronos

--- a/ja/contents.rst
+++ b/ja/contents.rst
@@ -9,12 +9,17 @@
 
 .. toctree::
     :maxdepth: 3
+    :caption: はじめに
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: 入門
 
     installation
     development/configuration
@@ -24,6 +29,10 @@
     controllers
     views
     orm
+
+.. toctree::
+    :maxdepth: 3
+    :caption: 一般的なトピック
 
     controllers/components/authentication
     bake
@@ -45,6 +54,10 @@
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: ユーティリティ
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -57,12 +70,21 @@
     core-libraries/time
     core-libraries/xml
 
-    core-libraries/global-constants-and-functions
+.. toctree::
+    :maxdepth: 3
+    :caption: プラグイン
+
     chronos
     debug-kit
     migrations
     elasticsearch
     upgrade-tool
+
+.. toctree::
+    :maxdepth: 3
+    :caption: その他
+
+    core-libraries/global-constants-and-functions
     appendices
 
 .. todolist::

--- a/pt/contents.rst
+++ b/pt/contents.rst
@@ -9,12 +9,17 @@ Conteúdo
 
 .. toctree::
     :maxdepth: 3
+    :caption: Prefácio
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Começando
 
     installation
     development/configuration
@@ -24,6 +29,10 @@ Conteúdo
     controllers
     views
     orm
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Using CakePHP
 
     controllers/components/authentication
     bake
@@ -45,6 +54,10 @@ Conteúdo
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: Classes utilitárias
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -57,12 +70,21 @@ Conteúdo
     core-libraries/time
     core-libraries/xml
 
-    core-libraries/global-constants-and-functions
+.. toctree::
+    :maxdepth: 3
+    :caption: Plugins
+
     chronos
     debug-kit
     migrations
     elasticsearch
     upgrade-tool
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Diversos
+
+    core-libraries/global-constants-and-functions
     appendices
 
 .. todolist::

--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -202,15 +202,6 @@
 }
 
 
-#sidebar-navigation > ul > li:lang(fr):nth-of-type(1):before {
-    content: "Préface";
-}
-#sidebar-navigation > ul > li:lang(es):nth-of-type(1):before {
-    content: "Preface";
-}
-#sidebar-navigation > ul > li:lang(pt):nth-of-type(1):before {
-    content: "Prefácio";
-}
 #sidebar-navigation > ul > li:lang(ja):nth-of-type(1):before {
     content: "はじめに";
 }
@@ -221,15 +212,6 @@
     content: "Preface";
 }
 
-#sidebar-navigation > ul > li:lang(fr):nth-of-type(6):before {
-    content: "Pour Commencer";
-}
-#sidebar-navigation > ul > li:lang(es):nth-of-type(6):before {
-    content: "Getting Started";
-}
-#sidebar-navigation > ul > li:lang(pt):nth-of-type(6):before {
-    content: "Começando";
-}
 #sidebar-navigation > ul > li:lang(ja):nth-of-type(6):before {
     content: "入門";
 }
@@ -240,15 +222,6 @@
     content: "Getting Started";
 }
 
-#sidebar-navigation > ul > li:lang(fr):nth-of-type(14):before {
-    content: "Généralités";
-}
-#sidebar-navigation > ul > li:lang(es):nth-of-type(14):before {
-    content: "General Topics";
-}
-#sidebar-navigation > ul > li:lang(pt):nth-of-type(14):before {
-    content: "Tópicos Gerais";
-}
 #sidebar-navigation > ul > li:lang(ja):nth-of-type(14):before {
     content: "一般的なトピック";
 }
@@ -259,15 +232,6 @@
     content: "General Topics";
 }
 
-#sidebar-navigation > ul > li:lang(fr):nth-of-type(33):before {
-    content: "Utilitaires";
-}
-#sidebar-navigation > ul > li:lang(es):nth-of-type(33):before {
-    content: "Utility Classes";
-}
-#sidebar-navigation > ul > li:lang(pt):nth-of-type(33):before {
-    content: "Classes utilitárias";
-}
 #sidebar-navigation > ul > li:lang(ja):nth-of-type(33):before {
     content: "ユーティリティ";
 }
@@ -278,15 +242,6 @@
     content: "Utility Classes";
 }
 
-#sidebar-navigation > ul > li:lang(fr):nth-of-type(44):before {
-    content: "Divers";
-}
-#sidebar-navigation > ul > li:lang(es):nth-of-type(44):before {
-    content: "Other";
-}
-#sidebar-navigation > ul > li:lang(pt):nth-of-type(44):before {
-    content: "Diversos";
-}
 #sidebar-navigation > ul > li:lang(ja):nth-of-type(44):before {
     content: "その他";
 }

--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -184,28 +184,24 @@
 
 #sidebar-navigation > ul {
     padding-left: 0;
+    margin: 0;
 }
-#sidebar-navigation > ul > li:before {
+#sidebar-navigation .caption {
     color: #363637;
     font-family: 'Raleway', sans-serif;
     display: block;
     font-weight: bold;
     font-size: 13px;
+    line-height: 1;
     padding-bottom: 0.4em;
     padding-top: 1.3em;
+    margin: 0;
 }
-#sidebar-navigation > ul > li:nth-of-type(5):last-child:after,
-#sidebar-navigation > ul > li:nth-of-type(14):last-child:after,
-#sidebar-navigation > ul > li:nth-of-type(33):last-child:after,
-#sidebar-navigation > ul > li:nth-of-type(44):last-child:after {
-    content: " ";
-    display: block;
-    margin-bottom: 1em;
-}
-#sidebar-navigation > ul > li:nth-of-type(1):before {
-    content: "Preface";
+#sidebar-navigation .caption:first-child {
     padding-top: 0;
 }
+
+
 #sidebar-navigation > ul > li:lang(fr):nth-of-type(1):before {
     content: "Préface";
 }
@@ -224,9 +220,7 @@
 #sidebar-navigation > ul > li:lang(tr):nth-of-type(1):before {
     content: "Preface";
 }
-#sidebar-navigation > ul > li:nth-of-type(6):before {
-    content: "Getting Started";
-}
+
 #sidebar-navigation > ul > li:lang(fr):nth-of-type(6):before {
     content: "Pour Commencer";
 }
@@ -245,9 +239,7 @@
 #sidebar-navigation > ul > li:lang(tr):nth-of-type(6):before {
     content: "Getting Started";
 }
-#sidebar-navigation > ul > li:nth-of-type(14):before {
-    content: "General Topics";
-}
+
 #sidebar-navigation > ul > li:lang(fr):nth-of-type(14):before {
     content: "Généralités";
 }
@@ -266,9 +258,7 @@
 #sidebar-navigation > ul > li:lang(tr):nth-of-type(14):before {
     content: "General Topics";
 }
-#sidebar-navigation > ul > li:nth-of-type(33):before {
-    content: "Utility Classes";
-}
+
 #sidebar-navigation > ul > li:lang(fr):nth-of-type(33):before {
     content: "Utilitaires";
 }
@@ -287,9 +277,7 @@
 #sidebar-navigation > ul > li:lang(tr):nth-of-type(33):before {
     content: "Utility Classes";
 }
-#sidebar-navigation > ul > li:nth-of-type(44):before {
-    content: "Other";
-}
+
 #sidebar-navigation > ul > li:lang(fr):nth-of-type(44):before {
     content: "Divers";
 }

--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -202,58 +202,6 @@
 }
 
 
-#sidebar-navigation > ul > li:lang(ja):nth-of-type(1):before {
-    content: "はじめに";
-}
-#sidebar-navigation > ul > li:lang(zh):nth-of-type(1):before {
-    content: "Preface";
-}
-#sidebar-navigation > ul > li:lang(tr):nth-of-type(1):before {
-    content: "Preface";
-}
-
-#sidebar-navigation > ul > li:lang(ja):nth-of-type(6):before {
-    content: "入門";
-}
-#sidebar-navigation > ul > li:lang(zh):nth-of-type(6):before {
-    content: "Getting Started";
-}
-#sidebar-navigation > ul > li:lang(tr):nth-of-type(6):before {
-    content: "Getting Started";
-}
-
-#sidebar-navigation > ul > li:lang(ja):nth-of-type(14):before {
-    content: "一般的なトピック";
-}
-#sidebar-navigation > ul > li:lang(zh):nth-of-type(14):before {
-    content: "General Topics";
-}
-#sidebar-navigation > ul > li:lang(tr):nth-of-type(14):before {
-    content: "General Topics";
-}
-
-#sidebar-navigation > ul > li:lang(ja):nth-of-type(33):before {
-    content: "ユーティリティ";
-}
-#sidebar-navigation > ul > li:lang(zh):nth-of-type(33):before {
-    content: "Utility Classes";
-}
-#sidebar-navigation > ul > li:lang(tr):nth-of-type(33):before {
-    content: "Utility Classes";
-}
-
-#sidebar-navigation > ul > li:lang(ja):nth-of-type(44):before {
-    content: "その他";
-}
-#sidebar-navigation > ul > li:lang(zh):nth-of-type(44):before {
-    content: "Other";
-}
-#sidebar-navigation > ul > li:lang(tr):nth-of-type(44):before {
-    content: "Other";
-}
-
-
-
 /* def list */
 dl.docutils {
     margin: 2em 0;

--- a/tr/contents.rst
+++ b/tr/contents.rst
@@ -9,12 +9,17 @@
 
 .. toctree::
     :maxdepth: 3
+    :caption: Preface
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Getting Started
 
     installation
     development/configuration
@@ -24,6 +29,10 @@
     controllers
     views
     orm
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Using CakePHP
 
     controllers/components/authentication
     bake
@@ -45,6 +54,10 @@
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: Utility Classes
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -57,12 +70,21 @@
     core-libraries/time
     core-libraries/xml
 
-    core-libraries/global-constants-and-functions
+.. toctree::
+    :maxdepth: 3
+    :caption: Plugins
+
     chronos
     debug-kit
     migrations
     elasticsearch
     upgrade-tool
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Other
+
+    core-libraries/global-constants-and-functions
     appendices
 
 .. todolist::

--- a/zh/contents.rst
+++ b/zh/contents.rst
@@ -9,12 +9,17 @@ Contents
 
 .. toctree::
     :maxdepth: 3
+    :caption: Preface
 
     intro
     quickstart
     appendices/3-x-migration-guide
     tutorials-and-examples
     contributing
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Getting Started
 
     installation
     development/configuration
@@ -24,6 +29,10 @@ Contents
     controllers
     views
     orm
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Using CakePHP
 
     controllers/components/authentication
     bake
@@ -45,6 +54,10 @@ Contents
     development/testing
     core-libraries/validation
 
+.. toctree::
+    :maxdepth: 3
+    :caption: Utility Classes
+
     core-libraries/app
     core-libraries/collections
     core-libraries/file-folder
@@ -57,12 +70,21 @@ Contents
     core-libraries/time
     core-libraries/xml
 
-    core-libraries/global-constants-and-functions
+.. toctree::
+    :maxdepth: 3
+    :caption: Plugins
+
     chronos
     debug-kit
     migrations
     elasticsearch
     upgrade-tool
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Other
+
+    core-libraries/global-constants-and-functions
     appendices
 
 .. todolist::


### PR DESCRIPTION
Remove the CSS hacks we've been relying on thus far to make menu sections. By using the `:caption:` feature we can keep sections with their menus.

I've also made a few small adjustments to the sectioning. Splitting out the core plugins from reference material (appendices and global functions) felt like a good choice.