### PR TITLE
Remove links to jenkins

### DIFF
--- a/en/contributing/documentation.rst
+++ b/en/contributing/documentation.rst
@@ -10,8 +10,7 @@ GitHub's online editor for that page.
 
 CakePHP documentation is
 `continuously integrated <http://en.wikipedia.org/wiki/Continuous_integration>`_,
-so you can check the status of the `various builds <http://ci.cakephp.org>`_
-on the Jenkins server at any time.
+and deployed after each pull request is merged.
 
 Translations
 ============


### PR DESCRIPTION
I don't think there is much value in exposing our jenkins server to the world so I'm removing it from here.

Refs #4555