### PR TITLE
Add edge version warnings to 3.next

### DIFF
--- a/config/all.py
+++ b/config/all.py
@@ -39,10 +39,10 @@ copyright = u'%d, Cake Software Foundation, Inc' % datetime.datetime.now().year
 # built documents.
 #
 # The short X.Y version.
-version = '3.x'
+version = '3.next'
 
 # The full version, including alpha/beta/rc tags.
-release = '3.x'
+release = '3.next'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -38,6 +38,22 @@ job('Book - Deploy 3.x') {
   }
 }
 
+job('Book - Deploy 3.next') {
+  description('Deploy the 3.next book when changes are pushed.')
+  scm {
+    github(REPO_NAME, '3.next')
+  }
+  triggers {
+    scm('H/5 * * * *')
+  }
+  logRotator {
+    daysToKeep(30)
+  }
+  steps {
+    shell(BUILD_STEPS.replaceAll('VERSION', '3next'))
+  }
+}
+
 job('Book - Deploy 2.x') {
   description('Deploy the 2.x book when changes are pushed.')
   scm {

--- a/themes/cakephp/layout.html
+++ b/themes/cakephp/layout.html
@@ -150,7 +150,7 @@
 							<h2>
 								<a href="{{ pathto(master_doc) }}">
 									<span class="glyph_range icon-submenu icon-submenu-cook">B</span>
-									CakePHP 3.3 Red Velvet <strong>Cookbook</strong>
+									CakePHP {{ version }} Red Velvet <strong>Cookbook</strong>
 								</a>
 							</h2>
 						</div>
@@ -231,6 +231,14 @@
 					</div>
 				</div>
 			</div>
+			{% if 'next' in version %}
+				<p class="edge-warning">
+					This document is for CakePHP's development version, which can be significantly different 
+					from previous releases.
+					<br>You may want to read
+					<a href="http://book.cakephp.org">current stable release doumentation</a> instead.
+				</p>
+			{% endif %}
 		</section>
 	</header>
 
@@ -266,7 +274,7 @@
 {% endblock -%}
 
 {%- block content %}
-<div class="container page-container">
+<div class="container page-container {% if 'next' in version %}is-next{% endif %}">
 
 	{%- if pagename != 'search' -%}
 	<div id="improve-slideout">

--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -45,6 +45,9 @@
     padding-top: 160px;
     padding-bottom: 40px;
 }
+.is-next.page-container {
+    padding-top: 200px;
+}
 
 /* General button */
 .offline-download a,
@@ -774,4 +777,13 @@ dt tt {
 }
 .genindextable a {
     font-size: 14px;
+}
+
+.edge-warning {
+    font-size: 1em;
+    line-height: 1.5em;
+    text-align: center;
+    background-color: #ffe4e4;
+    padding: 0.4em;
+    margin: 0;
 }


### PR DESCRIPTION
My thinking is that we can use the `3.next` branch in the docs as a longer-lived branch that contains docs for the 'next' version of 3.x.

I'd like to deploy these changes to `http://book.cakephp.org/3.next/en`. This will make it easier to host and link to docs for beta/rc versions that contain dramatic changes from the current 3.x release.

When we merge `3.next` into `3.0` we'll need to update `config/all.py` but as its a 1 line change I don't see this as being a big hurdle.

## What it looks like

![screen shot 2016-12-29 at 22 31 42](https://cloud.githubusercontent.com/assets/24086/21559244/c14a9c6c-ce16-11e6-8d85-44594406da65.png)

### Things to decide

* I've left 3.next out of the menu. I'm not confident this is the best option, but I didn't want people 'accidentally' getting to docs for unreleased versions.
* I'm not confident I have the wording of the warning right, any help is welcome.