### PR TITLE
[fr] 3.next sync

### DIFF
--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -105,9 +105,6 @@ Other Deprecations
 * ``Router::parse()`` is deprecated. ``Router::parseRequest()`` should be used
   instead as it accepts a request and gives more control/flexibility in handling
   incoming requests.
-* ``Route::parse()`` is deprecated. ``Route::parseRequest()`` should be used
-  instead as it accepts a request and gives more control/flexibility in handling
-  incoming requests.
 
 Deprecated Combined Get/Set Methods
 -----------------------------------

--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -153,8 +153,8 @@ The following is a list of methods that are deprecated and replaced with
     * ``config()``
     * setter part of ``canBeJoined()`` (now ``setCanBeJoined()``)
 ``Cake\ORM\EagerLoader``
-    * ``matching()`` (``getMatching()`` will have to be call after ``setMatching()`` to
-      keep the old behavior)
+    * ``matching()`` (``getMatching()`` will have to be called after ``setMatching()``
+      to keep the old behavior)
     * ``autoFields()`` (now ``enableAutoFields()``/``isAutoFieldsEnabled()``)
 ``Cake\ORM\Locator\TableLocator``
     * ``config()``
@@ -316,7 +316,6 @@ Event
 * ``Event::setData()`` was added.
 * ``Event::result()`` was added.
 * ``Event::setResult()`` was added.
-
 
 I18n
 ====

--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -105,6 +105,9 @@ Other Deprecations
 * ``Router::parse()`` is deprecated. ``Router::parseRequest()`` should be used
   instead as it accepts a request and gives more control/flexibility in handling
   incoming requests.
+* ``Route::parse()`` is deprecated. ``Route::parseRequest()`` should be used
+  instead as it accepts a request and gives more control/flexibility in handling
+  incoming requests.
 
 Deprecated Combined Get/Set Methods
 -----------------------------------

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -110,7 +110,7 @@ Autres dépréciations
   les autres parties de l'ORM.
 * ``Router::parse()`` est dépréciée. ``Router::parseRequest()`` est maintenant
   la méthode recommandée car elle accepte une request en argument et donne plus
-  de contrôles et de flexibilité dans la manipulation des requêtes entrantes.
+  de contrôle et de flexibilité dans la manipulation des requêtes entrantes.
 
 Dépréciation des getters / setters combinés
 -------------------------------------------
@@ -348,7 +348,7 @@ Routing
 HtmlHelper
 ==========
 
-* ``HtmlHelper::scriptBlock()`` n'engloge plus le Javascript dans un tag
+* ``HtmlHelper::scriptBlock()`` n'englobe plus le Javascript dans un tag
   ``<![CDATA[ ]]`` par défaut. L'option ``safe`` qui contrôle ce comportement
   a maintenant sa valeur par défaut à ``false``. Utiliser le tag ``<![CDATA[ ]]``
   était seulement requis pour le XHTML qui n'est plus le doctype prédominant

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -160,7 +160,8 @@ Cake\ORM\EagerLoadable
     * ``config()``
     * setter part of ``canBeJoined()`` (devenue ``setCanBeJoined()``)
 Cake\ORM\EagerLoader
-    * ``matching()``
+    * ``matching()`` (``getMatching()`` devra être appelé après ``setMatching()``
+      pour conserver l'ancien comportement)
     * ``autoFields()`` (devenue ``enableAutoFields()`` / ``isAutoFieldsEnabled()``)
 Cake\ORM\Locator\TableLocator
     * ``config()``

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -108,6 +108,9 @@ Autres dépréciations
 * L'option ``fieldList`` pour ``Cake\ORM\Table::newEntity()`` et
   ``patchEntity()`` a été renommée en ``fields`` pour être plus cohérent avec
   les autres parties de l'ORM.
+* ``Router::parse()`` est dépréciée. ``Router::parseRequest()`` est maintenant
+  la méthode recommandée car elle accepte une request en argument et donne plus
+  de contrôles et de flexibilité dans la manipulation des requêtes entrantes.
 
 Dépréciation des getters / setters combinés
 -------------------------------------------
@@ -338,6 +341,8 @@ Routing
 
 * ``RouteBuilder::prefix()`` accepte maintenant un tableau de paramètres par
   défaut à ajouter à chaque route "connectée".
+* Les routes peuvent maintenant être "matché" sur des hosts spécifiques à
+  l'aide de l'option ``_host``.
 
 PaginatorHelper
 ===============

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -344,6 +344,15 @@ Routing
 * Les routes peuvent maintenant être "matché" sur des hosts spécifiques à
   l'aide de l'option ``_host``.
 
+HtmlHelper
+==========
+
+* ``HtmlHelper::scriptBlock()`` n'engloge plus le Javascript dans un tag
+  ``<![CDATA[ ]]`` par défaut. L'option ``safe`` qui contrôle ce comportement
+  a maintenant sa valeur par défaut à ``false``. Utiliser le tag ``<![CDATA[ ]]``
+  était seulement requis pour le XHTML qui n'est plus le doctype prédominant
+  pour les pages web actuellement.
+
 PaginatorHelper
 ===============
 

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -163,7 +163,7 @@ Cake\ORM\EagerLoadable
     * ``config()``
     * setter part of ``canBeJoined()`` (devenue ``setCanBeJoined()``)
 Cake\ORM\EagerLoader
-    * ``matching()`` (``getMatching()`` devra être appelé après ``setMatching()``
+    * ``matching()`` (``getMatching()`` devra être appelée après ``setMatching()``
       pour conserver l'ancien comportement)
     * ``autoFields()`` (devenue ``enableAutoFields()`` / ``isAutoFieldsEnabled()``)
 Cake\ORM\Locator\TableLocator

--- a/fr/appendices/3-4-migration-guide.rst
+++ b/fr/appendices/3-4-migration-guide.rst
@@ -111,6 +111,9 @@ Autres dépréciations
 * ``Router::parse()`` est dépréciée. ``Router::parseRequest()`` est maintenant
   la méthode recommandée car elle accepte une request en argument et donne plus
   de contrôle et de flexibilité dans la manipulation des requêtes entrantes.
+* ``Route::parse()`` est dépréciée. ``Route::parseRequest()`` est maintenant
+  la méthode recommandée car elle accepte une request en argument et donne plus
+  de contrôle et de flexibilité dans la manipulation des requêtes entrantes.
 
 Dépréciation des getters / setters combinés
 -------------------------------------------

--- a/fr/development/routing.rst
+++ b/fr/development/routing.rst
@@ -679,8 +679,8 @@ Matching de Noms de Domaine Spécifiques
 ---------------------------------------
 
 Les routes peuvent utiliser l'option ``_host`` pour "matcher" des noms de
-domaines spécifiques. Vous pouvez utiliser le passe-partout wildcard ``*.``
-pour "matcher" n'importe quelle sous-domaine::
+domaines spécifiques. Vous pouvez utiliser la wildcard ``*.`` pour "matcher"
+n'importe quelle sous-domaine::
 
     Router::scope('/', function($routes) {
         // Cette route ne va "matcher" que sur le domaine http://images.example.com

--- a/fr/development/routing.rst
+++ b/fr/development/routing.rst
@@ -657,6 +657,53 @@ et une action ``showItems()``, la route générée sera
         $routes->fallbacks(DashedRoute::class);
     });
 
+Matching des Méthodes HTTP Spécifiques
+--------------------------------------
+
+Les routes peuvent "matcher" des méthodes HTTP spécifiques en utilisant
+l'option ``_method``::
+
+    Router::scope('/', function($routes) {
+        // Cette route ne sera "matcher" que sur les requêtes POST.
+        $routes->connect(
+            '/reviews/start',
+            ['controller' => 'Reviews', 'action' => 'start', '_method' => 'POST']
+        );
+    });
+
+Vous pouvez "matcher" plusieurs méthodes HTTP en fournissant un tableau.
+Puisque que l'option ``_method`` est une clé de routage, elle est utilisée à la
+fois dans le parsing des URL et la génération des URL.
+
+Matching de Noms de Domaine Spécifiques
+---------------------------------------
+
+Les routes peuvent utiliser l'option ``_host`` pour "matcher" des noms de
+domaines spécifiques. Vous pouvez utiliser le passe-partout wildcard ``*.``
+pour "matcher" n'importe quelle sous-domaine::
+
+    Router::scope('/', function($routes) {
+        // Cette route ne va "matcher" que sur le domaine http://images.example.com
+        $routes->connect(
+            '/images/default-logo.png',
+            ['controller' => 'Images', 'action' => 'default'],
+            ['_host' => 'images.example.com']
+        );
+
+        // Cette route matchera sur tous les sous-domaines http://*.example.com
+        $routes->connect(
+            '/images/old-log.png',
+            ['controller' => 'Images', 'action' => 'oldLogo'],
+            ['_host' => '*.example.com']
+        );
+    });
+
+L'option ``_host`` n'affecte que le parsing des URL depuis les requêtes et
+n'intervient jamais dans la génération d'URL.
+
+.. versionadded:: 3.4.0
+    L'option ``_host`` a été ajoutée dans la version 3.4.0
+
 .. index:: file extensions
 .. _file-extensions:
 


### PR DESCRIPTION
I removed a duplicate item in the original version.

@cake17 @antograssiot I did not translate "match" / "matching" when translating the Router parts : I did not find a suitable word. So I "frenched it up" instead. I'm open to suggestions.

Follows #4585 & #4592.