### PR TITLE
Fix `CASE` statement examples.

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -418,12 +418,12 @@ for implementing ``if ... then ... else`` logic inside your SQL. This can be use
 for reporting on data where you need to conditionally sum or count data, or where you
 need to specific data based on a condition.
 
-If we wished to know how many published articles are in our database, we'd need to generate the following SQL::
+If we wished to know how many published articles are in our database, we could use the following SQL::
 
     SELECT
-    SUM(CASE published = 'Y' THEN 1 ELSE 0) AS number_published,
-    SUM(CASE published = 'N' THEN 1 ELSE 0) AS number_unpublished
-    FROM articles GROUP BY published
+    COUNT(CASE WHEN published = 'Y' THEN 1 END) AS number_published,
+    COUNT(CASE WHEN published = 'N' THEN 1 END) AS number_unpublished
+    FROM articles
 
 To do this with the query builder, we'd use the following code::
 
@@ -434,7 +434,7 @@ To do this with the query builder, we'd use the following code::
             1,
             'integer'
         );
-    $notPublishedCase = $query->newExpr()
+    $unpublishedCase = $query->newExpr()
         ->addCase(
             $query->newExpr()->add(['published' => 'N']),
             1,
@@ -442,10 +442,9 @@ To do this with the query builder, we'd use the following code::
         );
 
     $query->select([
-        'number_published' => $query->func()->sum($publishedCase),
-        'number_unpublished' => $query->func()->sum($unpublishedCase)
-    ])
-    ->group('published');
+        'number_published' => $query->func()->count($publishedCase),
+        'number_unpublished' => $query->func()->count($unpublishedCase)
+    ]);
 
 The ``addCase`` function can also chain together multiple statements to create
 ``if .. then .. [elseif .. then .. ] [ .. else ]`` logic inside your SQL.

--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -438,12 +438,12 @@ d'additionner ou de compter conditionnellement, ou si vous avez besoin de
 données spécifiques basées sur une condition.
 
 Si vous vouliez savoir combien d'articles sont publiés dans notre base de
-données, vous auriez besoin de générer le SQL suivant::
+données, nous pourrions utiliser le SQL suivant::
 
     SELECT
-    SUM(CASE published = 'Y' THEN 1 ELSE 0) AS number_published,
-    SUM(CASE published = 'N' THEN 1 ELSE 0) AS number_unpublished
-    FROM articles GROUP BY published
+    COUNT(CASE WHEN published = 'Y' THEN 1 END) AS number_published,
+    COUNT(CASE WHEN published = 'N' THEN 1 END) AS number_unpublished
+    FROM articles
 
 Pour faire ceci avec le générateur de requêtes, vous utiliseriez le code
 suivant::
@@ -455,7 +455,7 @@ suivant::
             1,
             'integer'
         );
-    $notPublishedCase = $query->newExpr()
+    $unpublishedCase = $query->newExpr()
         ->addCase(
             $query->newExpr()->add(['published' => 'N']),
             1,
@@ -463,10 +463,9 @@ suivant::
         );
 
     $query->select([
-        'number_published' => $query->func()->sum($publishedCase),
-        'number_unpublished' => $query->func()->sum($unpublishedCase)
-    ])
-    ->group('published');
+        'number_published' => $query->func()->count($publishedCase),
+        'number_unpublished' => $query->func()->count($unpublishedCase)
+    ]);
 
 La fonction ``addCase`` peut aussi chaîner ensemble plusieurs instructions pour
 créer une logique ``if .. then .. [elseif .. then .. ] [ .. else ]`` dans


### PR DESCRIPTION
Use an example that matches the utilization of the single
condition/value usage of the `addCase` method. Using `COUNT` will
ensure that no `NULL` value can be returned. Grouping is being removed
so that the results would be returned in a single row.

JA modifications missing (due to weird git problems).