### PR TITLE
Fixing group by problem on Bookmark tutorial for MySQL 5.7

### DIFF
--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -358,14 +358,20 @@ method has not been implemented yet, so let's do that. In
     // to find('tagged') in our controller action.
     public function findTagged(Query $query, array $options)
     {
-        return $this->find()
-            ->distinct(['Bookmarks.id'])
-            ->matching('Tags', function ($q) use ($options) {
-                if (empty($options['tags'])) {
-                    return $q->where(['Tags.title IS' => null]);
-                }
+        $bookmarks = $this->find()
+            ->select(['id', 'url', 'title', 'description']);
+
+        if (empty($options['tags'])) {
+            $bookmarks->leftJoinWith('Tags', function ($q) {
+                return $q->where(['Tags.title IS ' => null]);
+            });
+        } else {
+            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
                 return $q->where(['Tags.title IN' => $options['tags']]);
             });
+        }
+
+        return $bookmarks->group(['Bookmarks.id']);
     }
 
 We just implemented a :ref:`custom finder method <custom-find-methods>`. This is

--- a/fr/tutorials-and-examples/bookmarks/intro.rst
+++ b/fr/tutorials-and-examples/bookmarks/intro.rst
@@ -379,14 +379,20 @@ Dans **src/Model/Table/BookmarksTable.php** ajoutez ce qui suit::
     // dans l'action de notre Controller
     public function findTagged(Query $query, array $options)
     {
-        return $this->find()
-            ->distinct(['Bookmarks.id'])
-            ->matching('Tags', function ($q) use ($options) {
-                if (empty($options['tags'])) {
-                    return $q->where(['Tags.title IS' => null]);
-                }
+        $bookmarks = $this->find()
+            ->select(['id', 'url', 'title', 'description']);
+
+        if (empty($options['tags'])) {
+            $bookmarks->leftJoinWith('Tags', function ($q) {
+                return $q->where(['Tags.title IS ' => null]);
+            });
+        } else {
+            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
                 return $q->where(['Tags.title IN' => $options['tags']]);
             });
+        }
+
+        return $bookmarks->group(['Bookmarks.id']);
     }
 
 Nous intégrons juste :ref:`des finders personnalisés <custom-find-methods>`.

--- a/ja/tutorials-and-examples/bookmarks/intro.rst
+++ b/ja/tutorials-and-examples/bookmarks/intro.rst
@@ -249,7 +249,7 @@ Scaffold コードの生成
 
 今から既存のユーザのパスワードを更新してくだい。パスワードを変更した際、一覧もしくは詳細ページで、
 入力した値の代わりにハッシュ化されたパスワードがあることを確認してください。CakePHP は、
-デフォルトで `bcrypt <http://codahale.com/how-to-safely-store-a-password/>`_ 
+デフォルトで `bcrypt <http://codahale.com/how-to-safely-store-a-password/>`_
 を使ってパスワードをハッシュ化します。既存のデータベースが動作している場合、 sha1 や md5 も
 使用できます。
 
@@ -345,14 +345,20 @@ CakePHP では、コントローラのアクションをスリムに保ち、ア
     // 'tag' オプションが含まれます。
     public function findTagged(Query $query, array $options)
     {
-        return $this->find()
-            ->distinct(['Bookmarks.id'])
-            ->matching('Tags', function ($q) use ($options) {
-               if (empty($options['tags'])) {
-                   return $q->where(['Tags.title IS' => null]);
-               }
-               return $q->where(['Tags.title IN' => $options['tags']]);
+        $bookmarks = $this->find()
+            ->select(['id', 'url', 'title', 'description']);
+
+        if (empty($options['tags'])) {
+            $bookmarks->leftJoinWith('Tags', function ($q) {
+                return $q->where(['Tags.title IS ' => null]);
             });
+        } else {
+            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
+                return $q->where(['Tags.title IN' => $options['tags']]);
+            });
+        }
+
+        return $bookmarks->group(['Bookmarks.id']);
     }
 
 :ref:`カスタム Finder メソッド <custom-find-methods>` を実装しました。

--- a/pt/tutorials-and-examples/bookmarks/intro.rst
+++ b/pt/tutorials-and-examples/bookmarks/intro.rst
@@ -292,16 +292,20 @@ método ``findTagged`` não estar implementado ainda, então vamos fazer isso. E
 
     public function findTagged(Query $query, array $options)
     {
-        $fields = [
-            'Bookmarks.id',
-            'Bookmarks.title',
-            'Bookmarks.url',
-        ];
-        return $this->find()
-            ->distinct($fields)
-            ->matching('Tags', function ($q) use ($options) {
+        $bookmarks = $this->find()
+            ->select(['id', 'url', 'title', 'description']);
+
+        if (empty($options['tags'])) {
+            $bookmarks->leftJoinWith('Tags', function ($q) {
+                return $q->where(['Tags.title IS ' => null]);
+            });
+        } else {
+            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
                 return $q->where(['Tags.title IN' => $options['tags']]);
             });
+        }
+
+        return $bookmarks->group(['Bookmarks.id']);
     }
 
 Nós implementamos um método


### PR DESCRIPTION
This issue was raised #4165.

The problem instead of disabling `ONLY_FULL_GROUP_BY` is to solve the query. In the documentations files I changed the query for `findTagged()`. I can confirm that works on MySQL 5.6 and MySQL 5.7.

More information on how group by works in this blogpost: [GROUP BY, are you sure you know it?](https://blog.gabriela.io/2016/03/03/group-by-are-you-sure-you-know-it/).