### PR TITLE
Add missing single quote - CounterCache Behavior

### DIFF
--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -85,7 +85,7 @@ before::
     $this->addBehavior('CounterCache', [
         'Articles' => [
             'comment_count' => [
-                ignoreDirty' => true
+                'ignoreDirty' => true
             ]
         ]
     ]);

--- a/fr/orm/behaviors/counter-cache.rst
+++ b/fr/orm/behaviors/counter-cache.rst
@@ -88,7 +88,7 @@ champ d'être recalculé automatiquement si vous l'avez définit ``dirty`` avant
     $this->addBehavior('CounterCache', [
         'Articles' => [
             'comment_count' => [
-                ignoreDirty' => true
+                'ignoreDirty' => true
             ]
         ]
     ]);


### PR DESCRIPTION
In a previous PR #4605 I forgot to add a single quote. Just found out while browsing the cookbook.