### PR TITLE
Fix grammar

### DIFF
--- a/en/core-libraries/text.rst
+++ b/en/core-libraries/text.rst
@@ -183,7 +183,7 @@ supported options are:
 If you need to ensure that the total width of the generated block won't
 exceed a certain length even with internal identation, you need to use
 ``wrapBlock()`` instead of ``wrap()``. This is particulary useful to generate
-text for the console for example. It accepts the same options than ``wrap()``::
+text for the console for example. It accepts the same options as ``wrap()``::
 
     $text = 'This is the song that never ends. This is the song that never ends.';
     $result = Text::wrapBlock($text, [


### PR DESCRIPTION
Use "as" instead of "than"