### PR TITLE
uniform helper name to class name in helper pages 

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -829,7 +829,7 @@ Will output:
     <input type="hidden" name="done" value="0">
     <input type="checkbox" name="done" value="555">
 
-If you don't want the Form helper to create a hidden input::
+If you don't want the FormHelper to create a hidden input::
 
     echo $this->Form->checkbox('done', ['hiddenField' => false]);
 
@@ -1953,4 +1953,4 @@ ensure that the special ``_Token`` inputs are generated.
 .. meta::
     :title lang=en: FormHelper
     :description lang=en: The FormHelper focuses on creating forms quickly, in a way that will streamline validation, re-population and layout.
-    :keywords lang=en: html helper,cakephp html,form create,form input,form select,form file field,form label,form text,form password,form checkbox,form radio,form submit,form date time,form error,validate upload,unlock field,form security
+    :keywords lang=en: form helper,cakephp form,form create,form input,form select,form file field,form label,form text,form password,form checkbox,form radio,form submit,form date time,form error,validate upload,unlock field,form security

--- a/en/views/helpers/number.rst
+++ b/en/views/helpers/number.rst
@@ -21,5 +21,5 @@ formatting numbers.
 
 .. meta::
     :title lang=en: NumberHelper
-    :description lang=en: The Number Helper contains convenience methods that enable display numbers in common formats in your views.
+    :description lang=en: The NumberHelper contains convenience methods that enable display numbers in common formats in your views.
     :keywords lang=en: number helper,currency,number format,number precision,format file size,format numbers

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -5,7 +5,7 @@ Paginator
 
 .. php:class:: PaginatorHelper(View $view, array $config = [])
 
-The Paginator helper is used to output pagination controls such as page numbers
+The PaginatorHelper is used to output pagination controls such as page numbers
 and next/previous links. It works in tandem with
 :php:class:`PaginatorComponent`.
 
@@ -377,7 +377,7 @@ Configuring Pagination Options
 
 .. php:method:: options($options = [])
 
-Sets all the options for the Paginator Helper. Supported options are:
+Sets all the options for the PaginatorHelper. Supported options are:
 
 * ``url`` The URL of the paginating action. 'url' has a few sub options as well:
 
@@ -515,5 +515,5 @@ By using the ``model`` option, ``PaginatorHelper`` will automatically use the
 
 .. meta::
     :title lang=en: PaginatorHelper
-    :description lang=en: The Pagination helper is used to output pagination controls such as page numbers and next/previous links.
+    :description lang=en: The PaginatorHelper is used to output pagination controls such as page numbers and next/previous links.
     :keywords lang=en: paginator helper,pagination,sort,page number links,pagination in views,prev link,next link,last link,first link,page counter

--- a/en/views/helpers/rss.rst
+++ b/en/views/helpers/rss.rst
@@ -5,7 +5,7 @@ Rss
 
 .. php:class:: RssHelper(View $view, array $config = [])
 
-The RSS helper makes generating XML for `RSS feeds <https://en.wikipedia.org/wiki/RSS>`_ easy.
+The RssHelper makes generating XML for `RSS feeds <https://en.wikipedia.org/wiki/RSS>`_ easy.
 
 Creating an RSS Feed with the RssHelper
 =======================================
@@ -195,5 +195,5 @@ site at http://validator.w3.org/feed/.
 
 .. meta::
     :title lang=en: RssHelper
-    :description lang=en: The RSS helper makes generating XML for RSS feeds easy.
+    :description lang=en: The RssHelper makes generating XML for RSS feeds easy.
     :keywords lang=en: rss helper,rss feed,isrss,rss item,channel data,document data,parse extensions,request handler

--- a/en/views/helpers/session.rst
+++ b/en/views/helpers/session.rst
@@ -14,7 +14,7 @@ As a natural counterpart to the Session object, the Session
 Helper replicates most of the object's functionality and makes it
 available in your view.
 
-The major difference between the Session Helper and the Session
+The major difference between the SessionHelper and the Session
 object is that the helper does *not* have the ability to write
 to the session.
 
@@ -27,7 +27,7 @@ As with the session object, data is read by using
 
 Given the previous array structure, the node would be accessed by
 ``User.username``, with the dot indicating the nested array. This
-notation is used for all Session helper methods wherever a ``$key`` is
+notation is used for all SessionHelper methods wherever a ``$key`` is
 used.
 
 .. php:method:: read(string $key)
@@ -46,5 +46,5 @@ used.
 
 .. meta::
     :title lang=en: SessionHelper
-    :description lang=en: The Session Helper replicates most of the functionality and making it available in your view.
+    :description lang=en: The SessionHelper replicates most of the functionality and making it available in your view.
     :keywords lang=en: session helper,flash messages,session flash,session read,session check

--- a/en/views/helpers/text.rst
+++ b/en/views/helpers/text.rst
@@ -83,5 +83,5 @@ Output::
 
 .. meta::
     :title lang=en: TextHelper
-    :description lang=en: The Text Helper contains methods to make text more usable and friendly in your views.
+    :description lang=en: The TextHelper contains methods to make text more usable and friendly in your views.
     :keywords lang=en: text helper,autoLinkEmails,autoLinkUrls,autoLink,excerpt,highlight,stripLinks,truncate,string text

--- a/en/views/helpers/time.rst
+++ b/en/views/helpers/time.rst
@@ -5,9 +5,9 @@ Time
 
 .. php:class:: TimeHelper(View $view, array $config = [])
 
-The Time Helper does what it says on the tin: saves you time. It
+The TimeHelper does what it says on the tin: saves you time. It
 allows for the quick processing of time related information. The
-Time Helper has two main tasks that it can perform:
+TimeHelper has two main tasks that it can perform:
 
 #. It can format time strings.
 #. It can test time (but cannot bend time, sorry).
@@ -15,7 +15,7 @@ Time Helper has two main tasks that it can perform:
 Using the Helper
 ================
 
-A common use of the Time Helper is to offset the date and time to match a
+A common use of the TimeHelper is to offset the date and time to match a
 user's time zone. Lets use a forum as an example. Your forum has many users who
 may post messages at any time from any part of the world. An easy way to
 manage the time is to save all dates and times as GMT+0 or UTC. Uncomment the
@@ -25,7 +25,7 @@ your application's time zone is set to GMT+0.
 Next add a time zone field to your users table and make the necessary
 modifications to allow your users to set their time zone. Now that we know
 the time zone of the logged in user we can correct the date and time on our
-posts using the Time Helper::
+posts using the TimeHelper::
 
     echo $this->Time->format(
       $post->created,
@@ -48,5 +48,5 @@ E.g. to read about the accepted formatting strings take a look at the
 
 .. meta::
     :title lang=en: TimeHelper
-    :description lang=en: The Time Helper will help you format time and test time.
+    :description lang=en: The TimeHelper will help you format time and test time.
     :keywords lang=en: time helper,format time,timezone,unix epoch,time strings,time zone offset,utc,gmt


### PR DESCRIPTION
Many of the helper's documents helper by class name, so I unified them by class name (except meta keywords)