### PR TITLE
Fix bug in return

### DIFF
--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -229,7 +229,7 @@ their own response. We can see both options in our simple middleware::
                     'expire' => '+ 1 year',
                 ]);
             }
-            return $response;
+            return $next($request, $response);
         }
     }
 


### PR DESCRIPTION
The example doesn't work without passing both the request and response on to the next middleware.