### PR TITLE
Change method output

### DIFF
--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -75,11 +75,11 @@ An example would be::
     {
         public function _displayError($error, $debug)
         {
-            return 'There has been an error!';
+            echo 'There has been an error!';
         }
         public function _displayException($exception)
         {
-            return 'There has been an exception!';
+            echo 'There has been an exception!';
         }
     }
 


### PR DESCRIPTION
In the `BaseErrorHandler` these methods are doc block'd with `@return void`, so they should not be returning anything.