### PR TITLE
Link to correct page

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -223,7 +223,7 @@ Translating model validation errors
 ===================================
 
 CakePHP will automatically extract the validation error when you are using the
-:doc:`i18n console task </console-and-shells>`. By default, the default domain is used.
+:doc:`i18n console task </console-and-shells/i18n-shell>`. By default, the default domain is used.
 This can be overwritten by setting the ``$validationDomain`` property in your model::
 
     class User extends AppModel {


### PR DESCRIPTION
https://book.cakephp.org/2.0/en/core-libraries/internationalization-and-localization.html#translating-model-validation-errors should llink to https://book.cakephp.org/2.0/en/console-and-shells/i18n-shell.html instead of https://book.cakephp.org/2.0/en/console-and-shells.html