### PR TITLE
Change formatResults argument type hinting

### DIFF
--- a/en/appendices/orm-migration.rst
+++ b/en/appendices/orm-migration.rst
@@ -184,7 +184,7 @@ the results taken from the database is not actually required::
     // No queries made in this example!
     $results = $articles->find()
         ->order(['title' => 'DESC'])
-        ->formatResults(function ($results) {
+        ->formatResults(function (\Cake\Collection\CollectionInterface $results) {
             return $results->extract('title');
         });
 
@@ -263,7 +263,7 @@ In the 3rd case above your code would look like::
 
     public function findAll(Query $query, array $options)
     {
-        return $query->formatResults(function ($results) {
+        return $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
             return $results->map(function ($row) {
                 // Your afterfind logic
             });

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -519,7 +519,7 @@ the :ref:`Map/Reduce <map-reduce>` feature instead. If you were querying a list
 of people, you could calculate their age with a result formatter::
 
     // Assuming we have built the fields, conditions and containments.
-    $query->formatResults(function (\Cake\Datasource\ResultSetInterface $results) {
+    $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
             return $row;
@@ -540,7 +540,7 @@ expect::
 
     // In a method in the Articles table
     $query->contain(['Authors' => function ($q) {
-        return $q->formatResults(function ($authors) {
+        return $q->formatResults(function (\Cake\Collection\CollectionInterface $authors) {
             return $authors->map(function ($author) {
                 $author['age'] = $author['birth_date']->diff(new \DateTime)->y;
                 return $author;

--- a/fr/appendices/orm-migration.rst
+++ b/fr/appendices/orm-migration.rst
@@ -207,7 +207,7 @@ données qui n'est en fait pas nécessaire::
     // Pas de requêtes faites dans cet exemple!
     $results = $articles->find()
         ->order(['title' => 'DESC'])
-        ->formatResults(function ($results) {
+        ->formatResults(function (\Cake\Collection\CollectionInterface $results) {
             return $results->extract('title');
         });
 
@@ -288,7 +288,7 @@ Dans le 3ème cas ci-dessus, votre code ressemblerait à::
 
     public function findAll(Query $query, array $options)
     {
-        return $query->formatResults(function ($results) {
+        return $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
             return $results->map(function ($row) {
                 // Votre logique afterfind
             });

--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -546,7 +546,7 @@ place. Si vous faîtes une requête d'une liste de personnes, vous pourriez
 calculer leur âge avec le formateur de résultats::
 
     // En supposant que nous avons construit les champs, les conditions et les contain.
-    $query->formatResults(function (\Cake\Datasource\ResultSetInterface $results) {
+    $query->formatResults(function (\Cake\Collection\CollectionInterface  $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
             return $row;
@@ -568,7 +568,7 @@ comme vous pouvez vous y attendre::
 
     // Dans une méthode dans la table Articles
     $query->contain(['Authors' => function ($q) {
-        return $q->formatResults(function ($authors) {
+        return $q->formatResults(function (\Cake\Collection\CollectionInterface $authors) {
             return $authors->map(function ($author) {
                 $author['age'] = $author['birth_date']->diff(new \DateTime)->y;
                 return $author;

--- a/ja/appendices/orm-migration.rst
+++ b/ja/appendices/orm-migration.rst
@@ -173,7 +173,7 @@ Query オブジェクトを返すということです。これにはいくつ�
     // この例では、クエリを作成しませんでした！
     $results = $articles->find()
         ->order(['title' => 'DESC'])
-        ->formatResults(function ($results) {
+        ->formatResults(function (\Cake\Collection\CollectionInterface $results) {
             return $results->extract('title');
         });
 
@@ -249,7 +249,7 @@ find メソッドから Query オブジェクトを返すことはいくつか�
 
     public function findAll(Query $query, array $options)
     {
-        return $query->formatResults(function ($results) {
+        return $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
             return $results->map(function ($row) {
                 // あなたの afterfind ロジック
             });

--- a/ja/orm/query-builder.rst
+++ b/ja/orm/query-builder.rst
@@ -503,13 +503,13 @@ ORM とオブジェクトの結果セットは強力である一方で、エン�
 人々のリストを問い合わせる際に、formatResults を使って年齢 (age) を算出するなら次のようになります。 ::
 
     // フィールド、条件、関連が構築済であると仮定します。
-    $query->formatResults(function (\Cake\Datasource\ResultSetInterface $results) {
+    $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
             return $row;
         });
     });
-    $query->formatResults(function (\Cake\Datasource\ResultSetInterface $results) {
+    $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
             return $row;
@@ -529,7 +529,7 @@ CakePHP はフォーマッタ関数が適切なスコープになるよう保証
 
     // Articles テーブル内のメソッドで
     $query->contain(['Authors' => function ($q) {
-        return $q->formatResults(function ($authors) {
+        return $q->formatResults(function (\Cake\Collection\CollectionInterface authors) {
             return $authors->map(function ($author) {
                 $author['age'] = $author['birth_date']->diff(new \DateTime)->y;
                 return $author;


### PR DESCRIPTION
I've changed all uses of ```formatResults``` in all languages. Please, let me know if I shouldn't have changed some. All examples where assuming the argument implements CollectionInterface so I think it makes sense.

Related to cakephp/cakephp#10236.