### PR TITLE
Improve Docs Search

### DIFF
--- a/themes/cakephp/static/app.js
+++ b/themes/cakephp/static/app.js
@@ -61,6 +61,7 @@ App.InlineSearch = (function () {
         async: true,
         limit: 10,
         templates: {
+          pending: '<div class="loading-result">Searching...</div>',
           empty: '<div class="empty-result">No matches found</div>',
           suggestion: function(item) {
             var div = $('<div></div>');

--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -251,6 +251,7 @@ table.internal-toc {
 }
 
 .tt-menu .empty-result,
+.tt-menu .loading-result,
 .tt-menu .tt-suggestion {
     font-size: 12px;
     line-height: 1.4em;

--- a/themes/cakephp/static/search.js
+++ b/themes/cakephp/static/search.js
@@ -40,6 +40,8 @@ App.Search = (function () {
       query.page = page;
     }
     var url = App.config.url + '?' + jQuery.param(query);
+
+    showPendingSearch();
     var xhr = $.ajax({
       url: url,
       dataType: 'json',
@@ -63,11 +65,19 @@ App.Search = (function () {
     }
   }());
 
+  function showPendingSearch() {
+    searchResults.empty().append('<ul><li>Searching...</li></ul>');
+  }
+
   /**
    * Generate the result HTML.
    */
   function createResults(results) {
       var ul = searchResults.find('ul');
+      if (results.length === 0) {
+        ul.append('<li>No matches found</li>');
+        return;
+      }
       $.each(results, function(index, item) {
         var li = $('<li></li>');
         var link = $('<a></a>');
@@ -116,12 +126,13 @@ App.Search = (function () {
       }, 200);
     });
 
-    // Handle clickin on pagintion links
+    // Handle clickin on pagination links
     paginationContainer.delegate('a', 'click', function (event) {
       var active = $(event.target);
       var page = active.attr('page');
       event.preventDefault();
 
+      $('html,body').animate({scrollTop: 0}, 200);
       executeSearch(searchInput.val(), page);
     });
 


### PR DESCRIPTION
It is an improvement proposal of search function. Please review.

* Display "searching..." message during loading. (search bar and /search.html)
* "No matches found" is displayed when /search.html

It solves the problem that it can not be determined whether the search page is loading or 0 search results.

These behaviors work as follows:
![menu-search](https://cloud.githubusercontent.com/assets/16202/23095764/be23f70e-f652-11e6-83b8-aa9891894cdf.gif)

![menu-search-full](https://cloud.githubusercontent.com/assets/16202/23095768/c24e8ae2-f652-11e6-869a-be2c685f59db.gif)

* Scroll to the top of the page when clicking the page link.

If merged, it will also backport to other branches.