### PR TITLE
Fix Loading configuration files section

### DIFF
--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -571,7 +571,7 @@ Once you've attached a config reader to Configure you can load configuration fil
 
 Loaded configuration files merge their data with the existing runtime configuration
 in Configure. This allows you to overwrite and add new values
-into the existing runtime configuration. By setting ``$merge`` to true, values
+into the existing runtime configuration. By setting ``$merge`` to false, values
 will not ever overwrite the existing configuration.
 
 Creating or modifying configuration files


### PR DESCRIPTION
``$merge`` value is true by default, in the documentation I fixed it from true to false when a user wants to not overwrite existing configuration. When merge = true we should overwrite when merge = false we shouldn't overwrite, or am I missing a point?