### PR TITLE
[es] Fix the tutorials titles

### DIFF
--- a/es/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/es/tutorials-and-examples/blog-auth-example/auth.rst
@@ -1,5 +1,5 @@
-Tutorial de aplicación Blog - Autenticación y Autorización
-##########################################################
+Tutorial Blog - Autenticación y Autorización
+############################################
 
 Siguiendo con nuestro ejemplo de aplicacion :doc:`/tutorials-and-examples/blog/blog`, imaginá que necesitamos proteger ciertas URLs, dependiendo del usuario logeado. También tenemos otro requisito, permitir que nuestro blog tenga varios autores, cada uno habilitado para crear sus posts, editar y borrarlos a voluntad, evitando que otros autores puedan cambiarlos.
 
@@ -353,5 +353,5 @@ Lectura sugerida
 #. :doc:`/controllers/components/authentication`: Registro y login de usuarios
 
 .. meta::
-    :title lang=es: Tutorial de aplicación Blog - Autenticación y Autorización
+    :title lang=es: Tutorial Blog - Autenticación y Autorización
     :keywords lang=es: auto increment,aplicacion con autorizacion,model user,array,convenciones,autenticacion,urls,cakephp,delete,doc,columns

--- a/es/tutorials-and-examples/blog/blog.rst
+++ b/es/tutorials-and-examples/blog/blog.rst
@@ -1,5 +1,5 @@
-Tutorial de desarrollo del Blog
-###############################
+Tutorial Blog
+#############
 
 Bienvenido a CakePHP. Probablemente estás consultando este tutorial porque
 quieres aprender más sobre cómo funciona CakePHP. Nuestro objetivo es potenciar
@@ -259,3 +259,6 @@ url-rewriting
 
 Ahora continúa hacia :doc:`/tutorials-and-examples/blog/part-two` para empezar
 a construir tu primera aplicación en CakePHP.
+
+.. meta::
+    :title lang=es: Tutorial Blog

--- a/es/tutorials-and-examples/blog/part-three.rst
+++ b/es/tutorials-and-examples/blog/part-three.rst
@@ -1,5 +1,5 @@
-Tutorial de desarrollo de Blog - Parte 3
-########################################
+Tutorial Blog - Parte 3
+#######################
 
 Crear categorias en Arbol
 =========================
@@ -283,5 +283,5 @@ El template add de Article debería verse similar a esto::
 Ingresando a `/yoursite/articles/add` deberías ver una lista de categorías para elegir.
 
 .. meta::
-    :title lang=es: Tutorial de aplicación Blog - Migración y Arbol
+    :title lang=es: Tutorial Blog - Parte 3
     :keywords lang=en: doc models,migracion,arbol,controller actions,model article,php class,model class,model object,business logic,database table,naming convention,bread and butter,callbacks,prefixes,nutshell,interaction,array,cakephp,interface,applications,delete

--- a/es/tutorials-and-examples/blog/part-two.rst
+++ b/es/tutorials-and-examples/blog/part-two.rst
@@ -1,5 +1,5 @@
-Tutorial de desarrollo del Blog - Añadiendo una capa
-####################################################
+Tutorial Blog - Parte 2
+#######################
 
 .. note::
     The documentation is currently partially supported in es language for this
@@ -651,3 +651,6 @@ aprender después:
 2. :ref:`view-elements` Incluír vistas y reutilizar trozos de código
 3. :doc:`/bake/usage`: Generación básica de CRUDs
 4. :doc:`/tutorials-and-examples/blog-auth-example/auth`: Tutorial de autenticación y permisos
+
+.. meta::
+    :title lang=es: Tutorial Blog - Parte 2

--- a/es/tutorials-and-examples/bookmarks/intro.rst
+++ b/es/tutorials-and-examples/bookmarks/intro.rst
@@ -1,5 +1,5 @@
-Tutorial - Bookmarker (Favoritos)
-##################################
+Tutorial Bookmarker (Favoritos)
+###############################
 
 Este tutorial te guiará en la creación de una aplicación sencilla para el guardado de favoritos (Bookmaker).
 
@@ -387,3 +387,6 @@ Ahora deberías poder visitar la URL **/bookmarks/tagged/funny** y ver todos los
 Hasta aquí hemos creado una aplicación básica para manejar favoritos (bookmarks), etiquetas (tags) y usuarios (users). Sin embargo todo el mundo puede ver las etiquetas de los demás. En el siguiente capítulo implementaremos autenticación y restringiremos el uso de etiquetas únicamente a aquellas que pertenezcan al usuario actual.
 
 Ahora ve a :doc:`/tutorials-and-examples/bookmarks/part-two` para continuar construyendo tu apliación o :doc:`sumérgete en la documentación </topics>` para aprender más sobre que puede hacer CakePHP por ti.
+
+.. meta::
+    :title lang=es: Tutorial Bookmarker (Favoritos)

--- a/es/tutorials-and-examples/bookmarks/part-two.rst
+++ b/es/tutorials-and-examples/bookmarks/part-two.rst
@@ -1,5 +1,5 @@
-Tutorial - Bookmarker (Favoritos) - Parte 2
-###########################################
+Tutorial Bookmarker (Favoritos) - Parte 2
+#########################################
 
 Tras realizar :doc:`la primera parte de este tutorial </tutorials-and-examples/bookmarks/intro>` 
 deberías tener una aplicación muy básica para guardar favoritos.
@@ -453,3 +453,6 @@ sacándole provecho a *FormHelper* y al potencial de *ORM*.
 Gracias por tomarte tu tiempo para explorar CakePHP. Ahora puedes realizar 
 el tutorial :doc:`/tutorials-and-examples/blog/blog`, aprender más sobre :doc:`/orm`, 
 o puedes leer detenidamente los :doc:`/topics`.
+
+.. meta::
+    :title lang=es: Tutorial Bookmarker (Favoritos) - Parte 2


### PR DESCRIPTION
I propose this change in the titles of the tutorials in the spanish
translation to follow the same name structure of the english version

And add the meta title in some pages that didn't have it