### PR TITLE
Prefix and suffix are backwards

### DIFF
--- a/en/core-utility-libraries/string.rst
+++ b/en/core-utility-libraries/string.rst
@@ -156,7 +156,7 @@ use the ``CakeText`` class::
     :param array $options: An array of options to use.
 
     If ``$text`` is longer than ``$length`` characters, this method truncates it
-    at ``$length`` and adds a prefix consisting of ``'ellipsis'``, if defined.
+    at ``$length`` and adds a suffix consisting of ``'ellipsis'``, if defined.
     If ``'exact'`` is passed as ``false``, the truncation will occur at the
     first whitespace after the point at which ``$length`` is exceeded. If
     ``'html'`` is passed as ``true``, HTML tags will be respected and will not
@@ -209,7 +209,7 @@ use the ``CakeText`` class::
     :param array $options: An array of options to use.
 
     If ``$text`` is longer than ``$length`` characters, this method removes an initial
-    substring with length consisting of the difference and prepends a suffix
+    substring with length consisting of the difference and prepends a prefix
     consisting of ``'ellipsis'``, if defined. If ``'exact'`` is passed as
     ``false``, the truncation will occur at the first whitespace prior to the
     point at which truncation would otherwise take place.


### PR DESCRIPTION
For some reason prefix and suffixed are used backwards while explaining truncate and tail 