### PR TITLE
Remove unused component in the example

### DIFF
--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -132,8 +132,7 @@ Using Components
 Once you've included some components in your controller, using them is pretty
 simple. Each component you use is exposed as a property on your controller. If
 you had loaded up the :php:class:`Cake\\Controller\\Component\\FlashComponent`
-and the :php:class:`Cake\\Controller\\Component\\CookieComponent` in your
-controller, you could access them like so::
+in your controller, you could access it like so::
 
     class PostsController extends AppController
     {
@@ -141,7 +140,6 @@ controller, you could access them like so::
         {
             parent::initialize();
             $this->loadComponent('Flash');
-            $this->loadComponent('Cookie');
         }
 
         public function delete()


### PR DESCRIPTION
While reading the documentation i stumbled upon this example on how to use components and it confused me a little since the cookie component is mentioned and initialized but never used. So I figured we should either change the example to use the cookie component or just remove it. Since I could not think of a use case (in this context) for the cookie component I removed it.