### PR TITLE
Make build run faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ before_install:
 
 script:
     - docker run -it --rm -v $(pwd):/data cakephpfr/docs:light make html SPHINXOPTS='-W'
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make pdf
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub SPHINXOPTS='-W'
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex SPHINXOPTS='-W'
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
 
 script:
     - docker run -it --rm -v $(pwd):/data cakephpfr/docs:light make html SPHINXOPTS='-W'
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub SPHINXOPTS='-W'
-    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex SPHINXOPTS='-W'
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make epub
+    - docker run -it --rm -v $(pwd):/data cakephpfr/docs make latex
 
 notifications:
     email: false


### PR DESCRIPTION
By not building the PDFs we shouldn't run into as many build failures on pull requests. This does mean that we might have some surprise failures when building the docs, but I'd rather not have many false negatives in pull requests.