### PR TITLE
Link to the API document is always the latest version. (2.x)

### DIFF
--- a/en/cakephp-overview/where-to-get-help.rst
+++ b/en/cakephp-overview/where-to-get-help.rst
@@ -33,7 +33,7 @@ gain instant fame and fortune.
 The API
 =======
 
-`https://api.cakephp.org/ <https://api.cakephp.org/>`_
+`https://api.cakephp.org/2.x/ <https://api.cakephp.org/2.x/>`_
 
 Straight to the point and straight from the core developers, the CakePHP API
 (Application Programming Interface) is the most comprehensive documentation

--- a/en/console-and-shells/upgrade-shell.rst
+++ b/en/console-and-shells/upgrade-shell.rst
@@ -24,7 +24,7 @@ available run the command::
 
     ./Console/cake upgrade --help
 
-Or visit the `API docs <https://api.cakephp.org/2.8/class-UpgradeShell.html>`_ for more info.
+Or visit the `API docs <https://api.cakephp.org/2.x/class-UpgradeShell.html>`_ for more info.
 
 Upgrade Your App
 ----------------

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -197,7 +197,7 @@ Controller Methods
 ==================
 
 For a complete list of controller methods and their descriptions
-visit the `CakePHP API <https://api.cakephp.org/2.8/class-Controller.html>`_.
+visit the `CakePHP API <https://api.cakephp.org/2.x/class-Controller.html>`_.
 
 Interacting with Views
 ----------------------
@@ -678,7 +678,7 @@ Controller Attributes
 =====================
 
 For a complete list of controller attributes and their descriptions
-visit the `CakePHP API <https://api.cakephp.org/2.8/class-Controller.html>`_.
+visit the `CakePHP API <https://api.cakephp.org/2.x/class-Controller.html>`_.
 
 .. php:attr:: name
 

--- a/en/core-libraries/helpers/form.rst
+++ b/en/core-libraries/helpers/form.rst
@@ -280,7 +280,7 @@ Closing the Form
         <div class="glass-pill"><input type="submit" value="Update" name="Update">
         </div>
 
-    See the `Form Helper API <https://api.cakephp.org/2.8/class-FormHelper.html>`_ for further details.
+    See the `Form Helper API <https://api.cakephp.org/2.x/class-FormHelper.html>`_ for further details.
 
     .. note::
 

--- a/en/core-libraries/helpers/html.rst
+++ b/en/core-libraries/helpers/html.rst
@@ -1005,7 +1005,7 @@ methods of the HtmlHelper and how to use them.
         /posts/search?foo=bar#first
 
     For further information check
-    `Router::url <https://api.cakephp.org/2.8/class-Router.html#_url>`_
+    `Router::url <https://api.cakephp.org/2.x/class-Router.html#_url>`_
     in the API.
 
 .. php:method:: useTag(string $tag)

--- a/en/core-libraries/helpers/paginator.rst
+++ b/en/core-libraries/helpers/paginator.rst
@@ -442,7 +442,7 @@ assume a tabular layout, but the PaginatorHelper available in views
 doesn't always need to be restricted as such.
 
 See the details on
-`PaginatorHelper <https://api.cakephp.org/2.8/class-PaginatorHelper.html>`_
+`PaginatorHelper <https://api.cakephp.org/2.x/class-PaginatorHelper.html>`_
 in the API. As mentioned, the PaginatorHelper also offers sorting features
 which can be easily integrated into your table column headers:
 

--- a/en/core-utility-libraries/security.rst
+++ b/en/core-utility-libraries/security.rst
@@ -3,7 +3,7 @@ Security
 
 .. php:class:: Security
 
-The `security library <https://api.cakephp.org/2.8/class-Security.html>`_
+The `security library <https://api.cakephp.org/2.x/class-Security.html>`_
 handles basic security measures such as providing methods for
 hashing and encrypting data.
 

--- a/en/models/model-attributes.rst
+++ b/en/models/model-attributes.rst
@@ -5,7 +5,7 @@ Model attributes allow you to set properties that can override the
 default model behavior.
 
 For a complete list of model attributes and their descriptions
-visit the `CakePHP API <https://api.cakephp.org/2.8/class-Model.html>`_.
+visit the `CakePHP API <https://api.cakephp.org/2.x/class-Model.html>`_.
 
 useDbConfig
 ===========

--- a/es/cakephp-overview/where-to-get-help.rst
+++ b/es/cakephp-overview/where-to-get-help.rst
@@ -33,7 +33,7 @@ estudio de usuarios del framework.
 El API
 ======
 
-`https://api.cakephp.org/2.8/ <https://api.cakephp.org/2.8/>`_
+`https://api.cakephp.org/2.x/ <https://api.cakephp.org/2.x/>`_
 
 Directo al grano y directamente de los desarrolladores principales, el
 API (Application Programming Interface) de CakePHP  es el más

--- a/es/tutorials-and-examples/blog/part-two.rst
+++ b/es/tutorials-and-examples/blog/part-two.rst
@@ -628,7 +628,7 @@ beneficios que hemos mencionado un poco más arriba)
 
 
 Ahora ya estás preparado para la acción. Empieza tu propio proyecto, lee el
-resto del manual y el API `Manual </>`_ `API <https://api.cakephp.org/2.8/>`_.
+resto del manual y el API `Manual </>`_ `API <https://api.cakephp.org/2.x/>`_.
 
 Lectura sugerida para continuar desde aquí
 ==========================================

--- a/fr/cakephp-overview/where-to-get-help.rst
+++ b/fr/cakephp-overview/where-to-get-help.rst
@@ -37,7 +37,7 @@ gloire et la fortune.
 L'API
 =====
 
-`https://api.cakephp.org/ <https://api.cakephp.org/>`_
+`https://api.cakephp.org/2.x/ <https://api.cakephp.org/2.x/>`_
 
 Allez droit au but et atteignez le graal des développeurs, l'API CakePHP
 (Application Programming Interface) est la documentation la plus complète sur

--- a/fr/console-and-shells/upgrade-shell.rst
+++ b/fr/console-and-shells/upgrade-shell.rst
@@ -25,7 +25,7 @@ toutes les étapes possibles, lancez la commande::
     ./Console/cake upgrade --help
 
 Ou allez voir les
-`docs de l'API <https://api.cakephp.org/2.4/class-UpgradeShell.html>`_
+`docs de l'API <https://api.cakephp.org/2.x/class-UpgradeShell.html>`_
 pour plus d'informations:
 
 Mise à jour de votre App

--- a/fr/controllers.rst
+++ b/fr/controllers.rst
@@ -211,7 +211,7 @@ Les Méthodes du Controller
 
 Pour une liste complète des méthodes de controller avec leurs descriptions,
 consultez
-`l'API de CakePHP <https://api.cakephp.org/2.4/class-Controller.html>`_.
+`l'API de CakePHP <https://api.cakephp.org/2.x/class-Controller.html>`_.
 
 Interactions avec les vues
 --------------------------
@@ -714,7 +714,7 @@ Les attributs du Controller
 ===========================
 
 Pour une liste complète des attributs du controller et ses descriptions,
-regardez `l'API de CakePHP <https://api.cakephp.org/2.4/class-Controller.html>`_.
+regardez `l'API de CakePHP <https://api.cakephp.org/2.x/class-Controller.html>`_.
 
 .. php:attr:: name
 

--- a/fr/core-libraries/helpers/form.rst
+++ b/fr/core-libraries/helpers/form.rst
@@ -292,7 +292,7 @@ Fermer le Formulaire
         <div class="glass-pill"><input type="submit" value="Update!" name="Update"></div>
 
     Voir `l'API du Helper Form
-    <https://api.cakephp.org/2.4/class-FormHelper.html>`_ pour plus de détails.
+    <https://api.cakephp.org/2.x/class-FormHelper.html>`_ pour plus de détails.
 
     .. note::
 

--- a/fr/core-libraries/helpers/html.rst
+++ b/fr/core-libraries/helpers/html.rst
@@ -985,7 +985,7 @@ couvrira les méthodes du Helper Html et comment les utiliser.
         /posts/search?foo=bar#first
 
     Pour plus d'information voir
-    `Router::url <https://api.cakephp.org/2.4/class-Router.html#_url>`_
+    `Router::url <https://api.cakephp.org/2.x/class-Router.html#_url>`_
     dans l' API.
 
 .. php:method:: useTag(string $tag)

--- a/fr/core-libraries/helpers/paginator.rst
+++ b/fr/core-libraries/helpers/paginator.rst
@@ -468,7 +468,7 @@ tabulaire, mais le Helper Paginator disponible dans les vues
 N'a pas toujours besoin d'être limité en tant que tel.
 
 Voir les détails sur
-`PaginatorHelper <https://api.cakephp.org/2.4/class-PaginatorHelper.html>`_
+`PaginatorHelper <https://api.cakephp.org/2.x/class-PaginatorHelper.html>`_
 dans l' API. Comme mentionné précédemment, le Helper Paginator
 offre également des fonctionnalités de tri qui peuvent être facilement
 intégrés dans vos en-têtes de colonne de table:

--- a/fr/core-utility-libraries/security.rst
+++ b/fr/core-utility-libraries/security.rst
@@ -3,7 +3,7 @@ Security
 
 .. php:class:: Security
 
-La `librairie security <https://api.cakephp.org/2.4/class-Security.html>`_
+La `librairie security <https://api.cakephp.org/2.x/class-Security.html>`_
 gère les mesures basiques de sécurité comme fournir des méthodes pour
 créer des hashs et chiffrer les données.
 

--- a/fr/models/model-attributes.rst
+++ b/fr/models/model-attributes.rst
@@ -5,7 +5,7 @@ Les attributs de Model vous permettent de configurer les propriétés qui
 peuvent surcharger le behavior du model par défaut.
 
 Pour une liste complète d'attributs du model et ses descriptions, allez voir
-`l'API de CakePHP <https://api.cakephp.org/2.4/class-Model.html>`_.
+`l'API de CakePHP <https://api.cakephp.org/2.x/class-Model.html>`_.
 
 useDbConfig
 ===========

--- a/ja/cakephp-overview/where-to-get-help.rst
+++ b/ja/cakephp-overview/where-to-get-help.rst
@@ -34,7 +34,7 @@ CakePHP に関する理解が深まったらログインして知識をコミュ
 API
 ===
 
-`https://api.cakephp.org/ <https://api.cakephp.org/>`_
+`https://api.cakephp.org/2.x/ <https://api.cakephp.org/2.x/>`_
 
 直接的な答えがコア開発者から直接得られるので、
 CakePHP API (*Application Programming Interface*) は、

--- a/ja/console-and-shells/upgrade-shell.rst
+++ b/ja/console-and-shells/upgrade-shell.rst
@@ -22,7 +22,7 @@ upgrade シェルは、 CakePHP アプリケーションを 1.3 から 2.0 へ�
 
     ./Console/cake upgrade --help
 
-詳しくは `API ドキュメント <https://api.cakephp.org/2.6/class-UpgradeShell.html>`_
+詳しくは `API ドキュメント <https://api.cakephp.org/2.x/class-UpgradeShell.html>`_
 を参照してください。
 
 アプリのアップグレード

--- a/ja/controllers.rst
+++ b/ja/controllers.rst
@@ -185,7 +185,7 @@ CakePHP のコントローラは、リクエストのライフサイクル周り
 ======================
 
 コントローラのメソッドとその説明については、
-`CakePHP API <https://api.cakephp.org/2.6/class-Controller.html>`_ を確認してください。
+`CakePHP API <https://api.cakephp.org/2.x/class-Controller.html>`_ を確認してください。
 
 ビューとの関係
 --------------
@@ -641,7 +641,7 @@ CakePHP は再度ビューを描画することはありません。 ::
 ================
 
 コントローラの変数とその説明については、
-`CakePHP API <https://api.cakephp.org/2.6/class-Controller.html>`_ を確認してください。
+`CakePHP API <https://api.cakephp.org/2.x/class-Controller.html>`_ を確認してください。
 
 .. php:attr:: name
 

--- a/ja/core-libraries/helpers/form.rst
+++ b/ja/core-libraries/helpers/form.rst
@@ -277,7 +277,7 @@ create() には多くのオプションがあります:
         </div>
 
     詳細は
-    `Form Helper API <https://api.cakephp.org/2.8/class-FormHelper.html>`_
+    `Form Helper API <https://api.cakephp.org/2.x/class-FormHelper.html>`_
     を参照してください。
 
     .. note::

--- a/ja/core-libraries/helpers/html.rst
+++ b/ja/core-libraries/helpers/html.rst
@@ -992,7 +992,7 @@ CPU のサイクルを減らすために、ビューをキャッシュするこ�
         /posts/search?foo=bar#first
 
     より詳しい情報は、API 集の
-    `Router::url <https://api.cakephp.org/2.8/class-Router.html#_url>`_
+    `Router::url <https://api.cakephp.org/2.x/class-Router.html#_url>`_
     を確認してください。
 
 .. php:method:: useTag(string $tag)

--- a/ja/core-libraries/helpers/paginator.rst
+++ b/ja/core-libraries/helpers/paginator.rst
@@ -442,7 +442,7 @@ PaginatorHelper を設定して JavaScript ヘルパーを使う
 機能を制限されているわけではありません。
 
 詳細は API の中の
-`PaginatorHelper <https://api.cakephp.org/2.8/class-PaginatorHelper.html>`_
+`PaginatorHelper <https://api.cakephp.org/2.x/class-PaginatorHelper.html>`_
 を参照してください。なお前述のように PaginatorHelper ではソート機能を提供
 してますので、これをテーブルの見出しの中に簡単に組み込めるようになっています。
 

--- a/ja/core-utility-libraries/security.rst
+++ b/ja/core-utility-libraries/security.rst
@@ -3,7 +3,7 @@ Security
 
 .. php:class:: Security
 
-`Security ライブラリ <https://api.cakephp.org/2.8/class-Security.html>`_ は、
+`Security ライブラリ <https://api.cakephp.org/2.x/class-Security.html>`_ は、
 データのハッシュ化や暗号化などのメソッドなどの基本的なセキュリティ分野を取り扱います。
 
 .. warning::

--- a/ja/models/model-attributes.rst
+++ b/ja/models/model-attributes.rst
@@ -5,7 +5,7 @@
 設定することができます。
 
 モデルの属性の完全なリストと説明については、
-`CakePHP API <https://api.cakephp.org/2.8/class-Model.html>`_ をご覧ください。
+`CakePHP API <https://api.cakephp.org/2.x/class-Model.html>`_ をご覧ください。
 
 useDbConfig
 ===========

--- a/pt/cakephp-overview/where-to-get-help.rst
+++ b/pt/cakephp-overview/where-to-get-help.rst
@@ -35,7 +35,7 @@ conhecimentos com a comunidade e ganhe fama e fortuna.
 A API
 =====
 
-`https://api.cakephp.org/2.8/ <https://api.cakephp.org/2.8/>`_
+`https://api.cakephp.org/2.x/ <https://api.cakephp.org/2.x/>`_
 
 Direto ao ponto e diretamente dos desenvolvedores do núcleo, a API
 (`Application Programming Interface`) do CakePHP é a mais completa documentação

--- a/pt/controllers.rst
+++ b/pt/controllers.rst
@@ -156,7 +156,7 @@ Métodos dos Controllers
 
 Para uma lista completa dos métodos e suas descrições, visite a API do CakePHP.
 Siga para `https://api.cakephp.org
-<https://api.cakephp.org/2.8/class-Controller.html>`__.
+<https://api.cakephp.org/2.x/class-Controller.html>`__.
 
 Interagindo Com as Views
 ------------------------
@@ -599,8 +599,8 @@ Atributos do Controller
 =======================
 
 Para uma completa lista dos atributos dos controllers e suas descrições, visite
-a API do CakePHP. Siga para `https://api.cakephp.org/2.8/class-Controller.html
-<https://api.cakephp.org/2.8/class-Controller.html>`_.
+a API do CakePHP. Siga para `https://api.cakephp.org/2.x/class-Controller.html
+<https://api.cakephp.org/2.x/class-Controller.html>`_.
 
 .. php:attr:: name
 

--- a/pt/tutorials-and-examples/blog/part-two.rst
+++ b/pt/tutorials-and-examples/blog/part-two.rst
@@ -615,7 +615,7 @@ mais aplicações ricas em recursos.
 
 Agora que você criou uma aplicação básica com o Cake, você está pronto para a
 coisa real. Comece seu próprio projeto, leia o restante do `Manual </>`_ e da
-`API <https://api.cakephp.org/2.8/>`_.
+`API <https://api.cakephp.org/2.x/>`_.
 
 E se você precisar de ajuda, nos vemos no canal #cakephp (e no #cakephp-pt).
 Seja bem-vindo ao CakePHP!

--- a/zh/cakephp-overview/where-to-get-help.rst
+++ b/zh/cakephp-overview/where-to-get-help.rst
@@ -29,7 +29,7 @@ CakePHP Bakery 是一个信息交换中心，可以了解有关 CakePHP 的一�
 应用程序编程接口 (*API*)
 ========================
 
-`https://api.cakephp.org/ <https://api.cakephp.org/>`_
+`https://api.cakephp.org/2.x/ <https://api.cakephp.org/2.x/>`_
 
 开门见山，并且直接来自核心开发人员，CakePHP 的 API(应用程序编程接口)是最全面的文
 档，囊括框架内部运作的所有细节。参考代码直截了当，所以你一定要努力跟上才行。

--- a/zh/controllers.rst
+++ b/zh/controllers.rst
@@ -164,7 +164,7 @@ CakePHP 控制器带有回调方法，用来在请求生命周期的各个阶段
 ==========
 
 欲知控制器方法的完整列表及其描述，请参看 
-`CakePHP API <https://api.cakephp.org/2.8/class-Controller.html>`_ 。
+`CakePHP API <https://api.cakephp.org/2.x/class-Controller.html>`_ 。
 
 与视图交互
 ----------
@@ -600,7 +600,7 @@ CakePHP 就不会试图再次渲染该视图了::
 ==========
 
 欲知控制器属性的完整列表及其描述，请参看 
-`CakePHP API <https://api.cakephp.org/2.8/class-Controller.html>`_ 。
+`CakePHP API <https://api.cakephp.org/2.x/class-Controller.html>`_ 。
 
 .. php:attr:: name
 

--- a/zh/core-libraries/helpers/html.rst
+++ b/zh/core-libraries/helpers/html.rst
@@ -956,7 +956,7 @@ HtmlHelper助件的一些方法及如何使用它们。
         /posts/search?foo=bar#first
 
     欲知详情，请查看API中的
-    `Router::url <https://api.cakephp.org/2.8/class-Router.html#_url>`_。
+    `Router::url <https://api.cakephp.org/2.x/class-Router.html#_url>`_。
 
 .. php:method:: useTag(string $tag)
 

--- a/zh/models/model-attributes.rst
+++ b/zh/models/model-attributes.rst
@@ -4,7 +4,7 @@
 模型属性让你可以改变默认的模型行为。
 
 欲知完整的模型属性列表及描述请，请访问
-`CakePHP API <https://api.cakephp.org/2.8/class-Model.html>`_。
+`CakePHP API <https://api.cakephp.org/2.x/class-Model.html>`_。
 
 useDbConfig
 ===========


### PR DESCRIPTION
Update links to API document page. (Same as #4814 )