### PR TITLE
Fix default sortBy order that is descending not ascending

### DIFF
--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -624,7 +624,7 @@ different values in the collection::
 In order to specify in which direction the collection should be sorted, you need
 to provide either ``SORT_ASC`` or ``SORT_DESC`` as the second parameter for
 sorting in ascending or descending direction respectively. By default,
-collections are sorted in ascending direction::
+collections are sorted in descending direction::
 
     $collection = new Collection($people);
     $sorted = $collection->sortBy('age', SORT_ASC);


### PR DESCRIPTION
sortBy method default order is actually descending, not ascending.

Actually, It may be better to change the default order to ascending, as I see it more natural and also more standard (as SQL works, for example), but if we do that we make break lots of applications that use the default order in the current way.