### PR TITLE
Don't show creation of validators on the fly

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -202,7 +202,6 @@ model fields, depending on a country, ie::
     {
         public function validationDefault(Validator $validator)
         {
-            $validator = new Validator();
             // add the provider to the validator
             $validator->provider('fr', 'Localized\Validation\FrValidation');
             // use the provider in a field validation rule

--- a/fr/core-libraries/validation.rst
+++ b/fr/core-libraries/validation.rst
@@ -215,7 +215,6 @@ pays, par exemple::
     {
         public function validationDefault(Validator $validator)
         {
-            $validator = new Validator();
             // Ajoute le provider au validator
             $validator->provider('fr', 'Localized\Validation\FrValidation');
             // utilise le provider dans une règle de validation de champ

--- a/ja/core-libraries/validation.rst
+++ b/ja/core-libraries/validation.rst
@@ -199,7 +199,6 @@ CakePHP のバリデーションは、任意の配列データに対するバリ
     {
         public function validationDefault(Validator $validator)
         {
-            $validator = new Validator();
             // バリデータにプロバイダーを追加
             $validator->provider('fr', 'Localized\Validation\FrValidation');
             // フィールドのバリデーションルールの中にプロバイダーを利用


### PR DESCRIPTION
Validator is already provided as an argument to the function.

The docs mention that you can combine validators. In that case it seems like these lines can break the chain.