### PR TITLE
Add documentation for {*}

### DIFF
--- a/en/core-utility-libraries/hash.rst
+++ b/en/core-utility-libraries/hash.rst
@@ -37,6 +37,8 @@ Expression Types
 |                                | string value including numeric string      |
 |                                | values.                                    |
 +--------------------------------+--------------------------------------------+
+| ``{*}``                        | Represents any value regardless of type.   |
++--------------------------------+--------------------------------------------+
 | ``Foo``                        | Matches keys with the exact same value.    |
 +--------------------------------+--------------------------------------------+
 


### PR DESCRIPTION
{*} is found in the docstring of ``Hash::extract()`` but not in the docs.

```php
/**
 * Gets the values from an array matching the $path expression.
 * The path expression is a dot separated expression, that can contain a set
 * of patterns and expressions:
 *
 * - `{n}` Matches any numeric key, or integer.
 * - `{s}` Matches any string key.
 * - `{*}` Matches any value.
 * - `Foo` Matches any key with the exact same value.
 * ...
 */
	public static function extract(array $data, $path) {
                ...
        }
```