### PR TITLE
Fix copy-paste example for resource route URL inflection

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -939,7 +939,7 @@ You can specify an alternative inflection type using the ``inflect`` option::
     Router::scope('/', function ($routes) {
         $routes->resources('BlogPosts', [
             'inflect' => 'dasherize' // Will use ``Inflector::dasherize()``
-        ];
+        ]);
     });
 
 The above will generate URLs styled like: **/blog-posts/\***.


### PR DESCRIPTION
Missing `)`