### PR TITLE
Improve url rewrite by nginx

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -448,22 +448,32 @@ nginx does not make use of .htaccess files like Apache, so it is necessary to
 create those rewritten URLs in the site-available configuration. This is usually
 found in ``/etc/nginx/sites-available/your_virtual_host_conf_file``. Depending
 on your setup, you will have to modify this, but at the very least, you will
-need PHP running as a FastCGI instance:
+need PHP running as a FastCGI instance.
+The following configuration redirects the request to ``webroot/index.php``:
+
+.. code-block:: nginx
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+A sample of the server directive is as follows:
 
 .. code-block:: nginx
 
     server {
         listen   80;
+        listen   [::]:80;
         server_name www.example.com;
-        rewrite ^(.*) http://example.com$1 permanent;
+        return 301 http://example.com$request_uri;
     }
 
     server {
         listen   80;
+        listen   [::]:80;
         server_name example.com;
 
-        # root directive should be global
-        root   /var/www/example.com/public/webroot/;
+        root   /var/www/example.com/public/webroot;
         index  index.php;
 
         access_log /var/www/example.com/log/access.log;
@@ -475,47 +485,17 @@ need PHP running as a FastCGI instance:
 
         location ~ \.php$ {
             try_files $uri =404;
-            include /etc/nginx/fastcgi_params;
-            fastcgi_pass    127.0.0.1:9000;
-            fastcgi_index   index.php;
+            include fastcgi_params;
+
+            fastcgi_pass 127.0.0.1:9000;
+            # When using PHP-FPM, configure it as follows instead
+            # fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
+
+            fastcgi_index index.php;
+            fastcgi_intercept_errors on;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }
-
-On some servers (Like Ubuntu 14.04) the above configuration won't work out of
-the box, and the nginx docs recommend a different approach anyway
-(http://nginx.org/en/docs/http/converting_rewrite_rules.html). You might try the
-following (you'll notice this is also just one server {} block, rather than two,
-although if you want example.com to resolve to your CakePHP application in
-addition to www.example.com consult the nginx link above):
-
-.. code-block:: nginx
-
-    server {
-        listen   80;
-        server_name www.example.com;
-        rewrite 301 http://www.example.com$request_uri permanent;
-
-        # root directive should be global
-        root   /var/www/example.com/public/webroot/;
-        index  index.php;
-
-        access_log /var/www/example.com/log/access.log;
-        error_log /var/www/example.com/log/error.log;
-
-        location / {
-            try_files $uri /index.php?$args;
-        }
-
-        location ~ \.php$ {
-            try_files $uri =404;
-            include /etc/nginx/fastcgi_params;
-            fastcgi_pass    127.0.0.1:9000;
-            fastcgi_index   index.php;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-    }
-
 
 IIS7 (Windows hosts)
 --------------------

--- a/en/installation.rst
+++ b/en/installation.rst
@@ -486,16 +486,15 @@ A sample of the server directive is as follows:
         location ~ \.php$ {
             try_files $uri =404;
             include fastcgi_params;
-
             fastcgi_pass 127.0.0.1:9000;
-            # When using PHP-FPM, configure it as follows instead
-            # fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
-
             fastcgi_index index.php;
             fastcgi_intercept_errors on;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }
+
+.. note::
+    Recent configuration of PHP-FPM is set to listen to php-fpm socket instead of TCP port 9000 on address 127.0.0.1. If you get 502 bad gateway error from above configuration, try replacing fastcgi_pass from TCP port to socket path (eg: fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;).
 
 IIS7 (Windows hosts)
 --------------------


### PR DESCRIPTION
I made the Url rewrite setting of nginx simple.

The following trouble was reported on Slack Japanese channel. (Reported by @shinderuman )

> [Installation](https://book.cakephp.org/3.0/en/installation.html#nginx)
> ```
> rewrite 301 http://www.example.com$request_uri permanent;
> ```
> In this setting, redirects if '301' is included in the URL such as 'http: //my.domain/foo/edit/10301'

But trying to fix it will cause a redirect all.
Initially, in this alternate configuration, the server directive is put together into one, but in the [linked nginx document](http://nginx.org/en/docs/http/converting_rewrite_rules.html), it is said that it is the right way to divide by domain.

I want to improve as follows

* Lose alternative configuration and make it universal config.
* Specify configurations directly related to URL rewrite, and exemplify the entire server directive as a supplement.

I tested it in the following environments:

* Ubuntu 14.04 LTS, nginx 1.4(repos: ubuntu update), PHP7.1(repos: ppa:ondrej/php)
* Ubuntu 16.04 LTS, nginx 1.10(repos: ubuntu update), PHP7.0(repos: ubuntu update)
* CentOS 6.8, nginx 1.12(repos: nginx official), PHP7.1 or 5.6(repos: remi)
* CentOS 7.3, nginx 1.12(repos: nginx official), PHP7.1 or 5.6(repos: remi)

In case of Ubuntu, Needs to change `fastcgi_pass` to socket path so I copied the note from the [CakePHP2 Book](https://book.cakephp.org/2.0/en/installation/url-rewriting.html#pretty-urls-on-nginx). Other than that, it works with the same configuration.