### PR TITLE
Fix findTagged "no tags" query in bookmarks tutorial.

### DIFF
--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -362,13 +362,13 @@ method has not been implemented yet, so let's do that. In
             ->select(['id', 'url', 'title', 'description']);
 
         if (empty($options['tags'])) {
-            $bookmarks->leftJoinWith('Tags', function ($q) {
-                return $q->where(['Tags.title IS ' => null]);
-            });
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
         } else {
-            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
         }
 
         return $bookmarks->group(['Bookmarks.id']);

--- a/es/tutorials-and-examples/bookmarks/intro.rst
+++ b/es/tutorials-and-examples/bookmarks/intro.rst
@@ -325,13 +325,13 @@ En **src/Model/Table/BookmarksTable.php** añade lo siguiente::
             ->select(['id', 'url', 'title', 'description']);
 
         if (empty($options['tags'])) {
-            $bookmarks->leftJoinWith('Tags', function ($q) {
-                return $q->where(['Tags.title IS ' => null]);
-            });
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
         } else {
-            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
         }
 
         return $bookmarks->group(['Bookmarks.id']);

--- a/fr/tutorials-and-examples/bookmarks/intro.rst
+++ b/fr/tutorials-and-examples/bookmarks/intro.rst
@@ -383,13 +383,13 @@ Dans **src/Model/Table/BookmarksTable.php** ajoutez ce qui suit::
             ->select(['id', 'url', 'title', 'description']);
 
         if (empty($options['tags'])) {
-            $bookmarks->leftJoinWith('Tags', function ($q) {
-                return $q->where(['Tags.title IS ' => null]);
-            });
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
         } else {
-            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
         }
 
         return $bookmarks->group(['Bookmarks.id']);

--- a/ja/tutorials-and-examples/bookmarks/intro.rst
+++ b/ja/tutorials-and-examples/bookmarks/intro.rst
@@ -349,13 +349,13 @@ CakePHP では、コントローラのアクションをスリムに保ち、ア
             ->select(['id', 'url', 'title', 'description']);
 
         if (empty($options['tags'])) {
-            $bookmarks->leftJoinWith('Tags', function ($q) {
-                return $q->where(['Tags.title IS ' => null]);
-            });
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
         } else {
-            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
         }
 
         return $bookmarks->group(['Bookmarks.id']);

--- a/pt/tutorials-and-examples/bookmarks/intro.rst
+++ b/pt/tutorials-and-examples/bookmarks/intro.rst
@@ -296,13 +296,13 @@ método ``findTagged`` não estar implementado ainda, então vamos fazer isso. E
             ->select(['id', 'url', 'title', 'description']);
 
         if (empty($options['tags'])) {
-            $bookmarks->leftJoinWith('Tags', function ($q) {
-                return $q->where(['Tags.title IS ' => null]);
-            });
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
         } else {
-            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
         }
 
         return $bookmarks->group(['Bookmarks.id']);

--- a/ru/tutorials-and-examples/bookmarks/intro.rst
+++ b/ru/tutorials-and-examples/bookmarks/intro.rst
@@ -364,13 +364,13 @@ CakePHP мы разделяем методы, оперирующие с колл
             ->select(['id', 'url', 'title', 'description']);
 
         if (empty($options['tags'])) {
-            $bookmarks->leftJoinWith('Tags', function ($q) {
-                return $q->where(['Tags.title IS ' => null]);
-            });
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
         } else {
-            $bookmarks->innerJoinWith('Tags', function ($q) use ($options) {
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
         }
 
         return $bookmarks->group(['Bookmarks.id']);

--- a/tr/tutorials-and-examples/bookmarks/intro.rst
+++ b/tr/tutorials-and-examples/bookmarks/intro.rst
@@ -349,14 +349,20 @@ de şunları ekleyiniz::
     // 'tags' seçeneğini içerir.
     public function findTagged(Query $query, array $options)
     {
-        return $this->find()
-            ->distinct(['Bookmarks.id'])
-            ->matching('Tags', function ($q) use ($options) {
-                if (empty($options['tags'])) {
-                    return $q->where(['Tags.title IS' => null]);
-                }
-                return $q->where(['Tags.title IN' => $options['tags']]);
-            });
+        $bookmarks = $this->find()
+            ->select(['id', 'url', 'title', 'description']);
+
+        if (empty($options['tags'])) {
+            $bookmarks
+                ->leftJoinWith('Tags')
+                ->where(['Tags.title IS' => null]);
+        } else {
+            $bookmarks
+                ->innerJoinWith('Tags')
+                ->where(['Tags.title IN ' => $options['tags']]);
+        }
+
+        return $bookmarks->group(['Bookmarks.id']);
     }
 
 Biz :ref:`özel bulucu metodu <custom-find-methods>` geliştirdik. Bu CakePHP nin


### PR DESCRIPTION
- There is a bug in the exising findTagged function.  When calling the
  function without any tags specified all bookmarks are returned, rather
  than the bookmarks that have no associated tags.
- The alternative query (tags specified) was also adjusted to use a
  similar approach - specifying the conditional after the join, rather
  than in it, IMHO making the logic a little clearer.