### PR TITLE
Fix description of findTagged function in bookmarks tutorial.

### DIFF
--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -379,12 +379,11 @@ a very powerful concept in CakePHP that allows you to package up re-usable
 queries. Finder methods always get a :doc:`/orm/query-builder` object and an
 array of options as parameters. Finders can manipulate the query and add any
 required conditions or criteria. When complete, finder methods must return
-a modified query object. In our finder we've leveraged the ``distinct()`` and
-``matching()`` methods which allow us to find distinct bookmarks that have
-a 'matching' tag. The ``matching()`` method accepts an `anonymous function
-<http://php.net/manual/en/functions.anonymous.php>`_ that receives a query
-builder as its argument. Inside the callback we use the query builder to define
-conditions that will filter bookmarks that have specific tags.
+a modified query object. In our finder we've leveraged the ``innerJoinWith()``,
+``where()`` and ``group()`` methods which allow us to find distinct bookmarks
+that have a matching tag.  When no tags are provided we use a
+``leftJoinWith()`` and modify the 'where' condition, finding bookmarks without
+tags.
 
 Creating the View
 -----------------

--- a/fr/tutorials-and-examples/bookmarks/intro.rst
+++ b/fr/tutorials-and-examples/bookmarks/intro.rst
@@ -401,13 +401,11 @@ réutilisable de vos requêtes. Les finders attendent toujours un objet
 :doc:`/orm/query-builder` et un tableau d'options en paramètre. Les finders
 peuvent manipuler les requêtes et ajouter n'importe quels conditions ou
 critères. Une fois qu'ils ont terminé, les finders doivent retourner l'objet
-Query modifié. Dans notre finder nous avons amené la méthode ``matching()`` qui
-nous permet de trouver les bookmarks qui ont un tag qui 'match'. La méthode
-``matching()`` accepte `une fonction anonyme
-<http://php.net/manual/fr/functions.anonymous.php>`_ qui reçoit un constructeur
-de requête comme argument. Dans le callback, nous utilisons le constructeur de
-requête pour définir de nouvelles conditions qui permettront de filtrer les
-bookmarks ayant les tags spécfiques.
+Query modifié. Dans notre finder nous avons amené les méthodes
+``innerJoinWith()``, ``where()`` et ``group()`` qui nous permet de trouver les
+bookmarks distinct qui ont un tag correspondante.  Lorsque aucune tag n'est
+fournie, nous utilisons un ``leftJoinWith()`` et modifions la condition
+'where', en trouvant des bookmarks sans tags.
 
 Créer la Vue
 ------------


### PR DESCRIPTION
- The function has been changed several times without adjusting
  the descriptive paragraph.
- Fixed now in English and French.

A follow up to the recent fixes to the findTagged function in PR https://github.com/cakephp/docs/pull/4920.