### PR TITLE
Enable anchor of submenu(When the width is narrow).

### DIFF
--- a/themes/cakephp/static/app.js
+++ b/themes/cakephp/static/app.js
@@ -132,14 +132,14 @@ App.ResponsiveMenus = (function () {
       modal.find('.modal-title-cookbook').text(title);
 
       // Bind click events for sub menus.
-      modal.find('li').on('click', function() {
-        var el = $(this),
-          menu = el.find('.submenu, .megamenu');
+      modal.find('li > a').on('click', function() {
+        var el = $(this).parent(),
+          subMenu = el.find('.submenu, .megamenu');
         // No menu, bail
-        if (menu.length == 0) {
+        if (subMenu.length === 0) {
           return;
         }
-        menu.toggle();
+        subMenu.toggle();
         return false;
       });
     });


### PR DESCRIPTION
It is a PR to fix bug in Cookbook site.

If the width of the browser is narrow, the following links will not work.
Similar bugs exist in other branches and bakery, api site too, so if you merge it will also request that.

<img width="640" alt="bug" src="https://cloud.githubusercontent.com/assets/16202/25557740/5ff70cca-2d52-11e7-833e-b284ac6e7839.png">
