### PR TITLE
update _initializeSchema() example

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -431,12 +431,12 @@ CakePHP's database layer will automatically convert our JSON data when creating
 queries. You can use the custom types you've created by mapping the types in
 your Table's :ref:`_initializeSchema() method <saving-complex-types>`::
 
-    use Cake\Database\Schema\Table as Schema;
+    use Cake\Database\Schema\TableSchema;
 
     class WidgetsTable extends Table
     {
 
-        protected function _initializeSchema(Schema $schema)
+        protected function _initializeSchema(TableSchema $schema)
         {
             $schema->columnType('widget_prefs', 'json');
             return $schema;

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -1074,12 +1074,12 @@ column Types::
     Type::map('json', 'App\Database\Type\JsonType');
 
     // In src/Model/Table/UsersTable.php
-    use Cake\Database\Schema\Table as Schema;
+    use Cake\Database\Schema\TableSchema;
 
     class UsersTable extends Table
     {
 
-        protected function _initializeSchema(Schema $schema)
+        protected function _initializeSchema(TableSchema $schema)
         {
             $schema->columnType('preferences', 'json');
             return $schema;


### PR DESCRIPTION
update _initializeSchema() example to not use deprecated class name