### PR TITLE
Add warning about staticExcepts() not being present in PHPUnit anymore 

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1028,6 +1028,11 @@ following::
 By using ``staticExpects`` you will be able to mock and manipulate static
 methods on components and models.
 
+.. warning::
+    If you are using PHPUnit 4 or 5, ``staticExpects()`` does not exist anymore.
+    Instead, you should insert the necessary data into the session with
+    ``CakeSession::write('Auth.User', $user)`` before calling the action.
+
 Testing a JSON Responding Controller
 ------------------------------------
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -16,15 +16,26 @@ for making sure your code does what you think it does.
 
 Install via Composer
 --------------------
-The newer versions of PHPUnit do not currently work with cake::
 
-    "phpunit/phpunit": "3.7.38"
+For a long time, CakePHP 2.x supported PHPunit 3.7.x only.
+To install PHPUnit as a development dependency through Composer, execute the
+following in the same directory as your composer.json::
+
+    php composer.phar require --dev phpunit/phpunit:"3.7.38"
+
+As of CakePHP 2.10.0, basic support for PHPUnit 4.x and 5.x was added.
+To upgrade PHPUnit and its dependencies for your application, execute the following:
+
+    php composer.phar require --dev phpunit/phpunit:"4.* || 5.*" --update-with-dependencies
+
+This will install either PHPUnit 4.x or 5.x, depending on your system setup and your
+composer.json configuration.
 
 Install via .phar Package
 -------------------------
 
-You can also download the file directly. Just make sure you get the correct version from https://phar.phpunit.de/.
-Make sure /usr/local/bin is in your php.ini file's include_path::
+You can also download the file directly. Just make sure you get the correct version
+from https://phar.phpunit.de/. Make sure /usr/local/bin is in your php.ini file's include_path::
 
     wget https://phar.phpunit.de/phpunit-3.7.38.phar -O phpunit.phar
     chmod +x phpunit.phar

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -24,7 +24,7 @@ following in the same directory as your composer.json::
     php composer.phar require --dev phpunit/phpunit:"3.7.38"
 
 As of CakePHP 2.10.0, basic support for PHPUnit 4.x and 5.x was added.
-To upgrade PHPUnit and its dependencies for your application, execute the following:
+To upgrade PHPUnit and its dependencies for your application, execute the following::
 
     php composer.phar require --dev phpunit/phpunit:"4.* || 5.*" --update-with-dependencies
 


### PR DESCRIPTION
Refers: https://github.com/cakephp/cakephp/issues/10518#issuecomment-294317455

Opted for a warning instead of just a note, as it would break tests in newer PHPUnit versions, if one misses this bit.