### PR TITLE
[en] fix the class name and the namespace.

### DIFF
--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -139,7 +139,7 @@ once a controller action has completed, CakePHP will handle rendering and
 delivering the View.
 
 If for some reason you'd like to skip the default behavior, you can return a
-:php:class:`Cake\\Network\\Response` object from the action with the fully
+:php:class:`Cake\\Http\\Response` object from the action with the fully
 created response.
 
 In order for you to use a controller effectively in your own application, we'll

--- a/en/controllers/components/csrf.rst
+++ b/en/controllers/components/csrf.rst
@@ -18,7 +18,7 @@ component will throw a
 .. note::
     You should always verify the HTTP method being used before executing
     side-effects. You should :ref:`check the HTTP method <check-the-request>` or
-    use :php:meth:`Cake\\Network\\Request::allowMethod()` to ensure the correct
+    use :php:meth:`Cake\\Http\\ServerRequest::allowMethod()` to ensure the correct
     HTTP method is used.
 
 .. versionadded:: 3.1

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -38,7 +38,7 @@ components in your ``initialize()`` method.
 
     You should always verify the HTTP method being used before executing
     side-effects. You should :ref:`check the HTTP method <check-the-request>` or
-    use :php:meth:`Cake\\Network\\Request::allowMethod()` to ensure the correct
+    use :php:meth:`Cake\\Http\\ServerRequest::allowMethod()` to ensure the correct
     HTTP method is used.
 
 Handling Blackhole Callbacks

--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -17,7 +17,7 @@ Doing Requests
 
 Doing requests is simple and straight forward.  Doing a GET request looks like::
 
-    use Cake\Network\Http\Client;
+    use Cake\Http\Client;
 
     $http = new Client();
 
@@ -88,10 +88,10 @@ Building Multipart Request Bodies by Hand
 -----------------------------------------
 
 There may be times when you need to build a request body in a very specific way.
-In these situations you can often use ``Cake\Network\Http\FormData`` to craft
+In these situations you can often use ``Cake\Http\Client\FormData`` to craft
 the specific multipart HTTP request you want::
 
-    use Cake\Network\Http\FormData;
+    use Cake\Http\Client\FormData;
 
     $data = new FormData();
 

--- a/en/development/dispatch-filters.rst
+++ b/en/development/dispatch-filters.rst
@@ -140,9 +140,9 @@ classes in CakePHP, dispatcher filters have a few conventions:
 ``DispatcherFilter`` exposes two methods that can be overridden in subclasses,
 they are ``beforeDispatch()`` and ``afterDispatch()``. These methods are
 executed before or after any controller is executed respectively. Both methods
-receive a :php:class:`Cake\\Event\\Event` object containing the ``Request`` and
-``Response`` objects (:php:class:`Cake\\Network\\Request` and
-:php:class:`Cake\\Network\\Response` instances) inside the ``$data`` property.
+receive a :php:class:`Cake\\Event\\Event` object containing the ``ServerRequest`` and
+``Response`` objects (:php:class:`Cake\\Http\\ServerRequest` and
+:php:class:`Cake\\Http\\Response` instances) inside the ``$data`` property.
 
 While our filter was pretty simple, there are a few other interesting things we
 can do in filter methods. By returning an ``Response`` object, you can

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1335,8 +1335,8 @@ correctly by the ``adjust()`` method in our component. We create the file
     use Cake\Controller\Controller;
     use Cake\Controller\ComponentRegistry;
     use Cake\Event\Event;
-    use Cake\Network\Request;
-    use Cake\Network\Response;
+    use Cake\Http\ServerRequest;
+    use Cake\Http\Response;
     use Cake\TestSuite\TestCase;
 
     class PagematronComponentTest extends TestCase
@@ -1349,7 +1349,7 @@ correctly by the ``adjust()`` method in our component. We create the file
         {
             parent::setUp();
             // Setup our component and fake test controller
-            $request = new Request();
+            $request = new ServerRequest();
             $response = new Response();
             $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
                 ->setConstructorArgs([$request, $response])

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -320,7 +320,7 @@ chance to show the user validation errors or other warnings.
 Every CakePHP request includes a ``ServerRequest`` object which is accessible using
 ``$this->request``. The request object contains useful information regarding the
 request that was just received, and can be used to control the flow of your
-application.  In this case, we use the :php:meth:`Cake\\Network\\ServerRequest::is()`
+application.  In this case, we use the :php:meth:`Cake\\Http\\ServerRequest::is()`
 method to check that the request is a HTTP POST request.
 
 When a user uses a form to POST data to your application, that

--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -224,7 +224,7 @@ Here's what the ``add()`` action does:
 Every CakePHP request includes a request object which is accessible using
 ``$this->request``. The request object contains information regarding the
 request that was just received. We use the
-:php:meth:`Cake\\Network\\ServerRequest::is()` method to check that the request
+:php:meth:`Cake\\Http\\ServerRequest::is()` method to check that the request
 is a HTTP POST request.
 
 Our POST data is available in ``$this->request->getData()``. You can use the


### PR DESCRIPTION
- Cake\Network\Request is renamed to Cake\Http\ServerRequest.
- Cake\Network\Response is renamed to Cake\Http\Response.
- Cake\Network\Http\Client is renamed to Cake\Http\Client.
- Cake\Network\Http\FormData is renamed to Cake\Http\Client\FormData.
