### PR TITLE
Added note about generating coverage with phpdbg

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -312,7 +312,7 @@ This will put the coverage results in your application's webroot directory. You
 should be able to view the results by going to
 ``http://localhost/your_app/coverage``.
 
-If you are using PHP 5.6.0 or greater, you can use `phpdbg <http://phpunit.de/manual/current/en/installation.html#installation.phar.windows>`__ 
+If you are using PHP 5.6.0 or greater, you can use `phpdbg <http://phpdbg.com/>`__ 
 to generate coverage instead of xdebug. ``phpdbg`` is generally faster at 
 generating coverage::
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -312,6 +312,14 @@ This will put the coverage results in your application's webroot directory. You
 should be able to view the results by going to
 ``http://localhost/your_app/coverage``.
 
+If you are using PHP 5.6.0 or greater, you can use `phpdbg <http://phpunit.de/manual/current/en/installation.html#installation.phar.windows>`__ 
+to generate coverage instead of xdebug. ``phpdbg`` is generally faster at 
+generating coverage::
+
+.. code-block:: bash
+
+    $ phpdbg -qrr phpunit --coverage-html webroot/coverage tests/TestCase/Model/Table/ArticlesTableTest
+
 Combining Test Suites for Plugins
 ---------------------------------
 


### PR DESCRIPTION
> `phpdbg` is generally faster at generating coverage

Is this too opinionated? I mean, it *is* faster, but perhaps not in all cases.

Here's my app's performance, for example (had to reinstall xdebug, forgot how fast `phpdbg` actually was 😄 ): 

![screen shot 2017-05-26 at 8 24 27 am](https://cloud.githubusercontent.com/assets/184903/26496361/cf28094c-41ec-11e7-8ea3-ad653561760a.png)

