### PR TITLE
[en][fr][ja] fix the method definition.

### DIFF
--- a/en/core-libraries/hash.rst
+++ b/en/core-libraries/hash.rst
@@ -181,7 +181,7 @@ Attribute Matching Types
             ]
         */
 
-.. php:staticmethod:: combine(array $data, $keyPath = null, $valuePath = null, $groupPath = null)
+.. php:staticmethod:: combine(array $data, $keyPath, $valuePath = null, $groupPath = null)
 
     Creates an associative array using a ``$keyPath`` as the path to build its keys,
     and optionally ``$valuePath`` as path to get the values. If ``$valuePath`` is not

--- a/fr/core-libraries/hash.rst
+++ b/fr/core-libraries/hash.rst
@@ -193,7 +193,7 @@ Les Types d'Attribut Correspondants
             ]
         */
 
-.. php:staticmethod:: combine(array $data, $keyPath = null, $valuePath = null, $groupPath = null)
+.. php:staticmethod:: combine(array $data, $keyPath, $valuePath = null, $groupPath = null)
 
     Crée un tableau associatif en utilisant ``$keyPath`` en clé pour le chemin
     à construire, et optionnellement ``$valuePath`` comme chemin pour récupérer

--- a/ja/core-libraries/hash.rst
+++ b/ja/core-libraries/hash.rst
@@ -178,7 +178,7 @@ Hash パス構文
             ]
         */
 
-.. php:staticmethod:: combine(array $data, $keyPath = null, $valuePath = null, $groupPath = null)
+.. php:staticmethod:: combine(array $data, $keyPath, $valuePath = null, $groupPath = null)
 
     ``$keyPath`` のパスをキー、``$valuePath`` （省略可） のパスを値として使って連想配列を作ります。
     ``$valuePath`` が省略された場合や、``$valuePath`` に合致するものが無かった場合は、値は null で初期化されます。


### PR DESCRIPTION
the $keyPath of Hash::combine() has no default argument value.

https://api.cakephp.org/3.4/class-Cake.Utility.Hash.html#_combine
