### PR TITLE
Clarify validCount

### DIFF
--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -440,8 +440,8 @@ two rules::
 
 .. note::
 
-   When comparing with the ``<`` or ``<=`` operators ``validCount()`` will return
-   false in case, say, you do not at least supply an empty list of tags.
+   When comparing via the ``<`` or ``<=`` operators, ``validCount()`` will return
+   ``false`` if you do not supply at least an empty list of - say - tags.
 
 .. versionadded:: 3.3.0
     The ``validCount()`` method was added in 3.3.0.

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -438,6 +438,11 @@ two rules::
     $rules->add($rules->validCount('tags', 3, '>=', 'You must have at least 3 tags'));
     $rules->add($rules->validCount('tags', 5, '<=', 'You must have at most 5 tags'));
 
+.. note::
+
+   When comparing with the ``<`` or ``<=`` operators ``validCount()`` will return
+   false in case, say, you do not at least supply an empty list of tags.
+
 .. versionadded:: 3.3.0
     The ``validCount()`` method was added in 3.3.0.
 

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -440,7 +440,7 @@ two rules::
 
 .. note::
 
-   When comparing via the ``<`` or ``<=`` operators, ``validCount()`` will return
+   When comparing via the ``<``, ``<=`` or ``== 0`` operators, ``validCount()`` will return
    ``false`` if you do not supply at least an empty list of - say - tags.
 
 .. versionadded:: 3.3.0

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -437,12 +437,13 @@ two rules::
     // Between 3 and 5 tags
     $rules->add($rules->validCount('tags', 3, '>=', 'You must have at least 3 tags'));
     $rules->add($rules->validCount('tags', 5, '<=', 'You must have at most 5 tags'));
+    $rules->add($rules->validCount('subscription', 0, '==', 'You may not have a subscription'));
 
 .. note::
 
-   ``validCount`` returns ``false`` if the property is not countable or does not exist
-   E.g. when comparing via the ``<``, ``<=`` or ``== 0`` operators, ``validCount()``
-   will return ``false`` if you do not supply at least an empty list of - say - tags.
+   ``validCount`` returns ``false`` if the property is not countable or does not exist.
+   E.g. comparing via ``<``, ``<=`` or against ``0`` may unexpectedly return ``false``,
+   if you do not supply at least an empty list of - say - subscriptions.
 
 .. versionadded:: 3.3.0
     The ``validCount()`` method was added in 3.3.0.

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -442,7 +442,7 @@ two rules::
 .. note::
 
    ``validCount`` returns ``false`` if the property is not countable or does not exist.
-   E.g. comparing via ``<``, ``<=`` or against ``0`` may unexpectedly return ``false``,
+   E.g. comparing via ``<``, ``<=`` or against ``0`` will return ``false``,
    if you do not supply at least an empty list of - say - subscriptions.
 
 .. versionadded:: 3.3.0

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -440,8 +440,9 @@ two rules::
 
 .. note::
 
-   When comparing via the ``<``, ``<=`` or ``== 0`` operators, ``validCount()`` will return
-   ``false`` if you do not supply at least an empty list of - say - tags.
+   ``validCount`` returns ``false`` if the property is not countable or does not exist
+   E.g. when comparing via the ``<``, ``<=`` or ``== 0`` operators, ``validCount()``
+   will return ``false`` if you do not supply at least an empty list of - say - tags.
 
 .. versionadded:: 3.3.0
     The ``validCount()`` method was added in 3.3.0.


### PR DESCRIPTION
It is intolerant against non existing keys.

Aka such a check is **not** inside class ValidCount:

```php
if (!$entity->has($this->_field) && array_key_exists('allowNulls', $options) && $options['allowNulls'] === true) { return true; }
```