### PR TITLE
Using varchar(191) on unique key columns

### DIFF
--- a/en/tutorials-and-examples/cms/database.rst
+++ b/en/tutorials-and-examples/cms/database.rst
@@ -19,7 +19,7 @@ tables::
         id INT AUTO_INCREMENT PRIMARY KEY,
         user_id INT NOT NULL,
         title VARCHAR(255) NOT NULL,
-        slug VARCHAR(255) NOT NULL,
+        slug VARCHAR(191) NOT NULL,
         body TEXT,
         published BOOLEAN DEFAULT FALSE,
         created DATETIME,
@@ -30,7 +30,7 @@ tables::
 
     CREATE TABLE tags (
         id INT AUTO_INCREMENT PRIMARY KEY,
-        title VARCHAR(255),
+        title VARCHAR(191),
         created DATETIME,
         modified DATETIME,
         UNIQUE KEY (title)


### PR DESCRIPTION
I started going through the tutorial from scratch but couldn't insert the tables with the provided SQL

> Error Code: 1071. Specified key was too long; max key length is 767 bytes

Updated the length on columns used as keys to meet length requirements as utfmb8 uses 4 bytes per char not 3.

see: https://stackoverflow.com/questions/1814532/1071-specified-key-was-too-long-max-key-length-is-767-bytes#comment69153099_16820166