### PR TITLE
JsonType example updates

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -424,7 +424,7 @@ the type mapping. During our application bootstrap we should do the following::
 
     use Cake\Database\Type;
 
-    Type::map('json', 'Cake\Database\Type\JsonType');
+    Type::map('json', 'App\Database\Type\JsonType');
 
 We can then overload the reflected schema data to use our new type, and
 CakePHP's database layer will automatically convert our JSON data when creating

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -426,6 +426,9 @@ the type mapping. During our application bootstrap we should do the following::
 
     Type::map('json', 'App\Database\Type\JsonType');
 
+.. versionadded:: 3.3.0
+    The JsonType described in this example was added to the core.
+
 We can then overload the reflected schema data to use our new type, and
 CakePHP's database layer will automatically convert our JSON data when creating
 queries. You can use the custom types you've created by mapping the types in

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -367,10 +367,10 @@ If you need to use vendor specific types that are not built into CakePHP you can
 add additional new types to CakePHP's type system. Type classes are expected to
 implement the following methods:
 
-* toPHP
-* toDatabase
-* toStatement
-* marshal
+* ``toPHP``: Casts given value from a database type to a PHP equivalent.
+* ``toDatabase``: Casts given value from a PHP type to one acceptable by a database.
+* ``toStatement``: Casts given value to its Statement equivalent.
+* ``marshal``: Marshals flat data into PHP objects.
 
 An easy way to fulfill the basic interface is to extend
 :php:class:`Cake\\Database\\Type`. For example if we wanted to add a JSON type,


### PR DESCRIPTION
Some minor improvements to the custom db type example.

- clarified what type methods do (copy/paste)
- fixed incorrect reference when mapping custom type
- added note about json type in 3.3