### PR TITLE
Overwrite Order By

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -247,6 +247,18 @@ method::
     $query = $articles->find()
         ->order(['title' => 'ASC', 'id' => 'ASC']);
 
+
+When calling ``order()`` multiple times on a query multiple clauses will be appended.
+However, when using finders you may sometimes need to overwrite the ``ORDER BY``.
+Set the second parameter of ``order()`` (as well as ``orderAsc()`` or ``orderDesc()``) to
+``Query::OVERWRITE`` or to ``true``;
+
+    $query = $articles->find()
+        ->order(['title' => 'ASC']);
+    // Later, overwrite the ORDER BY clause instead of appending to it.
+    $query = $articles->find()
+        ->order(['created' => 'DESC'], Query::OVERWRITE);
+
 .. versionadded:: 3.0.12
 
     In addition to ``order``, the ``orderAsc`` and ``orderDesc`` methods can be

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -251,7 +251,7 @@ method::
 When calling ``order()`` multiple times on a query multiple clauses will be appended.
 However, when using finders you may sometimes need to overwrite the ``ORDER BY``.
 Set the second parameter of ``order()`` (as well as ``orderAsc()`` or ``orderDesc()``) to
-``Query::OVERWRITE`` or to ``true``;
+``Query::OVERWRITE`` or to ``true``::
 
     $query = $articles->find()
         ->order(['title' => 'ASC']);


### PR DESCRIPTION
@lorenzo when writing this I thought that there should possibly be Query::PREPEND and Query::APPEND (latter is default behavior) to control Order building...