### PR TITLE
Fixed Example for custom Point Type

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -531,12 +531,14 @@ value object and into SQL expressions::
             if ($value instanceof Point) {
                 return new FunctionExpression(
                     'POINT',
-                    $value->lat(),
-                    $value->long()
+                    [
+                        $value->lat(),
+                        $value->long()
+                    ]
                 );
             }
             if (is_array($value)) {
-                return new FunctionExpression('POINT', $value[0], $value[1]);
+                return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
             // Handle other cases.
         }


### PR DESCRIPTION
Without this change the user will get an "Call to a member function types() on float" (or string or whatever).

The Values must be passed as array to the second parameter of FunctionExpression; 
until now they are passed in the example as second and third, which lead to interpreting the second value as "type".