### PR TITLE
Autobreak too long words on direct p children of .section

### DIFF
--- a/themes/cakephp/static/css/style.css
+++ b/themes/cakephp/static/css/style.css
@@ -646,8 +646,9 @@ iframe {
 .section-dark { background-color:#303236; }
 .section-white { background-color: #f5f5f5; }
 
-
-
+.section > p {
+    overflow-wrap: break-word;
+}
 
 /* Column paddings */
 .row.col-p0 { margin-left:0; margin-right:0; }


### PR DESCRIPTION
Fixes https://github.com/cakephp/docs/issues/4024
Tested in Chrome 59 Mobile Inspector