### PR TITLE
Capitalize classname

### DIFF
--- a/en/models/model-attributes.rst
+++ b/en/models/model-attributes.rst
@@ -105,15 +105,15 @@ recursive
 The recursive property defines how deep CakePHP should go to fetch
 associated model data via ``find()``, and ``read()`` methods.
 
-Imagine your application features Groups which belong to a domain
+Imagine your application features Groups which belong to a Domain
 and have many Users which in turn have many Articles. You can set
 $recursive to different values based on the amount of data you want
 back from a $this->Group->find() call:
 
 * -1 CakePHP fetches Group data only, no joins.
-* 0  CakePHP fetches Group data and its domain
-* 1  CakePHP fetches a Group, its domain and its associated Users
-* 2  CakePHP fetches a Group, its domain, its associated Users, and the
+* 0  CakePHP fetches Group data and its Domain
+* 1  CakePHP fetches a Group, its Domain and its associated Users
+* 2  CakePHP fetches a Group, its Domain, its associated Users, and the
   Users' associated Articles
 
 Set it no higher than you need. Having CakePHP fetch data you


### PR DESCRIPTION
Small fix to make it more readable that Domain is a model.
This came up on the forum:
http://discourse.cakephp.org/t/what-does-domain-mean-in-model-context-cakephp-2/2711