### PR TITLE
Element option for authError flash messages

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -557,6 +557,7 @@ AuthComponent uses for setting flash messages. The available keys are
 
 - ``key`` - The key to use, defaults to 'default'. Prior to 3.4.0, the key
   defaulted to 'auth'.
+- ``element`` - The element name to use for rendering, defaults to null.
 - ``params`` - The array of additional params to use, defaults to ``[]``.
 
 In addition to the flash message settings you can customize other error


### PR DESCRIPTION
Since internally `$this->Flash->set($message, $this->_config['flash'])` is used, element is also an option to customize the authError flash message.