### PR TITLE
Update json-and-xml-views.rst

### DIFF
--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -105,8 +105,8 @@ element the Xml will fail to generate.
 
 .. versionadded:: 3.1.0
 
-    You can also set ``_serialize`` to ``true`` to serialize all view variables
-    instead of explicitly specifying them.
+    In this version the variable is automaticaly set ``_serialize`` to ``true``
+    to serialize all view variables instead of explicitly specifying them.
 
 Using a Data View with Template Files
 =====================================
@@ -139,7 +139,8 @@ output the serialized content.
 .. note::
     As of 3.1.0 AppController, in the application skeleton automatically adds
     ``'_serialize' => true`` to all XML/JSON requests. You will need to remove
-    this code from the beforeRender callback if you want to use view files.
+    this code from the beforeRender callback or set ``'_serialize' => false`` in
+    your controller if you want to use view files.
 
 
 Creating XML Views


### PR DESCRIPTION
Gives details of what's needed to use custom templates for xml and json views and also clarifies the fact that _serialize is set to true by default.