### PR TITLE
[2.x] Use "internal data types" instead of "abstract types"

### DIFF
--- a/en/appendices/2-10-migration-guide.rst
+++ b/en/appendices/2-10-migration-guide.rst
@@ -13,9 +13,9 @@ Core
 Model
 =====
 
-* New abstract types were added for ``smallinteger`` and ``tinyinteger``.
+* New internal data types were added for ``smallinteger`` and ``tinyinteger``.
   Existing ``SMALLINT`` and ``TINYINT`` columns will now be reflected as these
-  new abstract types. ``TINYINT(1)`` columns will continue to be treated as
+  new internal data types. ``TINYINT(1)`` columns will continue to be treated as
   boolean columns in MySQL.
 * ``Model::find()`` now supports ``having`` and ``lock`` options that enable you
   to add ``HAVING`` and ``FOR UPDATE`` locking clauses to your find operations.


### PR DESCRIPTION
In the [CakePHP 2.10 migration guide](https://book.cakephp.org/2.0/en/appendices/2-10-migration-guide.html), "abstract types" are used. It can't be found on other pages.
I thought that it would be better to unify it to "internal data types" used on the [Testing](https://book.cakephp.org/2.0/en/development/testing.html#creating-fixtures) page.
How is it?