### PR TITLE
[fr] First round of 3.next translations

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -788,8 +788,8 @@ This will change the usage output to ``my-shell`` instead of the default ``cake`
     Usage:
     my-shell console [-h] [-v] [-q]
 
-.. versionadded:: 3.5
-    The help alias was added in 3.5.
+.. versionadded:: 3.5.0
+    The ``setHelpAlias`` method was added in 3.5.0
 
 Set the Epilog
 --------------

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -1060,11 +1060,9 @@ When defining a subcommand you can use the following options:
 
 Adding subcommands can be done as part of a fluent method chain.
 
-
 .. versionchanged:: 3.5.0
     When adding multi-word subcommands you can now invoke those commands using
     ``snake_case`` in addition to the camelBacked form.
-
 
 Building a ConsoleOptionParser from an Array
 --------------------------------------------

--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -203,7 +203,8 @@ in the future, you can use the ``addDefaultProvider()`` method as follows::
 .. note::
 
     DefaultProviders must be added before the ``Validator`` object is created
-    therefore **config/bootstrap.php** is the best place
+    therefore **config/bootstrap.php** is the best place to set up your
+    default providers.
 
 .. versionadded:: 3.5.0
 

--- a/en/views/cells.rst
+++ b/en/views/cells.rst
@@ -244,7 +244,7 @@ messages could look like::
         }
     }
 
-The above cell would  paginate the ``Messages`` model using :ref:`scoped
+The above cell would paginate the ``Messages`` model using :ref:`scoped
 pagination parameters <paginating-multiple-queries>`.
 
 .. versionadded:: 3.5.0

--- a/fr/console-and-shells.rst
+++ b/fr/console-and-shells.rst
@@ -1092,6 +1092,11 @@ suivantes:
 Ajouter des sous-commandes peut être fait comme une partie de la chaîne de
 méthode courante.
 
+.. versionchanged:: 3.5.0
+    Lorsque vous ajouter des sous-commandes composées de plusieurs mots, vous
+    pouvez maintenant les appeler en ``snake_case`` en plus de la forme en
+    camelBack.
+
 Construire un ConsoleOptionParser à partir d'un Tableau
 -------------------------------------------------------
 

--- a/fr/console-and-shells.rst
+++ b/fr/console-and-shells.rst
@@ -811,6 +811,25 @@ suivante::
     --verbose, -v  Enable verbose output.
     --quiet, -q    Enable quiet output.
 
+Set a help alias
+~~~~~~~~~~~~~~~~
+
+.. php:method:: setHelpAlias($alias)
+
+Si vous souhaitez changer le nom de la commande, vous pouvez utiliser la méthode
+``setHelpAlias()``::
+
+    $parser->setHelpAlias('my-shell');
+
+Cela changera la phrase de 'Usage' pour ``my-shell`` à la place de la valeur par
+défaut ``cake``::
+
+    Usage:
+    my-shell console [-h] [-v] [-q]
+
+.. versionadded:: 3.5.0
+    La méthode ``setHelpAlias`` a été ajoutée dans 3.5.0
+
 Définir un "Epilog"
 ~~~~~~~~~~~~~~~~~~~
 

--- a/fr/core-libraries/validation.rst
+++ b/fr/core-libraries/validation.rst
@@ -202,6 +202,25 @@ dans votre règle::
         'provider' => 'table'
     ]);
 
+Si vous souhaitez ajouter un ``provider`` à tous les objets ``Validator`` créés
+plus tard, vous pouvez utiliser la méthode ``addDefaultProvider()``::
+
+    use Cake\Validation\Validator;
+
+    // En utilisant une instance d'objet.
+    Validator::addDefaultProvider('custom', $myObject);
+
+    // En utilisant un nom de classe. Les méthodes devront être static.
+    Validator::addDefaultProvider('custom', 'App\Model\Validation');
+
+.. note::
+
+    Les DefaultProviders doivent être ajoutés avant que l'objet ``Validator`` ne
+    soit créé. Par conséquent **config/bootstrap.php** est le meilleur endroit
+    pour définir vos providers par défaut.
+
+.. versionadded:: 3.5.0
+
 Vous pouvez utiliser le `plugin Localized <https://github.com/cakephp/localized>`_ pour fournir des providers basés sur
 les pays. Avec ce plugin, vous pourrez valider les champs de models selon un
 pays, par exemple::

--- a/fr/development/routing.rst
+++ b/fr/development/routing.rst
@@ -966,7 +966,7 @@ Vous pouvez spécifier un type d'inflection alternatif en utilisant l'option
         ]);
     })
 
-Ce qui est au-dessus va générer des URLs de style **/blog-posts/***.
+Ce qui est au-dessus va générer des URLs de style **/blog-posts***.
 
 .. note::
 
@@ -974,6 +974,20 @@ Ce qui est au-dessus va générer des URLs de style **/blog-posts/***.
     comme classe de route par défaut. Donc il est recommandé d'utiliser l'option
     ``'inflect' => 'dasherize'`` pour connecter les routes resssource afin de
     garder la cohérence de l'URL.
+
+Changer le chemin d'un élément
+------------------------------
+
+Par défaut, les ressources de routes utilisent le nom de ressource ayant subi
+une inflexion en guise de segment d'URL. Vous pouvez définir un segment d'URL
+personnalisé à l'aide de l'option ``path``::
+
+    Router::scope('/', function ($routes) {
+        $routes->resources('BlogPosts', ['path' => 'posts']);
+    });
+
+.. versionadded:: 3.5.0
+    L'option ``path`` a été ajoutée dans 3.5.0.
 
 .. index:: passed arguments
 .. _passed-arguments:

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -1246,7 +1246,7 @@ utilise cette option quand le mode ``debug`` est activé.
 Désactiver le Middleware de Gestion d'Erreurs dans les Tests
 ------------------------------------------------------------
 
-Quand vous debugger des tests qui échouent car l'application a rencontré des
+Quand vous debuggez des tests qui échouent car l'application a rencontré des
 erreurs, il peut être utile de désactiver temporairement le middleware de gestion
 des erreurs pour permettre aux erreurs de remonter. Vous pouvez utiliser la méthode
 ``disableErrorHandlerMiddleware()`` pour permettre ce comportement::

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -968,17 +968,22 @@ assertions qu'intègre ``IntegrationTestCase``. Avant de pouvoir utiliser les
 assertions, vous aurez besoin de simuler une requête. Vous pouvez utiliser
 l'une des méthodes suivantes pour simuler une requête:
 
-* ``get()`` Sends a GET request.
-* ``post()`` Sends a POST request.
-* ``put()`` Sends a PUT request.
-* ``delete()`` Sends a DELETE request.
-* ``patch()`` Sends a PATCH request.
+* ``get()`` Envoie une requête GET.
+* ``post()`` Envoie une requête POST.
+* ``put()`` Envoie une requête PUT.
+* ``delete()`` Envoie une requête DELETE.
+* ``patch()`` Envoie une requête PATCH.
+* ``options()`` Envoie une requête OPTIONS.
+* ``head()`` Envoie une requête HEAD.
 
 Toutes les méthodes exceptées ``get()`` et ``delete()`` acceptent un second
 paramètre qui vous permet de saisir le corps d'une requête. Après avoir émis
 une requête, vous pouvez utiliser les différentes assertions que fournit
 ``IntegrationTestCase`` ou PHPUnit afin de vous assurer que votre requête
 possède de correctes effets secondaires.
+
+.. versionadded:: 3.5.0
+    ``options()`` et ``head()`` ont été ajoutées dans 3.5.0.
 
 Configurer la Requête
 ---------------------
@@ -1237,6 +1242,26 @@ et assurons-nous que le web service répond correctement::
 
 Nous utilisons l'option ``JSON_PRETTY_PRINT`` car la JsonView intégrée à CakePHP
 utilise cette option quand le mode ``debug`` est activé.
+
+Désactiver le Middleware de Gestion d'Erreurs dans les Tests
+------------------------------------------------------------
+
+Quand vous debugger des tests qui échouent car l'application a rencontré des
+erreurs, il peut être utile de désactiver temporairement le middleware de gestion
+des erreurs pour permettre aux erreurs de remonter. Vous pouvez utiliser la méthode
+``disableErrorHandlerMiddleware()`` pour permettre ce comportement::
+
+    public function testGetMissing()
+    {
+        $this->disableErrorHandlerMiddleware();
+        $this->get('/markers/not-there');
+        $this->assertResponseCode(404);
+    }
+
+Dans l'exemple ci-dessus, le test échouera et le message d'exception et le stack-trace
+seront affichés à la place de la page d'erreur de l'application.
+
+.. versionadded:: 3.5.0
 
 Méthodes d'Assertion
 --------------------

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -346,6 +346,11 @@ uuid
 integer
     Correspond au type INTEGER fourni par la base de données. BIT n'est pour
     l'instant pas supporté.
+smallinteger
+    Correspond au type SMALLINT fourni par la base de données.
+tinyinteger
+    Correspond au type TINYINT (ou SMALLINT) fourni par la base de données. Sur MySQL
+    ``TINYINT(1)`` sera traité comme un booléen.
 biginteger
     Correspond au type BIGINT fourni par la base de données.
 float
@@ -389,6 +394,12 @@ en 'datetime' va automatiquement convertir les paramètres d'input d'instances
 ``DateTime`` en timestamp ou chaines de dates formatées. Egalement, les
 colonnes 'binary' vont accepter un fichier qui gère, et génère le fichier lors
 de la lecture des données.
+
+.. versionchanged:: 3.3.0
+    Le type ``json`` a été ajouté.
+
+.. versionchanged:: 3.5.0
+    Les types ``smallinteger`` et ``tinyinteger`` ont été ajoutés.
 
 .. _adding-custom-database-types:
 

--- a/fr/orm/validation.rst
+++ b/fr/orm/validation.rst
@@ -265,6 +265,9 @@ table, vous pouvez récupérer l'objet résultant via son nom::
 
     $hardenedValidator = $usersTable->validator('hardened');
 
+.. deprecated:: 3.5.0
+    ``validator()`` est dépréciée. Utilisez ``getValidator()`` à la place.
+
 Classe Validator par Défault
 ============================
 

--- a/fr/views/cells.rst
+++ b/fr/views/cells.rst
@@ -216,3 +216,46 @@ template seront utilisés.
     ces nouveaux objets ne partagent pas de contexte avec le template /layout
     principal. Chaque cell est auto-contenu et a seulement accès aux variables
     passés en arguments par l'appel de ``View::cell()``.
+
+Paginer des Données dans une Cell
+=================================
+
+Créer une cell qui qui rend des résultats paginés peut être fait en utilisant
+la classe ``Paginator`` de l'ORM. Voici un exemple de pagination des messages
+favoris d'un utilisateur::
+
+    namespace App\View\Cell;
+
+    use Cake\View\Cell;
+    use Cake\Datasource\Paginator;
+
+    class FavoritesCell extends Cell
+    {
+        public function display($user)
+        {
+            $this->loadModel('Messages');
+
+            // Création du paginator
+            $paginator = new Paginator();
+
+            // Pagination du model
+            $results = $paginator->paginate(
+                $this->Messages,
+                $this->request->getQueryParams(),
+                [
+                    // Utilisation d'un finder personnalisé avec paramètre
+                    'finder' => ['favorites' => [$user]],
+
+                    // Utilisation de paramètre de query 'scoped'.
+                    'scope' => 'favorites',
+                ]
+            );
+            $this->set('favorites', $results);
+        }
+    }
+
+La cell ci-dessus va paginer le model ``Messages`` en utilisant les
+:ref:`paramètres de pagination 'scopés' <paginating-multiple-queries>`.
+
+.. versionadded:: 3.5.0
+    ``Cake\Datasource\Paginator`` a été ajoutée dans 3.5.0.

--- a/fr/views/helpers/paginator.rst
+++ b/fr/views/helpers/paginator.rst
@@ -421,6 +421,38 @@ supportées sont:
   :php:meth:`PaginatorHelper::defaultModel()`. Ceci est utilisé en conjonction
   avec la chaîne personnalisée de l'option 'format'.
 
+Générer des Url de Pagination
+=============================
+
+.. php:method:: generateUrl(array $options = [], $model = null, $full = false)
+
+Retourne par défaut une chaine de l'URL de pagination complète pour utiliser
+dans contexte non-standard (ex. JavaScript)::
+
+    echo $this->Paginator->generateUrl(['sort' => 'title']);
+
+Créer un Select de Limite
+=========================
+
+.. php:method:: limitControl(array $limits = [], $default = null, array $options = [])
+
+Créer un ``select`` qui permet de changer le paramètre ``limit`` de la query::
+
+    // Utilise le défaut.
+    echo $this->Paginator->limitControl();
+
+    // Permet de définir les limites que vous souhaitez.
+    echo $this->Paginator->limitControl([25 => 25, 50 => 50]);
+
+    // Limites personnalisées et set l'option sélectionnée
+    echo $this->Paginator->limitControl([25 => 25, 50 => 50], $user->perPage);
+
+Cela générera un ``form`` qui sera automatiquement soumis lors d'un changement
+de valeur sur le ``select``.
+
+.. versionadded:: 3.5.0
+    La méthode ``limitControl()`` a été ajoutée dans 3.5.0
+
 Configurer les Options de Pagination
 ====================================
 
@@ -532,16 +564,6 @@ utilisant des marqueurs spéciaux::
         'format' => 'Page {{page}} of {{pages}}, showing {{current}} records out of
                  {{count}} total, starting on record {{start}}, ending on {{end}}'
     ]) ?>
-
-Générer des Url de Pagination
-=============================
-
-.. php:method:: generateUrl(array $options = [], $model = null, $full = false)
-
-Retourne par défaut une chaine de l'URL de pagination complète pour utiliser
-dans contexte non-standard(ex. JavaScript)::
-
-    echo $this->Paginator->generateUrl(['sort' => 'title']);
 
 .. _paginator-helper-multiple:
 

--- a/fr/views/helpers/paginator.rst
+++ b/fr/views/helpers/paginator.rst
@@ -431,8 +431,8 @@ dans contexte non-standard (ex. JavaScript)::
 
     echo $this->Paginator->generateUrl(['sort' => 'title']);
 
-Créer un Select de Limite
-=========================
+Créer une Liste Déroulante de Limites
+=====================================
 
 .. php:method:: limitControl(array $limits = [], $default = null, array $options = [])
 

--- a/fr/views/helpers/rss.rst
+++ b/fr/views/helpers/rss.rst
@@ -8,6 +8,9 @@ Rss
 Le RssHelper permet de générer facilement le XML pour les
 `flux RSS <https://en.wikipedia.org/wiki/RSS>`_.
 
+.. deprecated:: 3.5.0
+    Le RssHelper est déprécié à partir de 3.5.0 et sera supprimé dans 4.0.0
+
 Créer un flux RSS avec RssHelper
 ================================
 


### PR DESCRIPTION
Follows #4801, #4831, #4904, #4927, #4948, #4951, #4999, #5003, #5040, #5060.

As usual, I did some minor edition in the original version of the doc.