### PR TITLE
[2.x] specify --dry option in schema shells create/update section

### DIFF
--- a/en/console-and-shells/schema-management-and-migrations.rst
+++ b/en/console-and-shells/schema-management-and-migrations.rst
@@ -379,7 +379,7 @@ of an error message saying you are missing a table):
     $ Console/cake schema create
     $ Console/cake schema update
 
-All these operations can be done in dry-run mode.
+All these operations can be done in dry-run mode with a ``--dry`` option.
 
 Rolling back
 ------------


### PR DESCRIPTION
I wasted a little bit of time because I could not do it even with the ``--dry-run`` option. 