### PR TITLE
[fr] Follows #5098

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -154,9 +154,9 @@ This can happen if two strings are identical but refer to different things. For
 example, 'letter' has multiple meanings in English. To solve that problem, you
 can use the :php:func:`__x()` function::
 
-    echo __x('written communication', 'He read the first letter');
+    echo __x('written communication', 'He reads the first letter');
 
-    echo __x('alphabet learning', 'He read the first letter');
+    echo __x('alphabet learning', 'He reads the first letter');
 
 The first argument is the context of the message and the second is the message
 to be translated.
@@ -164,7 +164,7 @@ to be translated.
 .. code-block:: pot
 
      msgctxt "written communication"
-     msgid "He read the first letter"
+     msgid "He reads the first letter"
      msgstr "Hey, lies den ersten Brief"
 
 Using Variables in Translation Messages

--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -154,9 +154,9 @@ This can happen if two strings are identical but refer to different things. For
 example, 'letter' has multiple meanings in English. To solve that problem, you
 can use the :php:func:`__x()` function::
 
-    echo __x('written communication', 'He reads the first letter');
+    echo __x('written communication', 'He read the first letter');
 
-    echo __x('alphabet learning', 'He reads the first letter');
+    echo __x('alphabet learning', 'He read the first letter');
 
 The first argument is the context of the message and the second is the message
 to be translated.
@@ -164,7 +164,7 @@ to be translated.
 .. code-block:: pot
 
      msgctxt "written communication"
-     msgid "He reads the first letter"
+     msgid "He read the first letter"
      msgstr "Hey, lies den ersten Brief"
 
 Using Variables in Translation Messages

--- a/fr/core-libraries/internationalization-and-localization.rst
+++ b/fr/core-libraries/internationalization-and-localization.rst
@@ -169,6 +169,12 @@ la fonction :php:func:`__x()`::
 Le premier argument est le contexte du message et le second est le message
 à traduire.
 
+.. code-block:: pot
+
+     msgctxt "written communication"
+     msgid "He reads the first letter"
+     msgstr "Il lit le premier courrier"
+
 Utiliser des Variables dans les Traductions de Messages
 -------------------------------------------------------
 

--- a/fr/core-libraries/internationalization-and-localization.rst
+++ b/fr/core-libraries/internationalization-and-localization.rst
@@ -171,7 +171,7 @@ Le premier argument est le contexte du message et le second est le message
 
 .. code-block:: pot
 
-     msgctxt "written communication"
+     msgctxt "communication écrite"
      msgid "He read the first letter"
      msgstr "Il a lu le premier courrier"
 

--- a/fr/core-libraries/internationalization-and-localization.rst
+++ b/fr/core-libraries/internationalization-and-localization.rst
@@ -162,9 +162,9 @@ se réfèrent à des choses différentes. Par exemple 'lettre' a plusieurs
 significations en français. Pour résoudre ce problème, vous pouvez utiliser
 la fonction :php:func:`__x()`::
 
-    echo __x('communication écrite', 'Il a lu la première lettre');
+    echo __x('communication écrite', 'He read the first letter');
 
-    echo __x('apprentissage de l alphabet', 'Il a lu la première lettre');
+    echo __x('apprentissage de l alphabet', 'He read the first letter');
 
 Le premier argument est le contexte du message et le second est le message
 à traduire.
@@ -172,8 +172,8 @@ Le premier argument est le contexte du message et le second est le message
 .. code-block:: pot
 
      msgctxt "written communication"
-     msgid "He reads the first letter"
-     msgstr "Il lit le premier courrier"
+     msgid "He read the first letter"
+     msgstr "Il a lu le premier courrier"
 
 Utiliser des Variables dans les Traductions de Messages
 -------------------------------------------------------


### PR DESCRIPTION
Follows #5098.

While at it, I fixed "he read" to "he reads" in the original translation.

Note to my fellow french reviewers : J'ai volontairement traduit "first letter" par "premier courrier". Même si "lettre" aurait été valable, ça aurait un peu rendu l'exemple creux (parce qu'en Français, c'est comme en anglais). Je me suis dit que "courrier" collait bien ici.