### PR TITLE
Fix a German sentence in a .po file example

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -165,7 +165,7 @@ to be translated.
 
      msgctxt "written communication"
      msgid "He read the first letter"
-     msgstr "Hey, lies den ersten Brief"
+     msgstr "Er las den ersten Brief"
 
 Using Variables in Translation Messages
 ---------------------------------------


### PR DESCRIPTION
"read" is a past tense in the English sentence.