### PR TITLE
Comma after last array element

### DIFF
--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -344,7 +344,7 @@ this way::
         'url' => true,
         'user' => true,
         'tags' => true,
-        'tag_string' => true,
+        'tag_string' => true
     ];
 
 


### PR DESCRIPTION
I found a syntax error in the 'Adding a Computed Field' section.

I've removed the comma.