### PR TITLE
Added 3.5 migration note on ConsoleIntegrationTestCase

### DIFF
--- a/en/appendices/3-5-migration-guide.rst
+++ b/en/appendices/3-5-migration-guide.rst
@@ -167,6 +167,15 @@ cache configuration to fall back to if the engine is misconfigured (or
 unavailable). See :ref:`cache-configuration-fallback` for more information on
 configuring fallbacks.
 
+Console Integration Testing
+---------------------------
+
+The ``Cake\TestSuite\ConsoleIntegrationTestCase`` class was added to make
+integration testing console applications easier. For more information, visit
+the :ref:`console-integration-testing` section. This test class is fully
+compatible with the current shell dispatcher as well as the new
+``Cake\Console\CommandRunner``.
+
 Core
 ----
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1322,6 +1322,8 @@ comparison files as they are referenced:
     #
     #   modified:   tests/comparisons/example.php
 
+.. _console-integration-testing:
+
 Console Integration Testing
 ===========================
 


### PR DESCRIPTION
I noticed this was missing when I was perusing the docs last night.