### PR TITLE
Remove border from definition lists.

### DIFF
--- a/themes/cakephp/static/css/default.css
+++ b/themes/cakephp/static/css/default.css
@@ -215,7 +215,6 @@ dl.docutils {
     margin-bottom: 0.5em;
 }
 .docutils dd {
-    border-left: 2px solid #ccc;
     margin: 0 0 1em 1em;
     padding: 0 0 .5em .5em;
     font-size: 1.4rem;


### PR DESCRIPTION
I found this border added visual noise and didn't make the book easier to read.

New style looks like:

![screen shot 2017-07-28 at 12 27 40](https://user-images.githubusercontent.com/24086/28726692-391b46b4-7390-11e7-8633-6bf7778b51c5.png)
