### PR TITLE
Added missing use statement

### DIFF
--- a/en/elasticsearch.rst
+++ b/en/elasticsearch.rst
@@ -95,6 +95,8 @@ plugin::
 
     namespace App\Model\Document;
 
+    use Cake\ElasticSearch\Type;
+
     class Article extends Document
     {
     }


### PR DESCRIPTION
The example code for a `Cake\ElasticSearch\Type` was missing a `use` statement