### PR TITLE
Added a note about plugins with prefix templates

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -518,6 +518,13 @@ path to the 'index' view of the Custom controller will be::
 Creating this file would allow you to override
 **vendor/thevendor/theplugin/src/Template/Custom/index.ctp**.
 
+If the plugin implements a routing prefix, you must include the routing prefix in your 
+application template overrides.
+
+If the 'ContactManager' plugin implemented an 'admin' prefix the overridng path would be::
+    
+    src/Template/Plugin/ContactManager/Admin/ContactManager/index.ctp
+
 .. _plugin-assets:
 
 


### PR DESCRIPTION
I found this was missing from the documentation today. I've tried to guess because I don't have the time or inclination to install, configure and learn Docker.

I tried to build it using `make`, but it seems to be missing all the stylesheets, so I can only hope that it'll look right.