### PR TITLE
Remove redundant login suggestion

### DIFF
--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -92,9 +92,6 @@ the users that has a hashed password.
     ``loadComponent('Auth')`` line. Then go and edit the user,
     saving a new password for them.
 
-You should now be able to log in. If not, make sure you are using a user that
-has a hashed password.
-
 Adding Logout
 =============
 


### PR DESCRIPTION
At the end of the 'Add Login" section the tutorial rightfully suggests that "you should now be able to login." This is followed by a note about how to create a user with a hashed password if one was not previously created. This note is followed by another line about being able to log in that is redundant to the first. As a reader I would expect to be able to login after completing the proposed fix.

An alternative would be to move the second recommendation into the note itself and say something to the effect of "After creating a user with a hashed password you can uncomment the auth code and you should now be able to log in with the newly created hashed password user," however, this may be excessive and unnecessary for a concise tutorial on beginning CakePHP