### PR TITLE
Update information about PDO driver for SQL Server

### DIFF
--- a/en/models/datasources.rst
+++ b/en/models/datasources.rst
@@ -298,13 +298,11 @@ and refer to it using the plugin notation::
 Connecting to SQL Server
 ========================
 
-The Sqlserver datasource depends on Microsoft's PHP extension called pdo_sqlsrv.
+The Sqlserver datasource depends on 
+`Microsoft's PHP extension called pdo_sqlsrv <https://github.com/Microsoft/msphpsql>`_.
 This PHP Extension is not included in the base installation of PHP and must be
-installed separately.
-
-Also the SQL Server Native Client must be installed for the extension to work.
-As the Native Client is available only for Windows you will not be able to
-install it on Linux, Mac OS X or FreeBSD.
+installed separately.  The SQL Server Native Client must also be installed for
+the extension to work.
 
 So if the Sqlserver Datasource errors out with::
 


### PR DESCRIPTION
PDO drivers for SQL Server are now available on both Windows and *nix operating systems.  Also added a link to the driver's github page, which is the best source of information about the driver IMHO.