### PR TITLE
Note about SQL Server not supporting persistent

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -190,7 +190,9 @@ driver
     a fully namespaced name, or a constructed driver instance.
     Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.
 persistent
-    Whether or not to use a persistent connection to the database.
+    Whether or not to use a persistent connection to the database.  This option is not supported by
+    SqlServer.  As of CakePHP version 3.4.13 an exception is thrown if you attempt to set persitent to true
+    with SqlServer.
 host
     The database server's hostname (or IP address).
 username


### PR DESCRIPTION
CakePHP now throws an exception when persistent is set to true with SQL Server.  This update explains that fact.