### PR TITLE
Moved hardcoded user_id to articles controller add method

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -204,6 +204,11 @@ to be created. Start by creating an ``add()`` action in the
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
+
+                // Hardcoding the user_id is temporary, and will be removed later
+                // when we build authentication out.
+                $article->user_id = 1;
+
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);
@@ -320,12 +325,6 @@ typically a URL-safe version of an article's title. We can use the
             $sluggedTitle = Text::slug($entity->title);
             // trim slug to maximum length defined in schema
             $entity->slug = substr($sluggedTitle, 0, 191)
-        }
-
-        // This is temporary, and will be removed later
-        // when we build authentication out.
-        if (!$entity->user_id) {
-            $entity->user_id = 1;
         }
     }
 

--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -231,7 +231,7 @@ Fixing the Add & Edit Actions
 =============================
 
 While we've blocked access to the edit action, we're still open to users
-changing the ``user_id`` attribute of articles on creation or during edit. We
+changing the ``user_id`` attribute of articles during edit. We
 will solve these problems next. First up is the ``add`` action.
 
 When creating articles, we want to fix the ``user_id`` to be the currently
@@ -245,7 +245,7 @@ logged in user. Replace your add action with the following::
         if ($this->request->is('post')) {
             $article = $this->Articles->patchEntity($article, $this->request->getData());
 
-            // Added: Set the user_id from the session.
+            // Changed: Set the user_id from the session.
             $article->user_id = $this->Auth->user('id');
 
             if ($this->Articles->save($article)) {
@@ -257,9 +257,7 @@ logged in user. Replace your add action with the following::
         $this->set('article', $article);
     }
 
-Remember to remove the ``user_id`` control from
-**src/Templates/Articles/add.ctp** as well. Next we'll update the ``edit``
-action. Replace the edit method with the following::
+Next we'll update the ``edit`` action. Replace the edit method with the following::
 
     // in src/Controller/ArticlesController.php
 

--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -129,6 +129,11 @@ articles. First, update the ``add`` action to look like::
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
+
+                // Hardcoding the user_id is temporary, and will be removed later
+                // when we build authentication out.
+                $article->user_id = 1;
+
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
                     return $this->redirect(['action' => 'index']);


### PR DESCRIPTION
Just a minor fix to the flow of the tutorial where `user_id` was previously hardcoded in the table's `beforeSave`. This changes lines up the code with what the tutorial is telling the user.