### PR TITLE
Update installation.rst

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -14,6 +14,7 @@ Requirements
 - PHP |minphpversion| or greater (including PHP 7.1).
 - mbstring PHP extension
 - intl PHP extension
+- simplexml PHP extension
 
 .. note::
 


### PR DESCRIPTION
Prevents this error at install time:

```
squizlabs/php_codesniffer 3.0.0 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.
```
