### PR TITLE
Fixed create and drop typo in the index fields

### DIFF
--- a/en/phinx/migrations.rst
+++ b/en/phinx/migrations.rst
@@ -387,7 +387,7 @@ store a collection of users::
                   ->addColumn('last_name', 'string', ['limit' => 30])
                   ->addColumn('created', 'datetime')
                   ->addColumn('updated', 'datetime', ['null' => true])
-                  ->addIndex(['username', 'email'), ['unique' => true])
+                  ->addIndex(['username', 'email'], ['unique' => true])
                   ->save();
         }
 
@@ -610,7 +610,7 @@ good idea to recreate the table again in the ``down()`` method::
                   ->addColumn('last_name', 'string', ['limit' => 30])
                   ->addColumn('created', 'datetime')
                   ->addColumn('updated', 'datetime', ['null' => true])
-                  ->addIndex(['username', 'email'), ['unique' => true])
+                  ->addIndex(['username', 'email'], ['unique' => true])
                   ->save();
         }
     }


### PR DESCRIPTION
Reading through docs I noticed a typo and thought, why not PR?

Thanks for what you're doing!