### PR TITLE
completion shell must be lowercase

### DIFF
--- a/en/console-and-shells/completion-shell.rst
+++ b/en/console-and-shells/completion-shell.rst
@@ -21,7 +21,7 @@ For the first step commands outputs the available Shell Commands, including
 plugin name when applicable. (All returned possibilities, for this and the other
 sub commands, are separated by a space.) For example::
 
-    bin/cake Completion commands
+    bin/cake completion commands
 
 Returns::
 
@@ -37,7 +37,7 @@ Once the preferred command has been chosen subCommands comes in as the second
 step and outputs the possible sub command for the given shell command. For
 example::
 
-    bin/cake Completion subcommands bake
+    bin/cake completion subcommands bake
 
 Returns::
 
@@ -50,7 +50,7 @@ As the third and final options outputs options for the given (sub) command as
 set in getOptionParser. (Including the default options inherited from Shell.)
 For example::
 
-    bin/cake Completion options bake
+    bin/cake completion options bake
 
 Returns::
 
@@ -101,11 +101,11 @@ in order to get autocompletion when using the CakePHP console::
 
         if [[ "$cur" == -* ]] ; then
             if [[ ${COMP_CWORD} = 1 ]] ; then
-                opts=$(${cake} Completion options)
+                opts=$(${cake} completion options)
             elif [[ ${COMP_CWORD} = 2 ]] ; then
-                opts=$(${cake} Completion options "${COMP_WORDS[1]}")
+                opts=$(${cake} completion options "${COMP_WORDS[1]}")
             else
-                opts=$(${cake} Completion options "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")
+                opts=$(${cake} completion options "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")
             fi
 
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
@@ -113,13 +113,13 @@ in order to get autocompletion when using the CakePHP console::
         fi
 
         if [[ ${COMP_CWORD} = 1 ]] ; then
-            opts=$(${cake} Completion commands)
+            opts=$(${cake} completion commands)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
         fi
 
         if [[ ${COMP_CWORD} = 2 ]] ; then
-            opts=$(${cake} Completion subcommands $prev)
+            opts=$(${cake} completion subcommands $prev)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             if [[ $COMPREPLY = "" ]] ; then
                 _filedir
@@ -128,7 +128,7 @@ in order to get autocompletion when using the CakePHP console::
             return 0
         fi
 
-        opts=$(${cake} Completion fuzzy "${COMP_WORDS[@]:1}")
+        opts=$(${cake} completion fuzzy "${COMP_WORDS[@]:1}")
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         if [[ $COMPREPLY = "" ]] ; then
             _filedir

--- a/fr/console-and-shells/completion-shell.rst
+++ b/fr/console-and-shells/completion-shell.rst
@@ -23,7 +23,7 @@ disponibles, y compris le nom du plugin quand il est valable. (Toutes les
 possibilités retournées, pour celle-ci et les autres sous-commandes, sont
 séparées par un espace.) Par exemple::
 
-    bin/cake Completion commands
+    bin/cake completion commands
 
 Retourne::
 
@@ -39,7 +39,7 @@ Une fois que la commande préférée a été choisie, les Sous-commandes apparai
 à la deuxième étape et affiche la sous-commande possible pour la commande de
 shell donnée. Par exemple::
 
-    bin/cake Completion subcommands bake
+    bin/cake completion subcommands bake
 
 Retourne::
 
@@ -53,7 +53,7 @@ commande donnée comme définies dans getOptionParser. (Y compris les options pa
 défaut héritées du Shell.)
 Par exemple::
 
-    bin/cake Completion options bake
+    bin/cake completion options bake
 
 Retourne::
 
@@ -105,11 +105,11 @@ console CakePHP::
 
         if [[ "$cur" == -* ]] ; then
             if [[ ${COMP_CWORD} = 1 ]] ; then
-                opts=$(${cake} Completion options)
+                opts=$(${cake} completion options)
             elif [[ ${COMP_CWORD} = 2 ]] ; then
-                opts=$(${cake} Completion options "${COMP_WORDS[1]}")
+                opts=$(${cake} completion options "${COMP_WORDS[1]}")
             else
-                opts=$(${cake} Completion options "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")
+                opts=$(${cake} completion options "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")
             fi
 
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
@@ -117,13 +117,13 @@ console CakePHP::
         fi
 
         if [[ ${COMP_CWORD} = 1 ]] ; then
-            opts=$(${cake} Completion commands)
+            opts=$(${cake} completion commands)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
         fi
 
         if [[ ${COMP_CWORD} = 2 ]] ; then
-            opts=$(${cake} Completion subcommands $prev)
+            opts=$(${cake} completion subcommands $prev)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             if [[ $COMPREPLY = "" ]] ; then
                 _filedir
@@ -132,7 +132,7 @@ console CakePHP::
             return 0
         fi
 
-        opts=$(${cake} Completion fuzzy "${COMP_WORDS[@]:1}")
+        opts=$(${cake} completion fuzzy "${COMP_WORDS[@]:1}")
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         if [[ $COMPREPLY = "" ]] ; then
             _filedir

--- a/ja/console-and-shells/completion-shell.rst
+++ b/ja/console-and-shells/completion-shell.rst
@@ -21,7 +21,7 @@ commands
 出力します。(出力結果は、このコマンド自身や他のサブコマンド全てがスペースで
 区切られています。) 例えば::
 
-    bin/cake Completion commands
+    bin/cake completion commands
 
 実行結果::
 
@@ -37,7 +37,7 @@ subCommands
 そして、与えられたシェルコマンドのために利用可能なサブコマンドを出力します。
 例えば::
 
-    bin/cake Completion subcommands bake
+    bin/cake completion subcommands bake
 
 実行結果::
 
@@ -51,7 +51,7 @@ options
 (Shell から継承されたデフォルトのオプションを含みます。)
 例えば::
 
-    bin/cake Completion options bake
+    bin/cake completion options bake
 
 実行結果::
 
@@ -101,11 +101,11 @@ Bash 補完ファイルの内容
 
         if [[ "$cur" == -* ]] ; then
             if [[ ${COMP_CWORD} = 1 ]] ; then
-                opts=$(${cake} Completion options)
+                opts=$(${cake} completion options)
             elif [[ ${COMP_CWORD} = 2 ]] ; then
-                opts=$(${cake} Completion options "${COMP_WORDS[1]}")
+                opts=$(${cake} completion options "${COMP_WORDS[1]}")
             else
-                opts=$(${cake} Completion options "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")
+                opts=$(${cake} completion options "${COMP_WORDS[1]}" "${COMP_WORDS[2]}")
             fi
 
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
@@ -113,13 +113,13 @@ Bash 補完ファイルの内容
         fi
 
         if [[ ${COMP_CWORD} = 1 ]] ; then
-            opts=$(${cake} Completion commands)
+            opts=$(${cake} completion commands)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
         fi
 
         if [[ ${COMP_CWORD} = 2 ]] ; then
-            opts=$(${cake} Completion subcommands $prev)
+            opts=$(${cake} completion subcommands $prev)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             if [[ $COMPREPLY = "" ]] ; then
                 _filedir
@@ -128,7 +128,7 @@ Bash 補完ファイルの内容
             return 0
         fi
 
-        opts=$(${cake} Completion fuzzy "${COMP_WORDS[@]:1}")
+        opts=$(${cake} completion fuzzy "${COMP_WORDS[@]:1}")
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         if [[ $COMPREPLY = "" ]] ; then
             _filedir


### PR DESCRIPTION
After upgrade cakephp/app to 3.5 the auto completion shell script ends to work because it wasn't found.

Looking at my `/etc/bash_completion.d/cake` I noted that completion shell script was always called capitalized i.e. `Completion` and I found that the docs was not updated.