### PR TITLE
Passing conditions to contain()

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -562,11 +562,12 @@ associations and filter them by conditions::
 
     // In a controller or table method.
 
-    $query = $articles->find()->contain('Comments', function ($q) {
-       return $q
-            ->select(['body', 'author_id'])
-            ->where(['Comments.approved' => true]);
-    });
+    $query = $articles->find()->contain(['Comments' => function ($q) {
+            return $q
+                ->select(['body', 'author_id'])
+                ->where(['Comments.approved' => true]);
+        }
+    ]);
 
 This also works for pagination at the Controller level::
 


### PR DESCRIPTION
I've tried passing a condition to contain, like it was shown in the manual, but I didn't got it to work. The manual said I had to pass contain('myModel', function($q){...}), but instead I had to use an array like contain(['myModel' => function($q){...}]);
I'm using cake 3.4.13