### PR TITLE
Try to clarify 'through' table expectation

### DIFF
--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -557,7 +557,7 @@ Possible keys for belongsToMany association arrays include:
 - **sort**: an array of find() compatible order clauses.
 - **dependent**: When the dependent key is set to ``false``, and an entity is
   deleted, the data of the join table will not be deleted.
-- **through**: Allows you to provide either the name of the Table instance you
+- **through**: Allows you to provide either the alias of the Table instance you
   want used on the join table, or the instance itself. This makes customizing
   the join table keys possible, and allows you to customize the behavior of the
   pivot table.


### PR DESCRIPTION
I got caught out here, and thought 'name' meant a FQCN, so I used `ExamplesTable::class` which produced a broken query. So just wanted to try and clarify that it's the registry alias, so would be `Examples` in this instance.