### PR TITLE
How to create custom collections, and some potential pitfalls

### DIFF
--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -1181,7 +1181,7 @@ places at the same time. In order to clone a collection out of another use the
 Creating your own custom Collections
 ====================================
 
-It is possible to create your own collection classes in your application to store, manage and manipulate groups of items. Simply create your collection class and extend the core collection class instance.
+It is possible to create your own collection classes in your application to store, manage and manipulate groups of items. Simply create your collection class and extend the core collection class instance.::
 
     namespace App\Lib\Collections;
 
@@ -1192,18 +1192,18 @@ It is possible to create your own collection classes in your application to stor
 
     }
 
-You can now use your collection class as you would a regular collection, and access all the power of the collection methods.
+You can now use your collection class as you would a regular collection, and access all the power of the collection methods.::
 
     $examplesCollection = new ExamplesCollection(['first' => 'Custom class example', 'second' => 'Extend core class']);
 
-If you are storing object instances in a custom collection it is recommended to include a key when constructing the collection.
+If you are storing object instances in a custom collection it is recommended to include a key when constructing the collection.::
 
     $objectCollection = new ExamplesCollection(
         'first' => new FirstExample(),
         'second' => new SecondExample()
     );
 
-In the above example, your Example objects will now be contained in the collection. However, the objects will need to implement the PHP ``ArrayAccess`` interface in order to be compatible with the collection methods. It is also recommended to include the ``toArray()`` method in the object, so that they can be displayed correctly in Debug Kit.
+In the above example, your Example objects will now be contained in the collection. However, the objects will need to implement the `PHP ArrayAccess interface <http://php.net/manual/en/class.arrayaccess.php>`_ in order to be compatible with the collection methods. It is also recommended to include the ``toArray()`` method in the object, so that they can be displayed correctly in Debug Kit.
 
 When you are nesting custom collections within objects which are themselves in a collection, some customisation of your custom collections ``toArray()`` method will be required.
 

--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -1178,6 +1178,35 @@ places at the same time. In order to clone a collection out of another use the
         }
     }
 
+Creating your own custom Collections
+====================================
+
+It is possible to create your own collection classes in your application to store, manage and manipulate groups of items. Simply create your collection class and extend the core collection class instance.
+
+    namespace App\Lib\Collections;
+
+    use Cake\Collection\Collection;
+
+    class ExamplesCollection extends Collection
+    {
+
+    }
+
+You can now use your collection class as you would a regular collection, and access all the power of the collection methods.
+
+    $examplesCollection = new ExamplesCollection(['first' => 'Custom class example', 'second' => 'Extend core class']);
+
+If you are storing object instances in a custom collection it is recommended to include a key when constructing the collection.
+
+    $objectCollection = new ExamplesCollection(
+        'first' => new FirstExample(),
+        'second' => new SecondExample()
+    );
+
+In the above example, your Example objects will now be contained in the collection. However, the objects will need to implement the PHP ``ArrayAccess`` interface in order to be compatible with the collection methods. It is also recommended to include the ``toArray()`` method in the object, so that they can be displayed correctly in Debug Kit.
+
+When you are nesting custom collections within objects which are themselves in a collection, some customisation of your custom collections ``toArray()`` method will be required.
+
 .. meta::
     :title lang=en: Collections
     :keywords lang=en: collections, cakephp, append, sort, compile, contains, countBy, each, every, extract, filter, first, firstMatch, groupBy, indexBy, jsonSerialize, map, match, max, min, reduce, reject, sample, shuffle, some, random, sortBy, take, toArray, insert, sumOf, stopWhen, unfold, through


### PR DESCRIPTION
Reference: https://github.com/cakephp/cakephp/issues/11201

I have started on a new section about using the Collection class to create your own custom collections.

I have also tried to guide readers on some potential pitfalls, and problems that I've encountered. Such as the use of `ArrayAccess` and `toArray()`.

I am not sure on the linking policy in the docs, so if anyone has guidance on stuff which should be linked, please let me know. To me, obvious candidates are things like internal page links to the collection methods table, and also a link to the PHP ArrayAccess man page, so readers don't think that ArrayAccess is a CakePHP interface, instead of a core PHP one.

I'm happy to take some feedback on what I have so far and contribute some more to this pull request.

Thanks!

PS, I can only hope that the styling works as intended, due to #5271 