### PR TITLE
Link to Composer

### DIFF
--- a/en/intro/cakephp-folder-structure.rst
+++ b/en/intro/cakephp-folder-structure.rst
@@ -18,8 +18,8 @@ level folders you should see:
   is usually used to store translation messages, model descriptions and sometimes
   session information.
 - The *vendor* folder is where CakePHP and other application dependencies will
-  be installed by Composer. Editing these files is not advised, as Composer will
-  overwrite your changes next time you update.
+  be installed by `Composer <http://getcomposer.org>`_. Editing these files is not
+  advised, as Composer will overwrite your changes next time you update.
 - The *webroot* directory is the public document root of your application. It
   contains all the files you want to be publically reachable.
 


### PR DESCRIPTION
We should link to Composer's website as people reading this page could not have visited the installation guide yet where they would have learned about Composer already.