### PR TITLE
Clarification of migration documentation

### DIFF
--- a/en/phinx/migrations.rst
+++ b/en/phinx/migrations.rst
@@ -73,7 +73,7 @@ The Change Method
 
 Phinx 0.2.0 introduced a new feature called reversible migrations. This feature
 has now become the default migration method. With reversible migrations, you
-only need to define the ``up`` logic, and Phinx can figure out how to migrate
+only need to define the ``change`` logic, and Phinx can figure out how to migrate
 down automatically for you. For example::
 
     <?php


### PR DESCRIPTION
I'm not sure if this is right, I was reading the documentation and the statement that 'up' methods migrate down automatically seemed wrong to me, since this paragraph is about the change method. And it makes much more sense that change migrates down automatically, I guess. :)