### PR TITLE
Up MySQL min version, add MariaDB version

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -34,7 +34,8 @@ Requirements
 While a database engine isn't required, we imagine that most applications will
 utilize one. CakePHP supports a variety of database storage engines:
 
--  MySQL (5.1.10 or greater)
+-  MySQL (5.5.3 or greater)
+-  MariaDB (5.5 or greater)
 -  PostgreSQL
 -  Microsoft SQL Server (2008 or higher)
 -  SQLite 3


### PR DESCRIPTION
Core PR: https://github.com/cakephp/cakephp/pull/11328

RDBMS Docs:

- https://mariadb.com/kb/en/library/unicode/ (utf8mb3 utf8mb4)
- https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html
- MariaDB Versions: https://mariadb.org/feedback_plugin/stats/major_version_breakdown/

p.s.: I am also okay with setting MariaDB version a lot higher, aka to 10.0 or 10.1 as we did not support it "officially" so far.