### PR TITLE
HATBM example has erroneous Model mentioned

### DIFF
--- a/en/models/associations-linking-models-together.rst
+++ b/en/models/associations-linking-models-together.rst
@@ -715,7 +715,7 @@ Possible keys for HABTM association arrays include:
    highly customized results.
 
 Once this association has been defined, find operations on the
-Recipe model will also fetch related Tag records if they exist::
+Recipe model will also fetch related Ingredient records if they exist::
 
     // Sample results from a $this->Recipe->find() call.
 


### PR DESCRIPTION
In the detailed example, Recipe HABTM Ingredient, not Tag.