### PR TITLE
[ja] Fix translation configuring Components

### DIFF
--- a/ja/controllers/components.rst
+++ b/ja/controllers/components.rst
@@ -30,8 +30,9 @@ CakePHP の中に含まれるコンポーネントの詳細については、各
 コアコンポーネントの多くは設定を必要としています。コンポーネントが設定を
 必要としている例は、 :doc:`/controllers/components/authentication` や
 :doc:`/controllers/components/cookie` などにあります。これらのコンポーネントや
-一般的なコンポーネントの設定は、通常、お使いのコントローラーの ``loadComponent()``
-メソッドまたは ``initialize()`` メソッド、 ``$components`` 配列を介して行われます。 ::
+一般的なコンポーネントの設定は、通常、お使いのコントローラーの ``initialize()``
+メソッド内で ``loadComponent()`` を使用するか、 ``$components`` 配列を介して行われます。 ::
+
 
     class PostsController extends AppController
     {


### PR DESCRIPTION
:bow:

https://github.com/cakephp/docs/blob/3.0/en/controllers/components.rst#configuring-components
```
Configuration for these components,
and for components in general, is usually done via ``loadComponent()`` in your
Controller's ``initialize()`` method or via the ``$components`` array::
```