### PR TITLE
Remove build warnings with relative references.

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -549,4 +549,4 @@ that uses JavaScript to do a POST request deleting our article.
     article.
 
 With a basic articles management setup, we'll create the  :doc:`basic actions
-for our Tags and Users tables <tags-and-users>`.
+for our Tags and Users tables </tutorials-and-examples/cms/tags-and-users>`.

--- a/en/tutorials-and-examples/cms/database.rst
+++ b/en/tutorials-and-examples/cms/database.rst
@@ -168,5 +168,5 @@ property which controls how properties can be modified by
 :ref:`entities-mass-assignment`.
 
 We can't do much with our models right now, so next we'll create our first
-:doc:`Controller and Template <articles-controller>` to allow us to interact
+:doc:`Controller and Template </tutorials-and-examples/cms/articles-controller>` to allow us to interact
 with our model.

--- a/en/tutorials-and-examples/cms/installation.rst
+++ b/en/tutorials-and-examples/cms/installation.rst
@@ -114,4 +114,4 @@ bullet points should be green chef hats other than CakePHP being able to connect
 your database. If not, you may need to install additional PHP extensions, or set
 directory permissions.
 
-Next, we will build our :doc:`Database and create our first model <database>`.
+Next, we will build our :doc:`Database and create our first model </tutorials-and-examples/cms/database>`.

--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -485,4 +485,4 @@ to showcase how powerful the ORM in CakePHP is. You can manipulate query
 results using the :doc:`/core-libraries/collections` methods, and handle
 scenarios where you are creating entities on the fly with ease.
 
-Next we'll be adding :doc:`authentication <authentication>`.
+Next we'll be adding :doc:`authentication </tutorials-and-examples/cms/authentication>`.


### PR DESCRIPTION
The following warning is displayed in the latest build log and the build failed in Travis.

https://travis-ci.org/cakephp/docs/builds/288987425

```
tutorials-and-examples/cms/installation.rst:117: WARNING: unknown document: database
tutorials-and-examples/cms/database.rst:170: WARNING: unknown document: articles-controller
tutorials-and-examples/cms/articles-controller.rst:551: WARNING: unknown document: tags-and-users
```

It seems to be caused by the relative reference link in the cms tutorial. So I fix it.
(However, the relative reference link will work... 😕 )