### PR TITLE
- Authentication modifications

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -443,8 +443,8 @@ from the normal password hash::
             // Make a password for digest auth.
             $entity->digest_hash = DigestAuthenticate::password(
                 $entity->username,
-                $entity->plain_password,
-                env('SERVER_NAME')
+                env('SERVER_NAME'),
+                $entity->plain_password
             );
             return true;
         }
@@ -455,9 +455,9 @@ other password hashes, based on the RFC for digest authentication.
 
 .. note::
 
-    The third parameter of DigestAuthenticate::password() must match the
+    The second parameter of DigestAuthenticate::password() must match the
     'realm' config value defined when DigestAuthentication was configured 
-    in AuthComponent::$authenticate. This defaults to ``env('SCRIPT_NAME')``. 
+    in AuthComponent::$authenticate. This defaults to ``env('SERVER_NAME')``. 
     You may wish to use a static string if you want consistent hashes in multiple environments.
 
 


### PR DESCRIPTION
I think should change a little bit the documentation.
```
            $entity->digest_hash = DigestAuthenticate::password(
                $entity->username,
                $entity->plain_password,
                env('SERVER_NAME')
            );

```
Maybe should be:
```
            $entity->digest_hash = DigestAuthenticate::password(
                $entity->username,
                env('SERVER_NAME'),
                $entity->plain_password
            );

```
 and 
    The **third** parameter of DigestAuthenticate::password() must match the
    'realm' config value defined when DigestAuthentication was configured 
    in AuthComponent::$authenticate. This defaults to **``env('SCRIPT_NAME')``**. 

Maybe should be
    The **second** parameter of DigestAuthenticate::password() must match the
    'realm' config value defined when DigestAuthentication was configured 
    in AuthComponent::$authenticate. This defaults to **``env('SERVER_NAME')``**. 

