### PR TITLE
Represent that $primary is boolean in beforeFind

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -209,7 +209,7 @@ into entities. See the :ref:`before-marshal` documentation for more information.
 beforeFind
 ----------
 
-.. php:method:: beforeFind(Event $event, Query $query, ArrayObject $options, $primary)
+.. php:method:: beforeFind(Event $event, Query $query, ArrayObject $options, boolean $primary)
 
 The ``Model.beforeFind`` event is fired before each find operation. By stopping
 the event and supplying a return value you can bypass the find operation


### PR DESCRIPTION
Parameter $primary in beforeFind is boolean.  It is present in the API but was not in the book.