### PR TITLE
DigestAuthenticate modification

### DIFF
--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -443,8 +443,8 @@ from the normal password hash::
             // Make a password for digest auth.
             $entity->digest_hash = DigestAuthenticate::password(
                 $entity->username,
-                env('SERVER_NAME'),
-                $entity->plain_password
+                $entity->plain_password,
+                env('SERVER_NAME')
             );
             return true;
         }

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -443,8 +443,8 @@ from the normal password hash::
             // Make a password for digest auth.
             $entity->digest_hash = DigestAuthenticate::password(
                 $entity->username,
-                $entity->plain_password,
-                env('SERVER_NAME')
+                env('SERVER_NAME'),
+                $entity->plain_password
             );
             return true;
         }
@@ -455,9 +455,9 @@ other password hashes, based on the RFC for digest authentication.
 
 .. note::
 
-    The third parameter of DigestAuthenticate::password() must match the
+    The second parameter of DigestAuthenticate::password() must match the
     'realm' config value defined when DigestAuthentication was configured 
-    in AuthComponent::$authenticate. This defaults to ``env('SCRIPT_NAME')``. 
+    in AuthComponent::$authenticate. This defaults to ``env('SERVER_NAME')``. 
     You may wish to use a static string if you want consistent hashes in multiple environments.
 
 

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -457,7 +457,7 @@ other password hashes, based on the RFC for digest authentication.
 
     The second parameter of DigestAuthenticate::password() must match the
     'realm' config value defined when DigestAuthentication was configured 
-    in AuthComponent::$authenticate. This defaults to ``env('SERVER_NAME')``. 
+    in AuthComponent::$authenticate. This defaults to ``env('SCRIPT_NAME')``. 
     You may wish to use a static string if you want consistent hashes in multiple environments.
 
 

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -457,7 +457,7 @@ other password hashes, based on the RFC for digest authentication.
 
     The second parameter of DigestAuthenticate::password() must match the
     'realm' config value defined when DigestAuthentication was configured 
-    in AuthComponent::$authenticate. This defaults to ``env('SCRIPT_NAME')``. 
+    in AuthComponent::$authenticate. This defaults to ``env('SERVER_NAME')``. 
     You may wish to use a static string if you want consistent hashes in multiple environments.
 
 


### PR DESCRIPTION
commit: b9a1fe95d6055c914ff3a2d985e6d3ccefb45350

In [hashing-passwords-for-digest-authentication](https://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#hashing-passwords-for-digest-authentication), in the note part, (not code), I think `env('SCRIPT_NAME')` should be `env('SERVER_NAME')`
