### PR TITLE
Fixed consistency

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -235,8 +235,8 @@ look like::
         'body' => 'The text',
         'user_id' => 1,
         'tags' => [
-            ['tag' => 'CakePHP'],
-            ['tag' => 'Internet'],
+            ['name' => 'CakePHP'],
+            ['name' => 'Internet'],
         ]
     ];
 


### PR DESCRIPTION
Just wanted to amend the tags examples so they both use the same fields, for clarity, and to avoid the possible thought that the key of the array is the name of the entity.