### PR TITLE
- Correct the DigestAuthenticate::password() default third parameter

### DIFF
--- a/en/core-libraries/components/authentication.rst
+++ b/en/core-libraries/components/authentication.rst
@@ -466,7 +466,7 @@ password hashes, based on the RFC for digest authentication.
 
     The third parameter of DigestAuthenticate::password() must match the 'realm'
     config value defined when DigestAuthentication was configured in
-    AuthComponent::$authenticate. This defaults to ``env('SCRIPT_NAME')``. You
+    AuthComponent::$authenticate. This defaults to ``env('SERVER_NAME')``. You
     may wish to use a static string if you want consistent hashes in multiple
     environments.
 

--- a/fr/core-libraries/components/authentication.rst
+++ b/fr/core-libraries/components/authentication.rst
@@ -506,7 +506,7 @@ vous connecter.
     le troisième paramètre de DigestAuthenticate::password() doit correspondre
     à la valeur de la configuration 'realm' définie quand DigestAuthentication
     était configuré dans AuthComponent::$authenticate. Par défaut à
-    ``env('SCRIPT_NAME')``. Vous devez utiliser une chaîne statique si vous
+    ``env('SERVER_NAME')``. Vous devez utiliser une chaîne statique si vous
     voulez un hachage permanent dans des environnements multiples.
 
 Création de classes de hachage de mots de passe personnalisées

--- a/ja/core-libraries/components/authentication.rst
+++ b/ja/core-libraries/components/authentication.rst
@@ -441,7 +441,7 @@ Blowfish password hasher は、任意の認証クラスで使用することが�
 
     AuthComponent::$authenticate 内で DigestAuthentication が設定された場合、
     DigestAuthenticate::password() の第３パラメータは定義した 'realm' の設定値と
-    一致する必要があります。このデフォルトは  ``env('SCRIPT_NAME')`` です。
+    一致する必要があります。このデフォルトは  ``env('SERVER_NAME')`` です。
     複数の環境で一貫したハッシュが欲しい場合に static な文字列を使用することができます。
 
 カスタムパスワードハッシュ化クラスの作成


### PR DESCRIPTION
According to [this comment](https://github.com/cakephp/cakephp/blob/24e4acf9a38dc6a3a96fa5bebf9939988e715d77/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php#L47), `env('SCRIPT_NAME')` should become `env('SERVER_NAME')` but [here](https://github.com/cakephp/cakephp/blob/24e4acf9a38dc6a3a96fa5bebf9939988e715d77/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php#L203) there is not default value.