### PR TITLE
Added Notes for Request & Response Changes

### DIFF
--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -87,6 +87,7 @@ with CakePHP::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
+                // Prior to 3.4.0 $this->request->data() was used.
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
@@ -311,6 +312,7 @@ currently logged in user as a reference for the created article::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
+            // Prior to 3.4.0 $this->request->data() was used.
             $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Added this line
             $article->user_id = $this->Auth->user('id');
@@ -388,13 +390,16 @@ own.  Add the following content to your **ArticlesController.php**::
     public function isAuthorized($user)
     {
         // All registered users can add articles
+        // Prior to 3.4.0 $this->request->param('action') was used.
         if ($this->request->getParam('action') === 'add') {
             return true;
         }
 
         // The owner of an article can edit and delete it
+        // Prior to 3.4.0 $this->request->param('action') was used.
         if (in_array($this->request->getParam('action'), ['edit', 'delete'])) {
-            $articleId = (int)$this->request->getParam('pass.0');
+            // Prior to 3.4.0 $this->request->params('pass.0')
+            $articleId = (int)$this->request->getParam('pass.0'); 
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;
             }

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -350,6 +350,7 @@ it::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
+                // Prior to 3.4.0 $this->request->data() was used.
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -296,6 +296,7 @@ First, start by creating an ``add()`` action in the
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
+                // Prior to 3.4.0 $this->request->data() was used.
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
@@ -324,7 +325,7 @@ application.  In this case, we use the :php:meth:`Cake\\Http\\ServerRequest::is(
 method to check that the request is a HTTP POST request.
 
 When a user uses a form to POST data to your application, that
-information is available in ``$this->request->getData()``. You can use the
+information is available in ``$this->request->getData()`` ( Or ``$this->request->data()`` for CakePHP v3.3 and under ). You can use the
 :php:func:`pr()` or :php:func:`debug()` functions to print it out if you want to
 see what it looks like.
 
@@ -459,6 +460,7 @@ like::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
+            // Prior to 3.4.0 $this->request->data() was used.
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));


### PR DESCRIPTION
The blog tutorial referenced methods only available to CakePHP greater than or equal to 3.4.0.

Added notes to the tutorial to aid in debugging when calling methods from < 3.4 Installations.

Since the code was referenced in a tutorial for copy-pastable code, I put them in a comment. I followed syntactical and verbiage examples from https://book.cakephp.org/3.0/en/controllers/request-response.html.