### PR TITLE
Remove xcache from documentation.

### DIFF
--- a/en/appendices/3-6-migration-guide.rst
+++ b/en/appendices/3-6-migration-guide.rst
@@ -21,6 +21,9 @@ features will continue to function until 4.0.0 after which they will be removed.
   ``Cake\Cache\Engine\ApcuEngine`` to better reflect the extension name.
 * ``Cake\ORM\Table::association()`` is deprecated. Use ``getAssociation()``
   instead.
+* The ``Xcache`` cache engine has been deprecated. The Xcache extension is no
+  longer actively maintained. If you are using xcache, consider adopting APCu,
+  Memcached, or Redis instead.
 
 
 Behavior Changes

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -30,8 +30,6 @@ to implement your own caching systems. The built-in caching engines are:
 * ``Wincache`` Wincache uses the `Wincache <http://php.net/wincache>`_
   extension. Wincache is similar to APC in features and performance, but
   optimized for Windows and IIS.
-* ``XcacheEngine`` `Xcache <http://xcache.lighttpd.net/>`_
-  is a PHP extension that provides similar features to APC.
 * ``MemcachedEngine`` Uses the `Memcached <http://php.net/memcached>`_
   extension.
 * ``RedisEngine`` Uses the `phpredis <https://github.com/nicolasff/phpredis>`_
@@ -552,4 +550,4 @@ The required API for a CacheEngine is
 
 .. meta::
     :title lang=en: Caching
-    :keywords lang=en: uniform api,xcache,cache engine,cache system,atomic operations,php class,disk storage,static methods,php extension,consistent manner,similar features,apcu,apc,memcache,queries,cakephp,elements,servers,memory
+    :keywords lang=en: uniform api,cache engine,cache system,atomic operations,php class,disk storage,static methods,php extension,consistent manner,similar features,apcu,apc,memcache,queries,cakephp,elements,servers,memory

--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -184,7 +184,7 @@ Cache Sessions
 --------------
 
 The Cache class can be used to store sessions as well. This allows you to store
-sessions in a cache like APC, Memcached, or XCache. There are some caveats to
+sessions in a cache like APCu, or Memcached. There are some caveats to
 using cache sessions, in that if you exhaust the cache space, sessions will
 start to expire as records are evicted.
 


### PR DESCRIPTION
Don't document/endorse the usage of a cache backend that will be removed.

Refs cakephp/cakephp#11421