### PR TITLE
Update tags-and-users.rst

### DIFF
--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -206,6 +206,7 @@ can implement this, we'll add a new route. Your **config/routes.php** should
 look like::
 
     <?php
+    use Cake\Core\Plugin;
     use Cake\Routing\Route\DashedRoute;
     use Cake\Routing\Router;
 


### PR DESCRIPTION
I get this error
    Fatal error: Class 'Plugin' not found in C:\[...]\www\cms\config\routes.php on line 33
So I fixed the problem by adding the use 
    use Cake\Core\Plugin;