### PR TITLE
Update authentication.rst french translation

### DIFF
--- a/fr/tutorials-and-examples/cms/authentication.rst
+++ b/fr/tutorials-and-examples/cms/authentication.rst
@@ -29,7 +29,6 @@ nous allons ajouter AuthComponent dans notre AppController::
         {
             // Code existant
 
-            $this->loadComponent('Flash');
             $this->loadComponent('Auth', [
                 'authenticate' => [
                     'Form' => [


### PR DESCRIPTION
Strange that the french translation has this extra line:
    `$this->loadComponent('Flash')`
It is already present in the original code and referred to by the commentary
    `// Code existant [Existing code]`
A distracted beginner might end up with the same statement twice.