### PR TITLE
Update articles-controller.rst french translation

### DIFF
--- a/fr/tutorials-and-examples/cms/articles-controller.rst
+++ b/fr/tutorials-and-examples/cms/articles-controller.rst
@@ -389,6 +389,7 @@ Le template edit devra ressembler à ceci :
     <h1>Modifier un article</h1>
     <?php
         echo $this->Form->create($article);
+        echo $this->Form->control('user_id', ['type' => 'hidden']);
         echo $this->Form->control('title');
         echo $this->Form->control('body', ['rows' => '3']);
         echo $this->Form->button(__('Sauvegarder l\'article'));


### PR DESCRIPTION
Missing statement in the french translation.
`echo $this->Form->control('user_id', ['type' => 'hidden']);`
This line is referred to at the end of the tutorial as we're asked to remove it.
French users might be confused if they don't find it in the template file _edit.ctp_.
Regarding this issue, japanese translation is ok.