### PR TITLE
3.next - Document network exception moves

### DIFF
--- a/en/appendices/3-6-migration-guide.rst
+++ b/en/appendices/3-6-migration-guide.rst
@@ -26,6 +26,16 @@ features will continue to function until 4.0.0 after which they will be removed.
   Memcached, or Redis instead.
 * Passing a list of arrays to ``Router::setRequestInfo()`` is now deprecated.
   Pass an instance of ``ServerRequest`` instead.
+* ``Cake\Controller\Controller:$name`` is protected now. Use
+  ``Controller::getName()/setName()`` to access a controller's name in other
+  contexts.
+* ``Cake\Controller\Controller:$plugin`` is protected now. Use
+  ``Controller::getPlugin()/setPlugin()`` to access a controller's plugin in
+  other contexts.
+* ``Cake\Controller\Controller:$autoRender`` is deprecated. Use
+  ``enableAutoRender()/disableAutoRender()/isAutoRenderEnabled()`` in other
+  contexts.
+  ``Controller::getPlugin()/setPlugin()`` instead.
 * ``Cake\Network\Exception\BadRequestException`` has been renamed to
   ``Cake\Http\Exception\BadRequestException``.
 * ``Cake\Network\Exception\ConflictException`` has been renamed to

--- a/en/appendices/3-6-migration-guide.rst
+++ b/en/appendices/3-6-migration-guide.rst
@@ -26,6 +26,34 @@ features will continue to function until 4.0.0 after which they will be removed.
   Memcached, or Redis instead.
 * Passing a list of arrays to ``Router::setRequestInfo()`` is now deprecated.
   Pass an instance of ``ServerRequest`` instead.
+* ``Cake\Network\Exception\BadRequestException`` has been renamed to
+  ``Cake\Http\Exception\BadRequestException``.
+* ``Cake\Network\Exception\ConflictException`` has been renamed to
+  ``Cake\Http\Exception\ConflictException``.
+* ``Cake\Network\Exception\ForbiddenException`` has been renamed to
+  ``Cake\Http\Exception\ForbiddenException``.
+* ``Cake\Network\Exception\GoneException`` has been renamed to
+  ``Cake\Http\Exception\GoneException``.
+* ``Cake\Network\Exception\HttpException`` has been renamed to
+  ``Cake\Http\Exception\HttpException``.
+* ``Cake\Network\Exception\InternalErrorException`` has been renamed to
+  ``Cake\Http\Exception\InternalErrorException``.
+* ``Cake\Network\Exception\InvalidCsrfTokenException`` has been renamed to
+  ``Cake\Http\Exception\InvalidCsrfTokenException``.
+* ``Cake\Network\Exception\MethodNotAllowedException`` has been renamed to
+  ``Cake\Http\Exception\MethodNotAllowedException``.
+* ``Cake\Network\Exception\NotAcceptableException`` has been renamed to
+  ``Cake\Http\Exception\NotAcceptableException``.
+* ``Cake\Network\Exception\NotFoundException`` has been renamed to
+  ``Cake\Http\Exception\NotFoundException``.
+* ``Cake\Network\Exception\NotImplementedException`` has been renamed to
+  ``Cake\Http\Exception\NotImplementedException``.
+* ``Cake\Network\Exception\ServiceUnavailableException`` has been renamed to
+  ``Cake\Http\Exception\ServiceUnavailableException``.
+* ``Cake\Network\Exception\UnauthorizedException`` has been renamed to
+  ``Cake\Http\Exception\UnauthorizedException``.
+* ``Cake\Network\Exception\UnavailableForLegalReasonsException`` has been
+  renamed to ``Cake\Http\Exception\UnavailableForLegalReasonsException``.
 
 Disabling Deprecation Warnings
 ==============================

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -278,7 +278,8 @@ page count.
 So you could either let the normal error page be rendered or use a try catch
 block and take appropriate action when a ``NotFoundException`` is caught::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     public function index()
     {

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -563,7 +563,8 @@ class like so::
 
     // In your bootstrap.php
     use Cake\Event\EventManager;
-    use Cake\Network\Exception\InternalErrorException;
+    // Prior to 3.6 use Cake\Network\Exception\InteralErrorException
+    use Cake\Http\Exception\InternalErrorException;
 
     $isCakeBakeShellRunning = (PHP_SAPI === 'cli' && isset($argv[1]) && $argv[1] === 'bake');
     if (!$isCakeBakeShellRunning) {

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -117,7 +117,7 @@ standard error page, you can override it like::
         }
     }
 
-.. php:namespace:: Cake\Network\Exception
+.. php:namespace:: Cake\Http\Exception
 
 Exception Classes
 =================
@@ -213,8 +213,9 @@ You can throw these exceptions from your controllers to indicate failure states,
 or HTTP errors. An example use of the HTTP exceptions could be rendering 404
 pages for items that have not been found::
 
-    use Cake\Network\Exception\NotFoundException;
-    
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
+
     public function view($id = null)
     {
         $article = $this->Articles->findById($id)->first();
@@ -380,8 +381,9 @@ Using HTTP Exceptions in your Controllers
 You can throw any of the HTTP related exceptions from your controller actions
 to indicate failure states. For example::
 
-    use Cake\Network\Exception\NotFoundException;
-    
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
+
     public function view($id = null)
     {
         $article = $this->Articles->findById($id)->first();

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -339,7 +339,8 @@ it::
 
     namespace App\Controller;
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
     {

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -194,7 +194,9 @@ mappings in your controller::
     namespace App\Controller;
 
     use App\Controller\AppController;
-    use Cake\Network\Exception\NotFoundException;
+
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class VideosController extends AppController
     {

--- a/es/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/es/tutorials-and-examples/blog-auth-example/auth.rst
@@ -52,7 +52,8 @@ También vamos a crear UsersController; el siguiente contenido fue generado usan
 
     use App\Controller\AppController;
     use Cake\Event\Event;
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class UsersController extends AppController
     {

--- a/es/tutorials-and-examples/blog/part-three.rst
+++ b/es/tutorials-and-examples/blog/part-three.rst
@@ -233,7 +233,8 @@ Esto nos permitirá elegir una categoría para un Article al momento de crearlo 
 
     namespace App\Controller;
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
     {

--- a/fr/controllers/components/pagination.rst
+++ b/fr/controllers/components/pagination.rst
@@ -290,7 +290,8 @@ Ainsi vous pouvez soit laisser s'afficher la page d'erreur normale, soit
 utiliser un bloc try catch et faire des actions appropriées quand une
 ``NotFoundException`` est attrapée::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     public function index()
     {

--- a/fr/development/configuration.rst
+++ b/fr/development/configuration.rst
@@ -593,7 +593,8 @@ générique plutôt que la vraie classe du Model::
 
     // Dans votre fichier bootstrap.php
     use Cake\Event\EventManager;
-    use Cake\Network\Exception\InternalErrorException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\InternalErrorException;
 
     $isCakeBakeShellRunning = (PHP_SAPI === 'cli' && isset($argv[1]) && $argv[1] === 'bake');
     if (!$isCakeBakeShellRunning) {

--- a/fr/development/errors.rst
+++ b/fr/development/errors.rst
@@ -122,7 +122,7 @@ la surcharger comme ceci::
         }
     }
 
-.. php:namespace:: Cake\Network\Exception
+.. php:namespace:: Cake\Http\Exception
 
 Classes des Exceptions
 ======================
@@ -215,7 +215,8 @@ les états d'échecs, ou les erreurs HTTP. Un exemple d'utilisation des
 exceptions HTTP pourrait être le rendu de pages 404 pour les items qui n'ont
 pas été trouvés::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     public function view($id = null)
     {
@@ -386,7 +387,8 @@ Utiliser les Exceptions HTTP dans vos Controllers
 Vous pouvez envoyer n'importe quelle exception HTTP liée à partir des actions
 de votre controller pour indiquer les états d'échec. Par exemple::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Http\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     public function view($id = null)
     {

--- a/fr/tutorials-and-examples/blog/part-three.rst
+++ b/fr/tutorials-and-examples/blog/part-three.rst
@@ -350,7 +350,8 @@ lorsque l'on va le créer ou le modifier::
 
     namespace App\Controller;
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
     {

--- a/fr/views/json-and-xml-views.rst
+++ b/fr/views/json-and-xml-views.rst
@@ -204,7 +204,8 @@ gérer les mappings de vue dans votre controller::
     namespace App\Controller;
 
     use App\Controller\AppController;
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class VideosController extends AppController
     {

--- a/ja/controllers/components/pagination.rst
+++ b/ja/controllers/components/pagination.rst
@@ -274,7 +274,8 @@ CakePHP は、デフォルトでは取得できる行数の上限は 100 に設�
 従って、 ``NotFoundException`` が返されたときは、通常のエラーページが表示されるようにしたり、
 try-catch 構文を活用して、適切な処理をすればよいです。 ::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     public function index()
     {

--- a/ja/development/configuration.rst
+++ b/ja/development/configuration.rst
@@ -532,7 +532,8 @@ CakePHP が固有のクラスを使用する代わりに、暗黙的に汎用的
 
     // bootstrap.php の中で
     use Cake\Event\EventManager;
-    use Cake\Network\Exception\InternalErrorException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\InternalErrorException;
 
     $isCakeBakeShellRunning = (PHP_SAPI === 'cli' && isset($argv[1]) && $argv[1] === 'bake');
     if (!$isCakeBakeShellRunning) {

--- a/ja/development/errors.rst
+++ b/ja/development/errors.rst
@@ -107,7 +107,7 @@ CakePHP はエラーが起きるとそれを表示しまたはログに記録す
         }
     }
 
-.. php:namespace:: Cake\Network\Exception
+.. php:namespace:: Cake\Http\Exception
 
 例外クラス
 ==========
@@ -200,7 +200,8 @@ HTTP 5xx エラーステータスコードの詳細は :rfc:`2616#section-10.5` 
 失敗の状態や HTTP エラーを示すためにあなたのコントローラーからこれらの例外を投げることができます。
 HTTP の例外の使用例はアイテムが見つからなかった場合に 404 ページを描画することでしょう。 ::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
     
     public function view($id = null)
     {
@@ -368,7 +369,8 @@ RFC2616 MethodNotAllowedException は言っています。 ::
 失敗の状態を示すためにあたなのコントローラーのアクションからあらゆる HTTP 関連の例外を投げることができます。
 たとえば::
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
     
     public function view($id = null)
     {

--- a/ja/tutorials-and-examples/blog/part-three.rst
+++ b/ja/tutorials-and-examples/blog/part-three.rst
@@ -334,7 +334,8 @@ Articles コントローラーを編集する
 
     namespace App\Controller;
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
     {

--- a/ja/views/json-and-xml-views.rst
+++ b/ja/views/json-and-xml-views.rst
@@ -189,7 +189,8 @@ JSONP レスポンスの返すことが出来ます。これに ``true`` を設�
     namespace App\Controller;
 
     use App\Controller\AppController;
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class VideosController extends AppController
     {

--- a/pt/development/configuration.rst
+++ b/pt/development/configuration.rst
@@ -644,7 +644,8 @@ assim::
 
     // No seu bootstrap.php
     use Cake\Event\EventManager;
-    use Cake\Network\Exception\InternalErrorException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\InternalErrorException;
 
     $isCakeBakeShellRunning = (PHP_SAPI === 'cli' && isset($argv[1]) && $argv[1] === 'bake');
     if (!$isCakeBakeShellRunning) {

--- a/pt/tutorials-and-examples/blog/part-three.rst
+++ b/pt/tutorials-and-examples/blog/part-three.rst
@@ -342,7 +342,8 @@ ele:
     // src/Controller/ArticlesController.php
     namespace App\Controller;
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
     {

--- a/ru/tutorials-and-examples/blog/part-three.rst
+++ b/ru/tutorials-and-examples/blog/part-three.rst
@@ -345,7 +345,8 @@ Bake создал все необходимве файлы с нужным со�
 
     namespace App\Controller;
 
-    use Cake\Network\Exception\NotFoundException;
+    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
+    use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
     {


### PR DESCRIPTION
I've updated usage of http exception to reflect new classnames. I could use some help on the translations.

Refs cakephp/cakephp#11464