### PR TITLE
Clarifications on callback method

### DIFF
--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -101,6 +101,9 @@ a callback method. This callable must return the count value to be stored::
         ]
     ]);
 
+It may also return a Query object that produces the count value and will be used
+as a subquery in the update statement. The ``$table`` parameter refers to the
+table object holding the behavior (not the target relation) for convenience.
 
 .. note::
 


### PR DESCRIPTION
As in `CounterCacheBehaviorTest::testLambdaSubquery()`, the return value actually does not _need_ to be a 'count value'.
Added a note about the $table parameter as well.