### PR TITLE
Update installation.rst to include IIS URL Rewrite rul for font direc…

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -536,7 +536,7 @@ these steps:
                     </rule>
                     <rule name="Rewrite routed access to assets(img, css, files, js, favicon)"
                       stopProcessing="true">
-                        <match url="^(img|css|files|js|favicon.ico)(.*)$" />
+                        <match url="^(font|img|css|files|js|favicon.ico)(.*)$" />
                         <action type="Rewrite" url="webroot/{R:1}{R:2}"
                           appendQueryString="false" />
                     </rule>


### PR DESCRIPTION
The IIS URL Rewrite rules don't allow the things in the webroot/font directory to be surfaced correctly.