### PR TITLE
Update testing.rst - incomplete translation...

### DIFF
--- a/ru/development/testing.rst
+++ b/ru/development/testing.rst
@@ -21,6 +21,11 @@ Testing Actions That Require Authentication
 Testing Events
 ==============
 
+.. _running-tests:
+
+Running Tests
+=============
+
 .. meta::
     :title lang=ru: Testing
     :keywords lang=ru: phpunit,test database,database configuration,database setup,database test,public test,test framework,running one,test setup,de facto standard,pear,runners,array,databases,cakephp,php,integration


### PR DESCRIPTION
Incomplete translation testing.rst to suppress errors. It is necessary to pass the test for the translated code.rst into ru (https://github.com/cakephp/docs/pull/5454)