### PR TITLE
CMS Tutorial - Delete unnecessary codes

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -279,12 +279,6 @@ Next we'll update the ``edit`` action. Replace the edit method with the followin
             }
             $this->Flash->error(__('Unable to update your article.'));
         }
-
-        // Get a list of tags.
-        $tags = $this->Articles->Tags->find('list');
-
-        // Set article & tags to the view context
-        $this->set('tags', $tags);
         $this->set('article', $article);
     }
 


### PR DESCRIPTION
The list of tags becomes unnecessary after [Improving the Tagging Experience](https://book.cakephp.org/3.0/en/tutorials-and-examples/cms/tags-and-users.html#improving-the-tagging-experience).
Since has been deleted from the add action, it has been deleted from the edit action.