### PR TITLE
Clarified the language

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -1146,7 +1146,7 @@ many rows at once, by assigning the new field values, and conditions for the upd
         $this->updateAll(
             [  // fields
                 'published' => true,
-                'publish_date' => new Chronos()
+                'publish_date' => FrozenTime::now()
             ],
             [  // conditions
                 'published' => false

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -1138,14 +1138,19 @@ Bulk Updates
 
 There may be times when updating rows individually is not efficient or
 necessary. In these cases it is more efficient to use a bulk-update to modify
-many rows at once::
+many rows at once, by assigning the new field values, and conditions for the update::
 
     // Publish all the unpublished articles.
     function publishAllUnpublished()
     {
         $this->updateAll(
-            ['published' => true], // fields
-            ['published' => false] // conditions
+            [  // fields
+                'published' => true,
+                'publish_date' => new Chronos()
+            ],
+            [  // conditions
+                'published' => false
+            ]
         );
     }
 


### PR DESCRIPTION
I found the use of the same field name and value in both the fields array and conditions array confusing. I have sought to improve this by clarifying that the fields are an array of `'field' => $newValue` and the conditions are an ORM conditions array.