### PR TITLE
Return types for custom validation

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -302,6 +302,9 @@ Then ensure that your validation method has the second context parameter. ::
     {
         $userid = $context['providers']['passed']['userid'];
     }
+    
+Closures should return boolean true if the validation passes. If it fails, return boolean false or for a custom error message return a string.
+
 
 Conditional Validation
 ----------------------


### PR DESCRIPTION
I wanted to capture that if you return a string in your closure that becomes your validation message. It wasn't documented. Took me a good while to find in the code. Hope this helps others who are looking to provide a more context specific error message.