### PR TITLE
Párrafo repetido. (Deleting a repeated paragraph)

### DIFF
--- a/es/tutorials-and-examples/blog/blog.rst
+++ b/es/tutorials-and-examples/blog/blog.rst
@@ -142,11 +142,6 @@ para más información, pero basta decir que nombrando nuestra tabla 'articles'
 automáticamente lo vincula a nuestro modelo Articles y que campos
 llamados `modified` y `created` serán gestionados automáticamente por CakePHP.
 
-Al llamar 'articles' a nuestra tabla de artículos, estamos diciendo a CakePHP
-que vincule esta tabla por defecto al Modelo 'Articles', e incluiya los campos
-'modified' y 'created' con ese nombre, los cuáles serán automáticamente
-administrados por CakePHP.
-
 Configurando la Base de Datos
 =============================
 


### PR DESCRIPTION
Borrado de un párrafo repetido. Estos eran los párrafos, se ha borrado el segundo: 

Echa un vistazo a :doc:`las convencionnes </intro/conventions>` para más información, pero basta decir que nombrando nuestra tabla 'articles' automáticamente lo vincula a nuestro modelo Articles y que campos llamados modified y created serán gestionados automáticamente por CakePHP.

Al llamar 'articles' a nuestra tabla de artículos, estamos diciendo a CakePHP que vincule esta tabla por defecto al Modelo 'Articles', e incluiya los campos 'modified' y 'created' con ese nombre, los cuáles serán automáticamente administrados por CakePHP.