### PR TITLE
Added a link for regular cookies as well as encrypted ones

### DIFF
--- a/en/controllers/components/cookie.rst
+++ b/en/controllers/components/cookie.rst
@@ -11,8 +11,8 @@ Cookies added through CookieComponent will only be sent if the controller action
 completes.
 
 .. deprecated:: 3.5.0
-    You should use :ref:`encrypted-cookie-middleware` instead of
-    ``CookieComponent``.
+    Cookies are available in the ``ServerRequest`` see :ref:`request-cookies`.
+    For encrypted cookies see the :ref:`encrypted-cookie-middleware`.
 
 Configuring Cookies
 ===================


### PR DESCRIPTION
I had no idea that Cookies were now part of the Request instance, and this part of the docs lead me to believe that I had to encrypt my cookies, when really all I wanted was to read them.

Hopefully this edit will go some way to clarifying the two use-cases for the Cookies.