### PR TITLE
Add parent method calls.

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -362,6 +362,7 @@ like::
     namespace ContactManager;
 
     use Cake\Core\BasePlugin;
+    use Cake\Core\PluginApplicationInterface;
 
     class Plugin extends BasePlugin
     {
@@ -377,16 +378,18 @@ like::
             return $commands;
         }
 
-        public function bootstrap()
-        {
+        public function bootstrap(PluginApplicationInterface $app)
+        {         
             // Add constants, load configuration defaults. 
             // By default will load `config/bootstrap.php` in the plugin.
+            parent::bootstrap($app);
         }
 
         public function routes($routes)
         {
-            // Add routes. By default will load `config/routes.php` in
-            // the plugin.
+            // Add routes.
+            // By default will load `config/routes.php` in the plugin.
+            parent::routes($routes);
         }
     }
 


### PR DESCRIPTION
Without them newbies might copy / paste the example and keep scratching their
heads as to why boostrap and/or routes file are not loaded by default as
the comments claim.