### PR TITLE
Deprecation docs for QueryTrait mapReduce and formatResults.

### DIFF
--- a/en/appendices/3-6-migration-guide.rst
+++ b/en/appendices/3-6-migration-guide.rst
@@ -45,6 +45,10 @@ features will continue to function until 4.0.0 after which they will be removed.
   ``Cake\ORM\Locator\LocatorAwareTrait``.
 * ``Cake\View\Helper\FormHelper::widgetRegistry()`` is deprecated. Use
   ``getWidgetLocator()`` and ``setWidgetLocator()`` instead.
+* The getter part of ``Cake\Datasource\QueryTrait::formatResults()`` is deprecated. Use
+  ``getResultFormatters()`` instead.
+* The getter part of ``Cake\Datasource\QueryTrait::mapReduce()`` is deprecated. Use
+  ``getMapReducers()`` instead.
 
 Several classes were *renamed*. Their old names will continue to work until 4.0,
 but will emit deprecation warnings:


### PR DESCRIPTION
Docs for https://github.com/cakephp/cakephp/pull/11821