### PR TITLE
inaccuracy in the documentation in time.rst [Eng]

### DIFF
--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -120,7 +120,7 @@ It is also allowed to directly assign those properties to modify the date::
     $time->timezone = 'Europe/Paris';
     
 .. note::
-    Starting with version 3.5, $now->timezone returned the object(DateTimeZone) 
+    Starting with version 3.4, $now->timezone returned the object(DateTimeZone) 
 
 Formatting
 ==========

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -118,6 +118,9 @@ It is also allowed to directly assign those properties to modify the date::
 
     $time->year = 2015;
     $time->timezone = 'Europe/Paris';
+    
+.. note::
+    Starting with version 3.5, $now->timezone returned the object(DateTimeZone) 
 
 Formatting
 ==========


### PR DESCRIPTION
inaccuracy in the documentation in time.rst [Eng]. 
$now = Time::now();
debug($now->timezone); // will return an object: object(DateTimeZone)

(only I'm not sure about the version with which it was changed, but in version 3.5 exactly this result)