### PR TITLE
modify: Folder::inPath() description.

### DIFF
--- a/en/core-libraries/file-folder.rst
+++ b/en/core-libraries/file-folder.rst
@@ -205,10 +205,10 @@ Folder API
 
         $Folder = new Folder(WWW_ROOT);
         $result = $Folder->inPath(APP);
-        // $result = true, /var/www/example/ is in /var/www/example/webroot/
+        // $result = false, /var/www/example/src/ is not in /var/www/example/webroot/
 
         $result = $Folder->inPath(WWW_ROOT . 'img' . DS, true);
-        // $result = true, /var/www/example/webroot/ is in /var/www/example/webroot/img/
+        // $result = true, /var/www/example/webroot/img/ is in /var/www/example/webroot/
 
 .. php:staticmethod:: isAbsolute(string $path)
 


### PR DESCRIPTION
Folder::inPath() description writing reverse meant.