### PR TITLE
setErrors doesn't have to be defined anymore

### DIFF
--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -165,6 +165,10 @@ invalidate the fields accordingly to the feedback from the remote server::
         $this->_errors = $errors;
     }
 
+.. versionchanged:: 3.5.1
+    You are not required to specify a ``setErrors`` function yourself as this 
+    has already been defined in the ``Form`` object for your convenience.
+
 According to how the validator class would have returned the errors, ``$errors``
 must be in this format::
 

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -166,8 +166,8 @@ invalidate the fields accordingly to the feedback from the remote server::
     }
 
 .. versionchanged:: 3.5.1
-    You are not required to specify a ``setErrors`` function yourself as this 
-    has already been defined in the ``Form`` object for your convenience.
+    You are not required to specify ``setErrors`` anymore as this has
+    already been included in the ``Form`` class for your convenience.
 
 According to how the validator class would have returned the errors, ``$errors``
 must be in this format::


### PR DESCRIPTION
Ref: [#11109](https://github.com/cakephp/cakephp/pull/11109)