### PR TITLE
Update email.rst (it is necessary to remove the clarification)

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -433,7 +433,7 @@ Relaxing Address Validation Rules
 
 If you are having validation issues when sending to non-compliant addresses, you
 can relax the pattern used to validate email addresses. This is sometimes
-necessary when dealing with some Japanese ISP's::
+necessary when dealing with some ISP's::
 
     $email = new Email('default');
 


### PR DESCRIPTION
I consider that it is necessary either to remove the mention of only one language or to add a mention of Russian language, because when using Russian (**Cyrillic**) mail, there are the same problems with validation.
For example email: **пример@письмапрезиденту.рф**