### PR TITLE
take type of exception into account

### DIFF
--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -198,9 +198,13 @@ require secure SSL requests::
             }
         }
 
-        public function forceSSL()
+        public function forceSSL($error = '', SecurityException $exception = null)
         {
-            return $this->redirect('https://' . env('SERVER_NAME') . $this->request->getRequestTarget());
+            if ($exception instanceof SecurityException && $exception->getType() === 'secure') {
+                return $this->redirect('https://' . env('SERVER_NAME') . $this->request->getRequestTarget());
+            } else {
+                throw $exception;
+            }
         }
     }
 


### PR DESCRIPTION
for now forceSSL is redirecting no matter of the error type (form tampering etc.)
it's hard to find other errors otherwise!