### PR TITLE
Fix wrong name on function

### DIFF
--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -35,7 +35,7 @@ a simple contact form would look like::
                 ->addField('body', ['type' => 'text']);
         }
 
-        public function validationDefault(Validator $validator)
+        protected function _buildValidator(Validator $validator)
         {
             $validator->add('name', 'length', [
                     'rule' => ['minLength', 10],


### PR DESCRIPTION
In order to make the default validator works in CakePHP 3.7, the name of the function should be _buildValidator instead of validationDefault