### PR TITLE
Added note about adding multiple commands that share a class

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -141,6 +141,11 @@ In the above example, the only commands available would be ``help``, ``version``
 and ``user``. See the :ref:`plugin-commands` section for how to add commands in
 your plugins.
 
+.. note::
+
+    When adding multiple commands that use the same Command class, the ``help``
+    command will display the shortest option.
+
 .. versionadded:: 3.5.0
     The ``console`` hook was added.
 


### PR DESCRIPTION
Spent a bit of time discussing this in #support before discovering this was the intended behavior.