### PR TITLE
Code error in Route Options Example

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -452,7 +452,7 @@ of ``connect()``::
 
     $routes->connect(
         '/:lang/articles/:slug',
-        ['controller' => 'Articles', 'action' => 'view'],
+        ['controller' => 'Articles', 'action' => 'view']
     )
     // Allow GET and POST requests.
     ->setMethods(['GET', 'POST'])


### PR DESCRIPTION
There is a trailing comma in $routes->connect('/:lang/articles/:slug', ['controller' => 'Articles', 'action' => 'view'],) which would lead to an error. The comma is removed in this proposed change.