### PR TITLE
Fix example.

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -115,7 +115,7 @@ application's ``bootstrap()`` function::
             $this->addPlugin(ContactManager::class);
 
             // Load a plugin with a vendor namespace by 'short name'
-            $this->addPlugin('AcmeCorp\ContactManager');
+            $this->addPlugin('AcmeCorp/ContactManager');
         }
     }
 


### PR DESCRIPTION
Plugin short names use forward slash not back slash.