### PR TITLE
Correct the count of exception handling ways

### DIFF
--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -51,7 +51,7 @@ message, file and line (``debug`` enabled).
 Changing Exception Handling
 ===========================
 
-Exception handling offers 3 ways to tailor how exceptions are handled.  Each
+Exception handling offers 4 ways to tailor how exceptions are handled.  Each
 approach gives you different amounts of control over the exception handling
 process.
 

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -51,7 +51,7 @@ message, file and line (``debug`` enabled).
 Changing Exception Handling
 ===========================
 
-Exception handling offers 4 ways to tailor how exceptions are handled.  Each
+Exception handling offers several ways to tailor how exceptions are handled.  Each
 approach gives you different amounts of control over the exception handling
 process.
 


### PR DESCRIPTION
The paragraph in "Changing Exception Handling" says "3 ways", but the list under it shows 4 ways.