### PR TITLE
4.x folder

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -17,7 +17,8 @@ Deprecated Features Removed
 All methods, properties and functionality that was emitting deprecation warnings
 as of 3.6 have been removed.
 
-The former RssHelper can be found as standalone [Feed](https://github.com/dereuromark/cakephp-feed) plugin with similar functionality.
+Authentication functionality has been splitted into standalone plugins `Authentication <https://github.com/cakephp/authentication>`__ and `Authorization <https://github.com/cakephp/authorization>`__.
+The former RssHelper can be found as standalone `Feed plugin <https://github.com/dereuromark/cakephp-feed>`__ with similar functionality.
 
 Breaking Changes
 ================

--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -17,7 +17,7 @@ Deprecated Features Removed
 All methods, properties and functionality that was emitting deprecation warnings
 as of 3.6 have been removed.
 
-The former Rss helper can be found as standalone [Feed](https://github.com/dereuromark/cakephp-feed) plugin with similar functionality.
+The former RssHelper can be found as standalone [Feed](https://github.com/dereuromark/cakephp-feed) plugin with similar functionality.
 
 Breaking Changes
 ================

--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -17,6 +17,8 @@ Deprecated Features Removed
 All methods, properties and functionality that was emitting deprecation warnings
 as of 3.6 have been removed.
 
+The former Rss helper can be found as standalone [Feed](https://github.com/dereuromark/cakephp-feed) plugin with similar functionality.
+
 Breaking Changes
 ================
 
@@ -43,6 +45,9 @@ changes made:
   'model' is the second argument.
 * ``Cake\Utility\Xml::fromArray()`` now requires an array for the ``$options``
   parameter.
+* ``Cake\Filesystem\Folder::copy($to, array $options = [])`` and
+  ``Cake\Filesystem\Folder::move($to, array $options = [])`` have now the target
+  path extracted as first argument.
 
 
 New Features


### PR DESCRIPTION
Docs for https://github.com/cakephp/cakephp/pull/12232

also included a note about migration path of auth and RSS functionality.