### PR TITLE
Update lire les en-têtes PHP

### DIFF
--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -367,7 +367,7 @@ l'en-tête ``Allow`` nécessaire avec les méthodes passées::
         ...
     }
 
-Lire les En-têtes HTTP
+Lire les en-têtes HTTP
 ----------------------
 
 Ces méthodes vous permettent d'accéder à n'importe quel en-tête ``HTTP_*`` qui
@@ -377,7 +377,7 @@ ont été utilisés dans la requête. Par exemple::
     $userAgent = $this->request->getHeaderLine('User-Agent');
 
     // Récupère un tableau de toutes les valeurs
-    $acceptHeader = $this->request->getHeader('Accept');
+    $acceptHeader = $this->request->getHeaders();
 
     // Vérifie l'existence d'un header
     $hasAcceptHeader = $this->request->hasHeader('Accept');


### PR DESCRIPTION
getHeader('Accept') only return the value with the Accept key, to return all values in array, must use getHeaders()