### PR TITLE
Update code examples

### DIFF
--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -961,7 +961,8 @@ In your migration file, you can do the following::
     public function up()
     {
         $this->table('old_table_name')
-            ->rename('new_table_name');
+            ->rename('new_table_name')
+            ->save();
     }
 
 Skipping the ``schema.lock`` file generation

--- a/en/phinx/migrations.rst
+++ b/en/phinx/migrations.rst
@@ -633,7 +633,8 @@ To rename a table access an instance of the Table object then call the
         public function up()
         {
             $table = $this->table('users');
-            $table->rename('legacy_users');
+            $table->rename('legacy_users')
+                  ->save();
         }
 
         /**
@@ -642,7 +643,8 @@ To rename a table access an instance of the Table object then call the
         public function down()
         {
             $table = $this->table('legacy_users');
-            $table->rename('users');
+            $table->rename('users')
+                  ->save();
         }
     }
 
@@ -1126,10 +1128,12 @@ call this method for each index::
         public function up()
         {
             $table = $this->table('users');
-            $table->removeIndex(['email']);
+            $table->removeIndex(['email'])
+                  ->save();
 
             // alternatively, you can delete an index by its name, ie:
-            $table->removeIndexByName('idx_users_email');
+            $table->removeIndexByName('idx_users_email')
+                  ->save();
         }
 
         /**
@@ -1140,11 +1144,6 @@ call this method for each index::
 
         }
     }
-
-.. note::
-
-    There is no need to call the ``save()`` method when using
-    ``removeIndex()``. The index will be removed immediately.
 
 Working With Foreign Keys
 -------------------------


### PR DESCRIPTION
Update for Phinx 0.10.3 and Migrations 2.0.0. I didn't leave old ways. Since `rename()`, `removeIndex()` and `removeIndexByName()` returns `$this` also in the legacy versions, I think there aren't side-effects of calling `save()`.