### PR TITLE
[ja]Restore quote style to English.

### DIFF
--- a/ja/docutils.conf
+++ b/ja/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smartquotes_locales: ja: “”‘’


### PR DESCRIPTION
After upgrading Sphinx, quotation marks are now converted to language-specific styles. However in Japanese, I think that quotation marks in English style match when surrounding English words. Also, if necessary, we will already use "「", "」" at the time of translation, so I propose converting to English style.

## Before

https://book.cakephp.org/3.0/ja/intro/conventions.html#id6

<img width="426" alt="2018-07-13 1 46 51" src="https://user-images.githubusercontent.com/16202/42648405-c572a7e6-8641-11e8-98ba-e866e15d6bbf.png">


## After

<img width="486" alt="2018-07-13 1 46 28" src="https://user-images.githubusercontent.com/16202/42648409-ca0c57b6-8641-11e8-88d2-2dfe88d46084.png">
