### PR TITLE
CacheEngine::write() param list fix

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -559,7 +559,7 @@ The required API for a CacheEngine is
 
     The base class for all cache engines used with Cache.
 
-.. php:method:: write($key, $value, $config = 'default')
+.. php:method:: write($key, $value)
 
     :return: boolean for success.
 


### PR DESCRIPTION
CacheEnging::write() does not define optional $config parameter, removed from docs.