### PR TITLE
Added a section about using Collections to build select options

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1033,7 +1033,7 @@ You can use the ``combine`` method to build a basic options array.
     $options = $entitiesArray->combine('id', 'name');
 
 It's also possible to add extra attributes by expanding the array. The following will create a data attribute on the
-option element.
+option element, using the ``map`` collection method.
 
     $options = $entitiesArray->map(function ($value, $key) {
         return [

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1035,7 +1035,7 @@ You can use the ``combine`` method to build a basic options array.
 It's also possible to add extra attributes by expanding the array. The following will create a data attribute on the
 option element, using the ``map`` collection method.
 
-    $options = $exampples->map(function ($value, $key) {
+    $options = $examples->map(function ($value, $key) {
         return [
             'value' => $value->id,
             'text' => $value->name,

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1030,12 +1030,12 @@ collection of entities and would like to build a select element from them.
 
 You can use the ``combine`` method to build a basic options array.
 
-    $options = $entitiesArray->combine('id', 'name');
+    $options = $examples->combine('id', 'name');
 
 It's also possible to add extra attributes by expanding the array. The following will create a data attribute on the
 option element, using the ``map`` collection method.
 
-    $options = $entitiesArray->map(function ($value, $key) {
+    $options = $exampples->map(function ($value, $key) {
         return [
             'value' => $value->id,
             'text' => $value->name,

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1028,12 +1028,12 @@ Using Collections to build options
 It's possible to use the Collection class to build your options array. This approach is ideal if you already have a
 collection of entities and would like to build a select element from them.
 
-You can use the ``combine`` method to build a basic options array.
+You can use the ``combine`` method to build a basic options array.::
 
     $options = $examples->combine('id', 'name');
 
 It's also possible to add extra attributes by expanding the array. The following will create a data attribute on the
-option element, using the ``map`` collection method.
+option element, using the ``map`` collection method.::
 
     $options = $examples->map(function ($value, $key) {
         return [

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1022,6 +1022,27 @@ methods are described in each method's own section.)
           'hiddenField' => 'N',
       ]);
 
+Using Collections to build options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It's possible to use the Collection class to build your options array. This approach is ideal if you already have a
+collection of entities and would like to build a select element from them.
+
+You can use the ``combine`` method to build a basic options array.
+
+    $options = $entitiesArray->combine('id', 'name');
+
+It's also possible to add extra attributes by expanding the array. The following will create a data attribute on the
+option element.
+
+    $options = $entitiesArray->map(function ($value, $key) {
+        return [
+            'value' => $value->id,
+            'text' => $value->name,
+            'data-created' => $value->created
+        ];
+    });
+
 Creating Checkboxes
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Using the Collection classes power to create options for select elements is missing from the documentation.

This pull request also shows that you can add extra data to the array, to produce extra attributes in the option tags created by the helper.

I have been unable to check the rendering of this change, because I can't build the documentation locally. I don't have Docker installed, and the `make html` fails.