### PR TITLE
Update tutorials-and-examples.rst

### DIFF
--- a/en/tutorials-and-examples.rst
+++ b/en/tutorials-and-examples.rst
@@ -19,7 +19,7 @@ and components.
     tutorials-and-examples/cms/authentication
 
 .. toctree::
-    :hidden:
+    :maxdepth: 1
 
     tutorials-and-examples/bookmarks/intro
     tutorials-and-examples/bookmarks/part-two


### PR DESCRIPTION
The 'bookmarks' and 'blog' tutorials are orphaned and unavailable to users. This edit should make the list which contains them visible