### PR TITLE
missing save method around `removeColumn`

### DIFF
--- a/ja/migrations.rst
+++ b/ja/migrations.rst
@@ -376,7 +376,8 @@ fieldType の後のクエスチョンマークは、ヌルを許可するカラ�
         public function up()
         {
             $table = $this->table('products');
-            $table->removeColumn('price');
+            $table->removeColumn('price')
+                  ->save();
         }
     }
 


### PR DESCRIPTION
In English Document, `->save()` method was added on the example code, though not in Japanese one.
It causes `[RuntimeException] Migration has pending actions after execution!`, and should be modified.