### PR TITLE
Do not abbreviate parameters into params

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -211,7 +211,7 @@ Shell
 
 - ``Shell::__construct()`` has changed. It now takes an instance of
   :php:class:`Cake\\Console\\ConsoleIo`.
-- ``Shell::param()`` has been added as convenience access to the params.
+- ``Shell::param()`` has been added as convenience access to the parameters.
 
 Additionally all shell methods will be transformed to camel case when invoked.
 For example, if you had a ``hello_world()`` method inside a shell and invoked it

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -558,7 +558,7 @@ uses. Using ``flash`` config you can configure the parameters
 - ``key`` - The key to use, defaults to 'default'. Prior to 3.4.0, the key
   defaulted to 'auth'.
 - ``element`` - The element name to use for rendering, defaults to null.
-- ``params`` - The array of additional params to use, defaults to ``[]``.
+- ``params`` - The array of additional parameters to use, defaults to ``[]``.
 
 In addition to the flash message settings you can customize other error
 messages ``AuthComponent`` uses. In your controller's ``beforeFilter()``, or
@@ -1045,7 +1045,7 @@ flash
 
     - ``element`` - The element to use; defaults to 'default'.
     - ``key`` - The key to use; defaults to 'auth'.
-    - ``params`` - The array of additional params to use; defaults to '[]'.
+    - ``params`` - The array of additional parameters to use; defaults to '[]'.
 
 loginAction
     A URL (defined as a string or array) to the controller action that handles

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -48,7 +48,7 @@ The request exposes routing parameters through the ``getParam()`` method::
 
 To get all routing parameters as an array use ``getAttribute()``::
 
-    $params = $this->request->getAttribute('params');
+    $parameters = $this->request->getAttribute('params');
 
 All :ref:`route-elements` are accessed through this interface.
 
@@ -1087,4 +1087,4 @@ collection if you modify a cookie::
 
 .. meta::
     :title lang=en: Request and Response objects
-    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable
+    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -498,7 +498,7 @@ Removing Callbacks and Listeners
 
 If for any reason you want to remove any callback from the event manager just
 call the :php:meth:`Cake\\Event\\EventManager::off()` method using as
-arguments the first two params you used for attaching it::
+arguments the first two parameters you used for attaching it::
 
     // Attaching a function
     $this->getEventManager()->on('My.event', [$this, 'doSomething']);

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -1514,10 +1514,10 @@ allows you to prepare URLs before routing.
 
 Callback filter functions should expect the following parameters:
 
-- ``$params`` The URL params being processed.
+- ``$params`` The URL parameters being processed.
 - ``$request`` The current request.
 
-The URL filter function should *always* return the params even if unmodified.
+The URL filter function should *always* return the parameters even if unmodified.
 
 URL filters allow you to implement features like persistent parameters::
 

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -18,7 +18,7 @@ Since the ORM now returns Collections and Entities, debugging these objects can
 be more complicated than in previous CakePHP versions. There are now various
 ways to inspect the data returned by the ORM.
 
-- ``debug($query)`` Shows the SQL and bound params, does not show results.
+- ``debug($query)`` Shows the SQL and bound parameters, does not show results.
 - ``sql($query)`` Shows the final rendered SQL, but only when having DebugKit installed.
 - ``debug($query->all())`` Shows the ResultSet properties (not the results).
 - ``debug($query->toList())`` An easy way to show each of the results.

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -217,7 +217,7 @@ Supported options are:
   you wish.
 
 While this method allows a lot of customization for its output. It is
-also ok to just call the method without any params. ::
+also ok to just call the method without any parameters. ::
 
     echo $this->Paginator->numbers();
 

--- a/es/controllers/request-response.rst
+++ b/es/controllers/request-response.rst
@@ -17,4 +17,4 @@ Request
 
 .. meta::
     :title lang=es: Request and Response objects
-    :keywords lang=es: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp
+    :keywords lang=es: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp

--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -1127,4 +1127,4 @@ devoir mettre à jour la collection si vous modifiez un cookie::
 
 .. meta::
     :title lang=fr: Objets ServerRequest et Response
-    :keywords lang=fr: requête controller,paramètres de requête,tableaux indicés,purpose index,objets réponse,information domaine,Objet requête,donnée requêtée,interrogation,params,précédentes versions,introspection,dispatcher,rout,structures de données,tableaux,adresse ip,migration,indexes,cakephp
+    :keywords lang=fr: requête controller,paramètres de requête,tableaux indicés,purpose index,objets réponse,information domaine,Objet requête,donnée requêtée,interrogation,params,parameters,précédentes versions,introspection,dispatcher,rout,structures de données,tableaux,adresse ip,migration,indexes,cakephp

--- a/ja/controllers/request-response.rst
+++ b/ja/controllers/request-response.rst
@@ -1032,4 +1032,4 @@ CakePHP 3.4.0 以降、レスポンスオブジェクトはレスポンスを不
 
 .. meta::
     :title lang=ja: リクエストとレスポンスオブジェクト
-    :keywords lang=ja: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable
+    :keywords lang=ja: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable

--- a/pt/development/routing.rst
+++ b/pt/development/routing.rst
@@ -1419,10 +1419,10 @@ allows you to prepare URLs before routing.
 
 Callback filter functions should expect the following parameters:
 
-- ``$params`` The URL params being processed.
+- ``$params`` The URL parameters being processed.
 - ``$request`` The current request.
 
-The URL filter function should *always* return the params even if unmodified.
+The URL filter function should *always* return the parameters even if unmodified.
 
 URL filters allow you to implement features like persistent parameters::
 

--- a/ru/controllers/request-response.rst
+++ b/ru/controllers/request-response.rst
@@ -1074,4 +1074,4 @@ HTML-файлы в зависимости от браузера. В таких �
 
 .. meta::
     :title lang=ru: Объекты запроса и ответа
-    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable
+    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable

--- a/tl/controllers/components/authentication.rst
+++ b/tl/controllers/components/authentication.rst
@@ -553,7 +553,7 @@ uses. Using ``flash`` config you can configure the parameters
 - ``key`` - The key to use, defaults to 'default'. Prior to 3.4.0, the key
   defaulted to 'auth'.
 - ``element`` - The element name to use for rendering, defaults to null.
-- ``params`` - The array of additional params to use, defaults to ``[]``.
+- ``params`` - The array of additional parameters to use, defaults to ``[]``.
 
 In addition to the flash message settings you can customize other error
 messages ``AuthComponent`` uses. In your controller's ``beforeFilter()``, or
@@ -1040,7 +1040,7 @@ flash
 
     - ``element`` - The element to use; defaults to 'default'.
     - ``key`` - The key to use; defaults to 'auth'.
-    - ``params`` - The array of additional params to use; defaults to '[]'.
+    - ``params`` - The array of additional parameters to use; defaults to '[]'.
 
 loginAction
     A URL (defined as a string or array) to the controller action that handles

--- a/tl/controllers/request-response.rst
+++ b/tl/controllers/request-response.rst
@@ -1078,4 +1078,4 @@ collection if you modify a cookie::
 
 .. meta::
     :title lang=en: Request and Response objects
-    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable
+    :keywords lang=en: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp,PSR-7,immutable

--- a/tl/core-libraries/events.rst
+++ b/tl/core-libraries/events.rst
@@ -494,7 +494,7 @@ Removing Callbacks and Listeners
 
 If for any reason you want to remove any callback from the event manager just
 call the :php:meth:`Cake\\Event\\EventManager::off()` method using as
-arguments the first two params you used for attaching it::
+arguments the first two parameters you used for attaching it::
 
     // Attaching a function
     $this->eventManager()->on('My.event', [$this, 'doSomething']);

--- a/tl/development/routing.rst
+++ b/tl/development/routing.rst
@@ -1416,10 +1416,10 @@ allows you to prepare URLs before routing.
 
 Callback filter functions should expect the following parameters:
 
-- ``$params`` The URL params being processed.
+- ``$params`` The URL parameters being processed.
 - ``$request`` The current request.
 
-The URL filter function should *always* return the params even if unmodified.
+The URL filter function should *always* return the parameters even if unmodified.
 
 URL filters allow you to implement features like persistent parameters::
 

--- a/tl/orm/retrieving-data-and-resultsets.rst
+++ b/tl/orm/retrieving-data-and-resultsets.rst
@@ -18,7 +18,7 @@ Since the ORM now returns Collections and Entities, debugging these objects can
 be more complicated than in previous CakePHP versions. There are now various
 ways to inspect the data returned by the ORM.
 
-- ``debug($query)`` Shows the SQL and bound params, does not show results.
+- ``debug($query)`` Shows the SQL and bound parameters, does not show results.
 - ``debug($query->all())`` Shows the ResultSet properties (not the results).
 - ``debug($query->toArray())`` An easy way to show each of the results.
 - ``debug(iterator_to_array($query))`` Shows query results in an array format.

--- a/tl/views/helpers/paginator.rst
+++ b/tl/views/helpers/paginator.rst
@@ -217,7 +217,7 @@ Supported options are:
   you wish.
 
 While this method allows a lot of customization for its output. It is
-also ok to just call the method without any params. ::
+also ok to just call the method without any parameters. ::
 
     echo $this->Paginator->numbers();
 

--- a/tl/views/helpers/url.rst
+++ b/tl/views/helpers/url.rst
@@ -49,7 +49,7 @@ URL (starting with '/') with the full base URL prepended::
     // Output
     http://somedomain.com/posts
 
-URL with GET params and fragment anchor::
+URL with GET parameters and fragment anchor::
 
     echo $this->Url->build([
         "controller" => "Posts",

--- a/tr/controllers/request-response.rst
+++ b/tr/controllers/request-response.rst
@@ -18,4 +18,4 @@ Request
 
 .. meta::
     :title lang=tr: Request and Response objects
-    :keywords lang=tr: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp
+    :keywords lang=tr: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp

--- a/zh/controllers/request-response.rst
+++ b/zh/controllers/request-response.rst
@@ -14,4 +14,4 @@ Request & Response Objects
 
 .. meta::
     :title lang=zh: Request and Response objects
-    :keywords lang=zh: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp
+    :keywords lang=zh: request controller,request parameters,array indexes,purpose index,response objects,domain information,request object,request data,interrogating,params,parameters,previous versions,introspection,dispatcher,rout,data structures,arrays,ip address,migration,indexes,cakephp


### PR DESCRIPTION
For a seasoned developer it's clear what "params" means, but not for everybody.
This improves the clarity for newbies.

We still use ``$params`` for a few methods or lambdas, though....