### PR TITLE
Update Adds Type Hinting Uniformly

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -559,12 +559,13 @@ Passing Conditions to Contain
 -----------------------------
 
 When using ``contain()`` you are able to restrict the data returned by the
-associations and filter them by conditions::
+associations and filter them by conditions. To specify conditions, pass an anonymous
+function that receives as the first argument a query object, ``\Cake\ORM\Query``::
 
     // In a controller or table method.
     // Prior to 3.5.0 you would use contain(['Comments' => function () { ... }])
 
-    $query = $articles->find()->contain('Comments', function ($q) {
+    $query = $articles->find()->contain('Comments', function (Query $q) {
         return $q
             ->select(['body', 'author_id'])
             ->where(['Comments.approved' => true]);
@@ -573,7 +574,7 @@ associations and filter them by conditions::
 This also works for pagination at the Controller level::
 
     $this->paginate['contain'] = [
-        'Comments' => function (\Cake\ORM\Query $query) {
+        'Comments' => function (Query $query) {
             return $query->select(['body', 'author_id'])
             ->where(['Comments.approved' => true]);
         }
@@ -590,7 +591,7 @@ notation::
 
     $query = $articles->find()->contain([
         'Comments',
-        'Authors.Profiles' => function ($q) {
+        'Authors.Profiles' => function (Query $q) {
             return $q->where(['Profiles.is_published' => true]);
         }
     ]);
@@ -602,7 +603,7 @@ finders in your associations, you can use them inside ``contain()``::
 
     // Bring all articles, but only bring the comments that are approved and
     // popular.
-    $query = $articles->find()->contain('Comments', function ($q) {
+    $query = $articles->find()->contain('Comments', function (Query $q) {
         return $q->find('approved')->find('popular');
     });
 
@@ -620,7 +621,7 @@ case you should use an array passing ``foreignKey`` and ``queryBuilder``::
     $query = $articles->find()->contain([
         'Authors' => [
             'foreignKey' => false,
-            'queryBuilder' => function ($q) {
+            'queryBuilder' => function (Query $q) {
                 return $q->where(...); // Full conditions for filtering
             }
         ]
@@ -643,7 +644,7 @@ Alternatively, if you have multiple associations, you can use ``enableAutoFields
     $query->select(['id', 'title'])
         ->contain(['Comments', 'Tags'])
         ->enableAutoFields(true) // Prior to 3.4.0 use autoFields(true)
-        ->contain(['Users' => function($q) {
+        ->contain(['Users' => function(Query $q) {
             return $q->autoFields(true);
         }]);
 


### PR DESCRIPTION
In the section "Passing Conditions" under Associations I added  some sections so that the type-hint Query would appear uniformly through the section.