### PR TITLE
added an example of read and write with config

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -337,6 +337,22 @@ For example::
     // Store data in cache
     Cache::write('cloud', $cloud);
     return $cloud;
+    
+Or if you are using another cache configuration called ``short``, you can
+specify it in ``Cache::read()`` and ``Cache::write()`` calls as below:
+    // read key cloud, but from short configuration instead of default
+    $cloud = Cache::read('cloud', 'short');
+
+    if ($cloud !== false) {
+        return $cloud;
+    }
+
+    // Generate cloud data
+    // ...
+
+    // Store data in cache, using short cache configuration instead of default
+    Cache::write('cloud', $cloud, 'short');
+    return $cloud;
 
 Reading Multiple Keys at Once
 -----------------------------

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -339,7 +339,8 @@ For example::
     return $cloud;
     
 Or if you are using another cache configuration called ``short``, you can
-specify it in ``Cache::read()`` and ``Cache::write()`` calls as below:
+specify it in ``Cache::read()`` and ``Cache::write()`` calls as below::
+
     // read key cloud, but from short configuration instead of default
     $cloud = Cache::read('cloud', 'short');
 


### PR DESCRIPTION
Even though it mentions a second parameter to read() and third parameter to write(), an example code with config was missing and it took me a while to notice that. So, I thought it might be useful to have same example with a different key