### PR TITLE
Clarify decimal type

### DIFF
--- a/en/phinx/migrations.rst
+++ b/en/phinx/migrations.rst
@@ -701,8 +701,8 @@ For ``decimal`` columns:
 ========= ===========
 Option    Description
 ========= ===========
-precision combine with ``scale`` set to set decimal accuracy
-scale     combine with ``precision`` to set decimal accuracy
+precision combine with ``scale`` set to set integer decimal accuracy
+scale     combine with ``precision`` to set fractional decimal accuracy
 signed    enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ========= ===========
 


### PR DESCRIPTION
This pull request aims to try and clarify the two different decimal parts, and what they are for. As precision refers to the whole integer part before the decimal point, and scale refers to the fractional part after the decimal point.

However this wasn't very clear, at least to me, from the way the documentation was worded.

Reference, https://math.stackexchange.com/questions/64042/what-are-the-numbers-before-and-after-the-decimal-point-referred-to-in-mathemati