### PR TITLE
Add use statement for core functions

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -63,6 +63,10 @@ You can use prepared statements to insert parameters::
 
 It is also possible to use complex data types as arguments::
 
+    use Cake\Datasource\ConnectionManager;
+    use DateTime;
+
+    $connection = ConnectionManager::get('default');
     $results = $connection
         ->execute(
             'SELECT * FROM articles WHERE created >= :created',
@@ -88,6 +92,7 @@ Running Insert Statements
 Inserting rows in the database is usually a matter of a couple lines::
 
     use Cake\Datasource\ConnectionManager;
+    use DateTime;
 
     $connection = ConnectionManager::get('default');
     $connection->insert('articles', [


### PR DESCRIPTION
Added use statements at the top of examples to guide reader to proper handling of core functions. I added a couple to the beginning of the document only as to not clutter up the entire page. Once they've done it a couple of times, they shouldn't need to keep seeing the guidance

Replaces PR #5877.