### PR TITLE
Add previous exception logging to migration guide

### DIFF
--- a/en/appendices/3-7-migration-guide.rst
+++ b/en/appendices/3-7-migration-guide.rst
@@ -153,6 +153,7 @@ Error
 * ``ExceptionRenderer`` will now look for prefixed error controllers when
   handling exceptions. This allows you to define custom error controller logic
   for each routing prefix in your application.
+* ``ErrorHandlerMiddleware`` will now include previous exceptions in logging.
 
 Filesystem
 ----------


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/12673