### PR TITLE
Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -399,6 +399,14 @@ If you need to modify the results after they have been fetched you should use
 a :ref:`map-reduce` function to modify the results. The map reduce features
 replace the 'afterFind' callback found in previous versions of CakePHP.
 
+.. note::
+
+    Passing arguements exposed in the **config** array, 
+    ``$products->find('sizes', ['large', 'medium'])`` 
+    can give unpredictable results when chaining 
+    custom finders. Always pass them in an associative array, 
+    ``$products->find('sizes', ['values' => ['large', 'medium']])``
+
 .. _dynamic-finders:
 
 Dynamic Finders

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -401,7 +401,7 @@ replace the 'afterFind' callback found in previous versions of CakePHP.
 
 .. note::
 
-    Passing arguements exposed in the **config** array, 
+    Passing arguments exposed in the **config** array, 
     ``$products->find('sizes', ['large', 'medium'])`` 
     can give unpredictable results when chaining 
     custom finders. Always pass them in an associative array, 

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -404,7 +404,7 @@ replace the 'afterFind' callback found in previous versions of CakePHP.
     Passing arguments exposed in the **config** array, 
     ``$products->find('sizes', ['large', 'medium'])`` 
     can give unpredictable results when chaining 
-    custom finders. Always pass them in an associative array, 
+    custom finders. Always pass options as an associative array, 
     ``$products->find('sizes', ['values' => ['large', 'medium']])``
 
 .. _dynamic-finders:

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -403,7 +403,7 @@ replace the 'afterFind' callback found in previous versions of CakePHP.
 
     Passing arguments exposed in the **config** array, 
     ``$products->find('sizes', ['large', 'medium'])`` 
-    can give unpredictable results when chaining 
+    can give unexpected results when chaining 
     custom finders. Always pass options as an associative array, 
     ``$products->find('sizes', ['values' => ['large', 'medium']])``
 


### PR DESCRIPTION
Since it's been argued that `Issue 12690 <https://github.com/cakephp/cakephp/issues/12690>` is an issue of method misuse rather than a bug, it might be helpful to make proper use of the second parameter in custom finders more explicit.
