### PR TITLE
Add call to parent beforeFilter()

### DIFF
--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -57,6 +57,8 @@ works::
 
     public function beforeFilter(Event $event)
     {
+        parent::beforeFilter($event);
+        
         $this->Security->setConfig('blackHoleCallback', 'blackhole');
     }
 
@@ -169,6 +171,8 @@ want and the Security Component will enforce them on its startup::
 
         public function beforeFilter(Event $event)
         {
+            parent::beforeFilter($event);
+
             if ($this->request->getParam('admin')) {
                 $this->Security->requireSecure();
             }
@@ -193,6 +197,8 @@ require secure SSL requests::
 
         public function beforeFilter(Event $event)
         {
+            parent::beforeFilter($event);
+
             if ($this->request->getParam('admin')) {
                 $this->Security->requireSecure();
             }
@@ -252,7 +258,10 @@ There may be cases where you want to disable all security checks for an action
 
         public function beforeFilter(Event $event)
         {
-             $this->Security->setConfig('unlockedActions', ['edit']);
+            parent::beforeFilter($event);
+            parent::beforeFilter($event);
+
+            $this->Security->setConfig('unlockedActions', ['edit']);
         }
     }
 


### PR DESCRIPTION
If folks simply copy & paste this, they could end up breaking their app because the ``beforeFilter()`` method of the super classes of their controllers won't get called anymore.