### PR TITLE
Added a note to save others the same bad experiance

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -306,6 +306,14 @@ stopping this event you will abort the delete operation. When the event is stopp
 of the event will be returned.
 How to stop an event is documented :ref:`here <stopping-events>`.
 
+.. note::
+
+    If you are using the TreeBehavior, beforeDelete without any further configuration of priorites is 
+    called after the beforeDelete from TreeBehavior, which deletes all children. If you desire to work
+    with the children in a beforeDelete Event, use the Eventmanager, add a listener and assign a priority 
+    lower than 10.
+
+
 afterDelete
 -----------
 


### PR DESCRIPTION
TreeBehavior has a beforeDelete, so making your beforeDelte to work wirk children in the table might end up you up working wirth the next root-nodes in the mptt-tree.