### PR TITLE
4.x remove invalid text about return values

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -106,7 +106,6 @@ Miscellaneous
 -------------
 
 * Locale files have been moved from ``src/Locale`` to ``resources/locales``.
-* Return values of ``string|bool`` are now ``string|null`` across the framework.
 * The ``cacert.pem`` file that was bundled in CakePHP has been replaced by
   a dependency on `composer/ca-bundle <https://packagist.org/packages/composer/ca-bundle>_`.
 


### PR DESCRIPTION
after revert to `string|false` and `string|bool` , this line is not valid anymore 