### PR TITLE
Always use "?" to specify query string params in URL array.

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -60,6 +60,10 @@ Http
 Router
 ------
 
+* URL query string can now be only be generated using ``?`` key in URL array.
+  Earlier any unknown key in URL array was converted to query string param which
+  is no longer the case. 3.x usage like ``['controller' => 'Posts', 'action' => 'search', 'q' => 'keyword']``
+  need to be converted to ``['controller' => 'Posts', 'action' => 'search', '?' => ['q' => 'keyword']]``.
 * ``RouteBuilder::resources()`` now inflects resource names to dasherized form
   instead of underscored by default in URLs. You can retain underscored
   inflection by using ``'inflect' => 'underscore'`` in ``$options`` argument.
@@ -146,7 +150,7 @@ Http
 
 * ``Cake\Http\Client\Response::isSuccess()`` was added. This method returns true
   if the response status code is 2xx.
-  
+
 Mailer
 ------
 

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -403,7 +403,7 @@ Generating Pagination URLs
 By default returns a full pagination URL string for use in non-standard contexts
 (i.e. JavaScript). ::
 
-    echo $this->Paginator->generateUrl(['sort' => 'title']);
+    echo $this->Paginator->generateUrl(['?' => ['sort' => 'title']]);
 
 Creating a Limit Selectbox Control
 ==================================
@@ -443,14 +443,16 @@ Sets all the options for the PaginatorHelper. Supported options are:
   You can also append additional URL content into all URLs generated in the
   helper::
 
-      $this->Paginator->options([
-          'url' => [
-              'sort' => 'email',
-              'direction' => 'desc',
-              'page' => 6,
-              'lang' => 'en'
-          ]
-      ]);
+    $this->Paginator->options([
+        'url' => [
+            '?' => [
+                'sort' => 'email',
+                'direction' => 'desc',
+                'page' => 6,
+            ]
+            'lang' => 'en'
+        ]
+    ]);
 
   The above adds the ``en`` route parameter to all links the helper will
   generate. It will also create links with specific sort, direction and page

--- a/en/views/helpers/url.rst
+++ b/en/views/helpers/url.rst
@@ -61,9 +61,8 @@ URL with GET params and fragment anchor::
     // Output
     /posts/search?foo=bar#first
 
-The above example uses the ``?`` key which is useful when you want to be
-explicit about the query string parameters you are using, or if you want a query
-string parameter that shares a name with one of your route placeholders.
+The above example uses the ``?`` special key for specifying query string
+parameters and ``#`` key for URL fragment.
 
 URL for named route::
 


### PR DESCRIPTION
Refs cakephp/cakephp#12802.

I couldn't find examples for the defunct style of usage which is nice.