### PR TITLE
Added return value of deleteAll method

### DIFF
--- a/en/orm/deleting-data.rst
+++ b/en/orm/deleting-data.rst
@@ -70,7 +70,8 @@ once::
         return $this->deleteAll(['is_spam' => true]);
     }
 
-A bulk-delete will be considered successful if 1 or more rows are deleted.
+A bulk-delete will be considered successful if 1 or more rows are deleted. The
+function returns the number of deleted records as an integer.
 
 .. warning::
 


### PR DESCRIPTION
The deleteAll method return value wasn't documented, forcing one to check the class docs to know if it just returns a boolean value (as implied by the "considered successful" note in the docs), or a true number of deleted rows.