### PR TITLE
Update testing.rst with deprecation fix

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1622,7 +1622,7 @@ the event data::
             parent::setUp();
             $this->Orders = TableRegistry::get('Orders');
             // enable event tracking
-            $this->Orders->eventManager()->setEventList(new EventList());
+            $this->Orders->getEventManager()->setEventList(new EventList());
         }
 
         public function testPlace()
@@ -1635,8 +1635,8 @@ the event data::
 
             $this->assertTrue($this->Orders->place($order));
 
-            $this->assertEventFired('Model.Order.afterPlace', $this->Orders->eventManager());
-            $this->assertEventFiredWith('Model.Order.afterPlace', 'order', $order, $this->Orders->eventManager());
+            $this->assertEventFired('Model.Order.afterPlace', $this->Orders->getEventManager());
+            $this->assertEventFiredWith('Model.Order.afterPlace', 'order', $order, $this->Orders->getEventManager());
         }
     }
 


### PR DESCRIPTION
Current example test code returned an error 

```
Deprecated Error: EventDispatcherTrait::eventManager() is deprecated. Use EventDispatcherTrait::setEventManager()/getEventManager() instead. - /var/www/html/tests/TestCase/Model/Table/BatchesTableTest.php, line: 44
 You can disable deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED` in your config/app.php. in [/var/www/html/vendor/cakephp/cakephp/src/Core/functions.php, line 311]
```

This change fixes the example code to use getEventManager() which removes the error.