### PR TITLE
[pt] Translates missing Migrations page sections to Portuguese

### DIFF
--- a/pt/migrations.rst
+++ b/pt/migrations.rst
@@ -440,6 +440,50 @@ ao snapshot do seu plugin.
 Fique atento que quando você faz o bake de um snapshot, ele é automaticamente
  adicionado ao log do phinx como migrado.
 
+Gerando um *diff* entre dois estados da base de dados
+=====================================================
+
+.. versionadded:: cakephp/migrations 1.6.0
+
+Você pode gerar um arquivo de migração que agrupará todas as diferenças entre
+dois estados de uma base de dados usando ``migration_diff``. Para fazê-lo,
+você pode usar o seguinte comando::
+
+    $ bin/cake bake migration_diff NomeDasMigrações
+
+De forma a ter um ponto de comparação do estado atual da sua base de dados, a
+*shell* de ``migrations`` gerará um arquivo de *dump* após cada chamada de
+``migrate`` ou ``rollback``. O arquivo de *dump* é um arquivo contendo o
+estado completo do esquema da sua base de dados em um determinado instante no
+tempo.
+
+Uma vez gerado o arquivo de *dump*, cada modificação que você fizer
+diretamente no seu sistema de gerenciamento da base de dados será adicionada
+quando você chamar o comando ``bake migration_diff``.
+
+Por padrão, o *diff* será criado através de uma conexão com a base de dados
+definida na configuração de conexão ``default``.
+Se você precisar criar um *diff* de uma fonte de dados diferente, você pode
+usar a opção ``--connection``::
+
+    $ bin/cake bake migration_diff NomeDasMigrações --connection minha_outra_conexão
+
+Se você quiser usar a funcionalidade de *diff* em uma aplicação que já possui
+um histórico de migrações, você precisará criar manualmente o arquivo de
+*dump* a ser usado como base da comparação::
+
+    $ bin/cake migrations dump
+
+O estado da base de dados deve ser o mesmo que você teria caso você tivesse
+migrado todas as suas migrações antes de criar o arquivo de *dump*.
+Uma vez que o arquivo de *dump* for gerado, você pode começar a fazer
+modificações na sua base de dados e usar o comando ``bake migration_diff``
+sempre que desejar.
+
+.. note::
+
+    A *shell* de migrações não é capaz de detectar colunas renomeadas.
+
 Os Comandos
 ===========
 

--- a/pt/migrations.rst
+++ b/pt/migrations.rst
@@ -626,6 +626,37 @@ arquivos de **seed**::
     # You can specify an alternative connection when generating a seeder.
     $ bin/cake bake seed Articles --connection connection
 
+.. versionadded:: cakephp/migrations 1.6.4
+
+    As opções ``--data``, ``--limit`` e ``--fields`` foram adicionadas para
+    exportar dados da sua base de dados.
+
+A partir da versão 16.4, o comando ``bake seed`` permite que você crie um
+arquivo de *seed* com dados exportados da sua base de dados com o uso da
+*flag* ``--data``::
+
+    $ bin/cake bake seed --data Articles
+
+Por padrão, esse comando exportará todas as linhas encontradas na sua
+tabela. Você pode limitar o número de linhas a exportar usando a opção
+``--limit``::
+
+    # Exportará apenas as 10 primeiras linhas encontradas
+    $ bin/cake bake seed --data --limit 10 Articles
+
+Se você deseja incluir apenas uma seleção dos campos da tabela no seu
+arquivo de *seed*, você pode usar a opção ``--fields``. Ela recebe a
+lista de campos a incluir na forma de uma *string* separada por
+vírgulas::
+
+    # Exportará apenas os campos `id`, `title` e `excerpt`
+    $ bin/cake bake seed --data --fields id,title,excerpt Articles
+
+.. tip::
+
+    Você pode utilizar ambas as opções ``--limit`` e ``--fields``
+    simultaneamente em uma mesma chamada.
+
 Para popular seu banco de dados, você pode usar o subcomando ``seed``::
 
     # Without parameters, the seed subcommand will run all available seeders


### PR DESCRIPTION
Translates the following pieces of the _Migrations_ page to Portuguese:
- _"Generating a diff between two database states"_ section  (added in version 1.6.0)
- New `bake seed` options `--data`, `--limit` and `--fields` (added in version 1.6.4)