### PR TITLE
fix deprecated method and add translate in plugins.rst

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -759,7 +759,7 @@ now looks like this::
         {
             $query = $this->Articles->find('published');
             $this->assertInstanceOf('Cake\ORM\Query', $query);
-            $result = $query->hydrate(false)->toArray();
+            $result = $query->enableHydration(false)->toArray();
             $expected = [
                 ['id' => 1, 'title' => 'First Article'],
                 ['id' => 2, 'title' => 'Second Article'],

--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -730,7 +730,7 @@ modified のタイムスタンプに今日の日付を反映させたいので�
         {
             $query = $this->Articles->find('published');
             $this->assertInstanceOf('Cake\ORM\Query', $query);
-            $result = $query->hydrate(false)->toArray();
+            $result = $query->enableHydration(false)->toArray();
             $expected = [
                 ['id' => 1, 'title' => 'First Article'],
                 ['id' => 2, 'title' => 'Second Article'],

--- a/ja/plugins.rst
+++ b/ja/plugins.rst
@@ -92,6 +92,12 @@ Composer を使ったプラグインのインストール
 
     Plugin::load('ContactManager', ['autoload' => true]);
 
+.. deprecated:: 3.7.0
+    Plugin::load() と ``autoload`` オプションは非推奨です。
+
+.. note::
+    重要: ``autoload`` オプションは ``addPlugin()`` では使用できません。代わりに ``composer dumpautoload`` を使用してください。
+
 プラグインの読み込み
 ====================
 
@@ -256,6 +262,9 @@ Plugin オブジェクトは、名前とパス情報も知っています。 ::
 
 ほとんどのプラグインで、設定するための正確な手続きとデータベースのセットアップするための方法が、
 ドキュメントに書かれています。他よりセットアップが必要なものもあります。
+
+.. deprecated:: 3.7.0
+	Plugin::load() と Plugin::loadAdd() は非推奨です。
 
 プラグインの利用
 ================


### PR DESCRIPTION
- fix deprecated method
`hydrate` is already deprecated in 3.4.x, so replace to `enableHydration`
refs: https://book.cakephp.org/3.0/en/appendices/3-4-migration-guide.html#deprecated-combined-get-set-methods

- add translate in plugins.rst
refs: https://github.com/cakephp/docs/pull/5927/files