### PR TITLE
tutorial code use allowEmptyString instead of notEmpty

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -441,11 +441,11 @@ using :ref:`a validator <validating-request-data>`::
     public function validationDefault(Validator $validator)
     {
         $validator
-            ->notEmpty('title')
+            ->allowEmptyString('title', false)
             ->minLength('title', 10)
             ->maxLength('title', 255)
 
-            ->notEmpty('body')
+            ->allowEmptyString('body', false)
             ->minLength('body', 10);
 
         return $validator;

--- a/ja/tutorials-and-examples/cms/articles-controller.rst
+++ b/ja/tutorials-and-examples/cms/articles-controller.rst
@@ -428,11 +428,11 @@ Articles の検証ルールの更新
     public function validationDefault(Validator $validator)
     {
         $validator
-            ->notEmpty('title')
+            ->allowEmptyString('title', false)
             ->minLength('title', 10)
             ->maxLength('title', 255)
 
-            ->notEmpty('body')
+            ->allowEmptyString('body', false)
             ->minLength('body', 10);
 
         return $validator;


### PR DESCRIPTION
In validation doc, it is recommended not to use `notEmpty`, Then I think `notEmpty` should not be used in cms tutorial.
Therefore, I fixed to use `allowEmptyString` instead of `notEmpty`.

ref: https://book.cakephp.org/3.0/en/core-libraries/validation.html#allowing-empty-fields

> You can also use notEmpty() to mark a field invalid if any ‘empty’ value is used. In general, it is recommended that you do not use notEmpty() and use more specific validators instead.
