### PR TITLE
use TableRegistry::getTableLocator()->get() in testing.rst

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -600,7 +600,7 @@ use that to retrieve the table name::
         public $import = ['model' => 'Articles'];
     }
 
-Since this uses ``TableRegistry::get()``, it also supports plugin syntax.
+Since this uses ``TableRegistry::getTableLocator()->get()``, it also supports plugin syntax.
 
 You can naturally import your table definition from an existing model/table, but
 have your records defined directly on the fixture as it was shown on previous
@@ -752,7 +752,7 @@ now looks like this::
         public function setUp()
         {
             parent::setUp();
-            $this->Articles = TableRegistry::get('Articles');
+            $this->Articles = TableRegistry::getTableLocator()->get('Articles');
         }
 
         public function testFindPublished()
@@ -907,7 +907,7 @@ Create a file named **ArticlesControllerTest.php** in your
             $this->post('/articles', $data);
 
             $this->assertResponseSuccess();
-            $articles = TableRegistry::get('Articles');
+            $articles = TableRegistry::getTableLocator()->get('Articles');
             $query = $articles->find()->where(['title' => $data['title']]);
             $this->assertEquals(1, $query->count());
         }
@@ -1619,7 +1619,7 @@ the event data::
         public function setUp()
         {
             parent::setUp();
-            $this->Orders = TableRegistry::get('Orders');
+            $this->Orders = TableRegistry::getTableLocator()->get('Orders');
             // enable event tracking
             $this->Orders->getEventManager()->setEventList(new EventList());
         }

--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -576,7 +576,7 @@ modified のタイムスタンプに今日の日付を反映させたいので�
         public $import = ['model' => 'Articles'];
     }
 
-``TableRegistry::get()`` を使用するので、プラグイン記法をサポートしています。
+``TableRegistry::getTableLocator()->get()`` を使用するので、プラグイン記法をサポートしています。
 
 あなたは自然に既存のモデルやテーブルからテーブル定義をインポートしますが、それは前のセクションに
 示されたように、フィクスチャーで直接定義されたレコードを設定することができます。例えば::
@@ -723,7 +723,7 @@ modified のタイムスタンプに今日の日付を反映させたいので�
         public function setUp()
         {
             parent::setUp();
-            $this->Articles = TableRegistry::get('Articles');
+            $this->Articles = TableRegistry::getTableLocator()->get('Articles');
         }
 
         public function testFindPublished()
@@ -875,7 +875,7 @@ CakePHP は特殊な ``IntegrationTestTrait`` トレイトを提供していま�
             $this->post('/articles', $data);
 
             $this->assertResponseSuccess();
-            $articles = TableRegistry::get('Articles');
+            $articles = TableRegistry::getTableLocator()->get('Articles');
             $query = $articles->find()->where(['title' => $data['title']]);
             $this->assertEquals(1, $query->count());
         }
@@ -1572,7 +1572,7 @@ Orders を例に詳しく説明します。以下のテーブルを持ってい�
         public function setUp()
         {
             parent::setUp();
-            $this->Orders = TableRegistry::get('Orders');
+            $this->Orders = TableRegistry::getTableLocator()->get('Orders');
             // イベントトラッキングの有効化
             $this->Orders->getEventManager()->setEventList(new EventList());
         }


### PR DESCRIPTION
fix testing.rst because after 3.6.0 it is recommended that to use `TableRegistry::getTableLocator()->get()` instead of `TableRegistry::get()`.

refs: https://book.cakephp.org/3.0/en/orm/table-objects.html#getting-instances-of-a-table-class