### PR TITLE
Link to 4.x shim FormHelper.

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -185,3 +185,4 @@ View
   ``autoSetCustomValidity`` class configuration option.
 * ``FormHelper`` now generates native HTML5 input tags for datetime fields.
   Check the :ref:`Form Helper <create-datetime-controls>` page for more details.
+  If you need to retain the former markup, a shimmed FormHelper can be foudn in `Shim plugin <https://github.com/dereuromark/cakephp-shim>`__ with the old behavior/generation (4.x branch).

--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -185,4 +185,4 @@ View
   ``autoSetCustomValidity`` class configuration option.
 * ``FormHelper`` now generates native HTML5 input tags for datetime fields.
   Check the :ref:`Form Helper <create-datetime-controls>` page for more details.
-  If you need to retain the former markup, a shimmed FormHelper can be foudn in `Shim plugin <https://github.com/dereuromark/cakephp-shim>`__ with the old behavior/generation (4.x branch).
+  If you need to retain the former markup, a shimmed FormHelper can be found in `Shim plugin <https://github.com/dereuromark/cakephp-shim>`__ with the old behavior/generation (4.x branch).


### PR DESCRIPTION
Small note as follow up for https://github.com/cakephp/docs/pull/5964
on
https://github.com/dereuromark/cakephp-shim/blob/4.x/src/View/Helper/FormHelper.php
usage.