### PR TITLE
Cleanup of CMS tutorial

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -55,6 +55,11 @@ view pages. CakePHP hashes passwords with `bcrypt
 use SHA-1 or MD5 if you're working with an existing database, but we recommend
 bcrypt for all new applications.
 
+.. note::
+
+    Create a hashed password for at least one of the user accounts now! 
+    It will be needed in the next steps.
+    
 
 Adding Login
 ============
@@ -92,8 +97,6 @@ AuthComponent in our AppController::
                     'controller' => 'Users',
                     'action' => 'login'
                 ],
-                 //use isAuthorized in Controllers
-                'authorize' => ['Controller'],
                  // If unauthorized, return them to page they were just on
                 'unauthorizedRedirect' => $this->referer()
             ]);
@@ -102,6 +105,7 @@ AuthComponent in our AppController::
             // continues to work. Also enable the read only actions.
             $this->Auth->allow(['display', 'view', 'index']);
         }
+        
     }
 
 We've just told CakePHP that we want to load the ``Auth``
@@ -124,7 +128,7 @@ the login action::
         }
     }
 
-And in **src/Template/Users/login.ctp** add the following::
+Create a new template **src/Template/Users/login.ctp** and add the following::
 
     <h1>Login</h1>
     <?= $this->Form->create() ?>

--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -374,6 +374,16 @@ With the entity updated we can add a new control for our tags. In
 replace the existing ``tags._ids`` control with the following::
 
     echo $this->Form->control('tag_string', ['type' => 'text']);
+    
+We'll also need to update the article view template. In
+**src/Template/Articles/view.ctp** add the line as shown::
+
+    <!-- File: src/Template/Articles/view.ctp -->
+
+    <h1><?= h($article->title) ?></h1>
+    <p><?= h($article->body) ?></p>
+    // Add the following line
+    <p><b>Tags:</b> <?= h($article->tag_string) ?></p>
 
 Persisting the Tag String
 -------------------------
@@ -432,5 +442,50 @@ While this code is a bit more complicated than what we've done so far, it helps
 to showcase how powerful the ORM in CakePHP is. You can manipulate query
 results using the :doc:`/core-libraries/collections` methods, and handle
 scenarios where you are creating entities on the fly with ease.
+
+Auto-populating the Tag String
+==============================
+
+Before we finish up, we'll need a mechanism that will load the associated tags 
+(if any) whenever we load an article. 
+
+In your **src/Model/Table/ArticlesTable.php**, change::
+
+    public function initialize(array $config)
+    {
+        $this->addBehavior('Timestamp');
+        // Change this line
+        $this->belongsToMany('Tags', [
+            'joinTable' => 'articles_tags',
+            'dependent' => true
+        ]);
+    }
+
+This will tell the Articles table model that there is a join table associated
+with tags.  The 'dependent' option tells the table to delete any associated 
+records from the join table if an article is deleted.
+
+Lastly, update the findBySlug() method calls in 
+**src/Controller/ArticlesController.php**::
+
+    public function edit($slug)
+    {
+        // Update this line
+        $article = $this->Articles->findBySlug($slug)->contain(['Tags'])
+            ->firstOrFail();
+    ...
+    }
+    
+    public function view($slug = null)
+    {
+        // Update this line
+        $article = $this->Articles->findBySlug($slug)->contain(['Tags'])
+            ->firstOrFail();
+        $this->set(compact('article'));
+    }
+
+The contain() method tells the ArticlesTable object to also populate the Tags 
+association when the article is loaded.  Now when tag_string is called for an
+Article entity, there will be data present to create the string!
 
 Next we'll be adding :doc:`authentication </tutorials-and-examples/cms/authentication>`.


### PR DESCRIPTION
Changes to two files in the CMS tutorial:

authentication.rst
------------------
- 58: Note was added because not enough import was given to the fact that a hashed password was needed.  If the student doesn't do it at this point, then they will be locked out of any accounts they created, and will need to confusingly comment out portions of code to access again.

- 95: 'authorize' option was removed because it was causing a system error that no isAuthorized() functions were present, and the instructions do not mention it.  This 'authorize' is added later in the tutorials.  I believe it was inserted here by mistake

- 131: Instruction was changed because login.ctp doesn't exist at this point.

tags-and-users.rst
-------------------
- 377: Added because tag strings will not be see in the article view without this.

- 446: An entire section of code was left out in order to allow the calculated field to be created upon a database query, including the joinTable option in the initialize function!