### PR TITLE
The fieldList option has been deprecated since 3.4.

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -683,6 +683,9 @@ privileges.
 The ``fieldList`` options is also accepted by the ``newEntity()``,
 ``newEntities()`` and ``patchEntities()`` methods.
 
+.. deprecated:: 3.4.0
+    Use ``fields`` instead of ``fieldList``.
+
 .. _saving-entities:
 
 Saving Entities


### PR DESCRIPTION
The fieldList option has been deprecated since 3.4.
Use the `fields` option instead.

https://github.com/cakephp/cakephp/commit/bfc93253e23a605f8e6ab6c521c2036bc1f290dc

https://github.com/cakephp/cakephp/blob/9258019c6544f67ea49cb882e08aa8c3e3bbe95f/src/ORM/Marshaller.php#L276