### PR TITLE
Remove prior comments from 4.x docs

### DIFF
--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -165,18 +165,6 @@ And the resultant baked class (**src/Shell/FooShell.php**) looks like this::
 
     }
 
-.. note::
-
-    Prior to version 1.5.0 bake used a custom erb-style tags inside .ctp template files.
-
-    * ``<%`` A Bake template php open tag
-    * ``%>`` A Bake template php close tag
-    * ``<%=`` A Bake template php short-echo tag
-    * ``<%-`` A Bake template php open tag, stripping any leading whitespace
-      before the tag
-    * ``-%>`` A Bake template php close tag, stripping trailing whitespace after
-      the tag
-
 .. _creating-a-bake-theme:
 
 Creating a Bake Theme

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -236,7 +236,6 @@ send the email with::
     use Cake\Mailer\Email;
 
     $email = new Email();
-    // Prior to 3.4 use domain()
     $email->setDomain('www.example.org');
 
 This asserts that the generated message IDs are valid and fit to the domain the

--- a/en/console-and-shells/option-parsers.rst
+++ b/en/console-and-shells/option-parsers.rst
@@ -358,8 +358,6 @@ in either an array or a string, you can set the value of the description::
 
     // Set multiple lines at once
     $parser->setDescription(['line one', 'line two']);
-    // Prior to 3.4
-    $parser->description(['line one', 'line two']);
 
     // Read the current value
     $parser->getDescription();
@@ -375,8 +373,6 @@ can set the value of the epilog::
 
     // Set multiple lines at once
     $parser->setEpilog(['line one', 'line two']);
-    // Prior to 3.4
-    $parser->epilog(['line one', 'line two']);
 
     // Read the current value
     $parser->getEpilog();

--- a/en/console-and-shells/plugin-shell.rst
+++ b/en/console-and-shells/plugin-shell.rst
@@ -21,9 +21,6 @@ This will add the following to your **src/Application.php**::
     // In the bootstrap method add:
     $this->addPlugin('MyPlugin');
 
-    // Prior to 3.6, add the following to config/bootstrap.php
-    Plugin::load('MyPlugin');
-
 If you are loading a plugin that only provides CLI tools - like bake - you can
 update your ``bootstrap_cli.php`` with::
 

--- a/en/console-and-shells/schema-cache.rst
+++ b/en/console-and-shells/schema-cache.rst
@@ -22,6 +22,3 @@ cached metadata as well::
 
     # Clear a single table
     bin/cake schema_cache clear articles
-
-.. note::
-    Prior to 3.6 you should use ``orm_cache`` instead of ``schema_cache``.

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -545,18 +545,13 @@ In order to display the session error messages that Auth generates, you
 need to add the following code to your layout. Add the following two
 lines to the **templates/Layout/default.php** file in the body section::
 
-    // Only this is necessary after 3.4.0
     echo $this->Flash->render();
-
-    // Prior to 3.4.0 this will be required as well.
-    echo $this->Flash->render('auth');
 
 You can customize the error messages and flash settings ``AuthComponent``
 uses. Using ``flash`` config you can configure the parameters
 ``AuthComponent`` uses for setting flash messages. The available keys are
 
-- ``key`` - The key to use, defaults to 'default'. Prior to 3.4.0, the key
-  defaulted to 'auth'.
+- ``key`` - The key to use, defaults to 'default'.
 - ``element`` - The element name to use for rendering, defaults to null.
 - ``params`` - The array of additional parameters to use, defaults to ``[]``.
 

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -318,7 +318,6 @@ page count.
 So you could either let the normal error page be rendered or use a try catch
 block and take appropriate action when a ``NotFoundException`` is caught::
 
-    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
     use Cake\Http\Exception\NotFoundException;
 
     public function index()

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -218,14 +218,10 @@ require secure SSL requests::
             if ($exception instanceof SecurityException && $exception->getType() === 'secure') {
                 return $this->redirect('https://' . env('SERVER_NAME') . Router::url($this->request->getRequestTarget()));
             }
-            
+
             throw $exception;
         }
     }
-
-.. note::
-
-    Use ``$this->request->here()`` for CakePHP versions prior to 3.4.0
 
 This example would force all actions that had admin routing to require secure
 SSL requests. When the request is black holed, it will call the nominated
@@ -272,10 +268,6 @@ There may be cases where you want to disable all security checks for an action
             $this->Security->setConfig('unlockedActions', ['edit']);
         }
     }
-
-.. note::
-
-    Use ``$this->Security->config()`` for CakePHP versions prior to 3.4.0
 
 This example would disable all security checks for the edit action.
 

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -43,9 +43,6 @@ The request exposes routing parameters through the ``getParam()`` method::
 
     $controllerName = $this->request->getParam('controller');
 
-    // Prior to 3.4.0
-    $controllerName = $this->request->param('controller');
-
 To get all routing parameters as an array use ``getAttribute()``::
 
     $parameters = $this->request->getAttribute('params');
@@ -79,9 +76,6 @@ Query string parameters can be read using the ``getQuery()`` method::
 
     // URL is /posts/index?page=1&sort=title
     $page = $this->request->getQuery('page');
-
-    // Prior to 3.4.0
-    $page = $this->request->query('page');
 
 You can either directly access the query property, or you can use
 ``getQuery()`` method to read the URL query array in an error-free manner.
@@ -195,11 +189,6 @@ subdirectory. The attributes you can use are::
 
     // Holds /subdir/
     $base = $request->getAttribute('webroot');
-
-    // Prior to 3.4.0
-    $webroot = $request->webroot;
-    $base = $request->base;
-    $here = $request->here();
 
 .. _check-the-request:
 
@@ -340,9 +329,6 @@ Returns the HTTP method the request was made with::
     // Output POST
     echo $request->getMethod();
 
-    // Prior to 3.4.0
-    echo $request->method();
-
 Restricting Which HTTP method an Action Accepts
 -----------------------------------------------
 
@@ -373,9 +359,6 @@ for the request. For example::
 
     // Check if a header exists
     $hasAcceptHeader = $this->request->hasHeader('Accept');
-
-    // Prior to 3.4.0
-    $userAgent = $this->request->header('User-Agent');
 
 While some apache installs don't make the ``Authorization`` header accessible,
 CakePHP will make it available through apache specific methods as required.
@@ -514,9 +497,6 @@ with content types that are not built into Response, you can map them with
     // Set the response Content-Type to vcard.
     $this->response = $this->response->withType('vcf');
 
-    // Prior to 3.4.0
-    $this->response->type('vcf');
-
 Usually, you'll want to map additional content types in your controller's
 :php:meth:`~Controller::beforeFilter()` callback, so you can leverage the
 automatic view switching features of :php:class:`RequestHandlerComponent` if you
@@ -541,13 +521,6 @@ You can accomplish that by using :php:meth:`Cake\\Http\\Response::withFile()`::
         return $response;
     }
 
-    // Prior to 3.4.0
-    $file = $this->Attachments->getFile($id);
-    $this->response->file($file['path']);
-    // Return the response to prevent controller from trying to render
-    // a view.
-    return $this->response;
-
 As shown in the above example, you must pass the file path to the method.
 CakePHP will send a proper content type header if it's a known file type listed
 in `Cake\\Http\\Response::$_mimeTypes`. You can add new types prior to calling
@@ -558,12 +531,6 @@ If you want, you can also force a file to be downloaded instead of displayed in
 the browser by specifying the options::
 
     $response = $this->response->withFile(
-        $file['path'],
-        ['download' => true, 'name' => 'foo']
-    );
-
-    // Prior to 3.4.0
-    $this->response->file(
         $file['path'],
         ['download' => true, 'name' => 'foo']
     );
@@ -630,9 +597,6 @@ instance with the new header::
     // Append a value to an existing header
     $response = $response->withAddedHeader('Set-Cookie', 'remember_me=1');
 
-    // Prior to 3.4.0 - Set a header
-    $this->response->header('Location', 'http://example.com');
-
 Headers are not sent when set. Instead, they are held until the response is
 emitted by ``Cake\Http\Server``.
 
@@ -664,9 +628,6 @@ To set the response body, use the ``withBody()`` method, which is provided by th
 
     $response = $response->withBody($stream);
 
-    // Prior to 3.4.0 - Set the body
-    $this->response->body('My Body');
-
 Be sure that ``$stream`` is a :php:class:`Psr\\Http\\Message\\StreamInterface` object.
 See below on how to create a new stream.
 
@@ -694,14 +655,6 @@ stream to the client::
     });
     $response = $response->withBody($stream);
 
-    // Prior to 3.4.0 you can use the following to create streaming responses.
-    $file = fopen('/some/file.png', 'r');
-    $this->response->body(function () use ($file) {
-        rewind($file);
-        fpassthru($file);
-        fclose($file);
-    });
-
 Setting the Character Set
 -------------------------
 
@@ -710,9 +663,6 @@ Setting the Character Set
 Sets the charset that will be used in the response::
 
     $this->response = $this->response->withCharset('UTF-8');
-
-    // Prior to 3.4.0
-    $this->response->charset('UTF-8');
 
 Interacting with Browser Caching
 --------------------------------
@@ -727,9 +677,6 @@ that::
     {
         // Disable caching
         $this->response = $this->response->withDisabledCache();
-
-        // Prior to 3.4.0
-        $this->response->disableCache();
     }
 
 .. warning::

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -24,8 +24,7 @@ build your own backend. The built-in caching engines are:
   work well in files.
 * ``Apcu`` APCu cache uses the PHP `APCu <http://php.net/apcu>`_ extension.
   This extension uses shared memory on the webserver to store objects.
-  This makes it very fast, and able to provide atomic read/write features. Prior
-  to 3.6.0 ``ApcuEngine`` was named ``ApcEngine``.
+  This makes it very fast, and able to provide atomic read/write features.
 * ``Wincache`` Wincache uses the `Wincache <http://php.net/wincache>`_
   extension. Wincache is similar to APC in features and performance, but
   optimized for Windows and IIS.

--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -119,7 +119,6 @@ change the configuration data. An example transport configuration looks like::
     use Cake\Mailer\TransportFactory;
 
     // Sample Mail configuration
-    // Prior to 3.7.0 use Email::configTransport()
     TransportFactory::setConfig('default', [
         'className' => 'Mail'
     ]);
@@ -168,11 +167,6 @@ Configuration options can also be provided as a :term:`DSN` string. This is
 useful when working with environment variables or :term:`PaaS` providers::
 
     TransportFactory::setConfig('default', [
-        'url' => 'smtp://my@gmail.com:secret@smtp.gmail.com:587?tls=true',
-    ]);
-
-    // Prior to 3.7.0 use
-    Email::configTransport('default', [
         'url' => 'smtp://my@gmail.com:secret@smtp.gmail.com:587?tls=true',
     ]);
 

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -245,7 +245,6 @@ a more direct approach and only listen to the event you really need::
         ->on('Model.afterSave', function($event, $entity)
         {
             // For example we can send an email to the admin
-            // Prior to 3.4 use from()/to()/subject() methods
             $email = new Email('default');
             $email->setFrom(['info@yoursite.com' => 'Your Site'])
                 ->setTo('admin@yoursite.com')

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -137,15 +137,6 @@ Values set with this method will overwrite existing data in the form object::
         }
     }
 
-Prior to 3.7.0 you must set default values for form by modifying the request::
-
-    // Set default values on get
-    if ($this->request->is('get')) {
-        // Values from the User Model e.g.
-        $this->request->data('name', 'John Doe');
-        $this->request->data('email','john.doe@example.com');
-    }
-
 Values should only be defined if the request method is GET, otherwise
 you will overwrite your previous POST Data which might have validation errors
 that need corrections.
@@ -159,7 +150,7 @@ Getting Form Errors
 
 Once a form has been validated you can retrieve the errors from it::
 
-    $errors = $form->getErrors(); // $form->errors(); // prior to 3.7.0
+    $errors = $form->getErrors();
     /* $errors contains
     [
         'email' => ['A valid email address is required']

--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -9,9 +9,6 @@ CakePHP includes a PSR-18 compliant HTTP client which can be used for
 making requests. It is a great way to communicate with webservices, and
 remote APIs.
 
-.. versionchanged:: 3.3.0
-    Prior to 3.3.0 you should use ``Cake\Network\Http\Client``.
-
 Doing Requests
 ==============
 
@@ -373,11 +370,6 @@ You read the entire response body as a string::
     // Read the entire response as a string.
     $response->getStringBody();
 
-    // Prior to 3.7.0 use
-    $response->body();
-    // or
-    $response->body;
-
 You can also access the stream object for the response and use its methods::
 
     // Get a Psr\Http\Message\StreamInterface containing the response body
@@ -402,16 +394,10 @@ XML data is decoded into a ``SimpleXMLElement`` tree::
     $response = $http->get('http://example.com/test.xml');
     $xml = $response->getXml();
 
-    // Prior to 3.7.0
-    $xml = $response->xml;
-
     // Get some JSON
     $http = new Client();
     $response = $http->get('http://example.com/test.json');
     $json = $response->getJson();
-
-    // Prior to 3.7.0
-    $json = $response->json;
 
 The decoded response data is stored in the response object, so accessing it
 multiple times has no additional cost.

--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -121,7 +121,6 @@ To change the language for translated strings you can call this method::
 
     use Cake\I18n\I18n;
 
-    // Prior to 3.5 use I18n::locale()
     I18n::setLocale('de_DE');
 
 This will also change how numbers and dates are formatted when using one of the
@@ -412,7 +411,6 @@ minimum that is required for creating a translator is that the loader function
 should return a ``Aura\Intl\Package`` object. Once the code is in place you can
 use the translation functions as usual::
 
-    // Prior to 3.5 use I18n::locale()
     I18n::setLocale('fr_FR');
     __d('animals', 'Dog'); // Returns "Chien"
 
@@ -425,7 +423,6 @@ For example, you can still use **.po** files, but loaded from another location::
     use Cake\I18n\MessagesFileLoader as Loader;
 
     // Load messages from resources/locales/folder/sub_folder/filename.po
-    // Prior to 3.5 use translator()
     I18n::setTranslator(
         'animals',
         new Loader('filename', 'folder/sub_folder', 'po'),
@@ -578,7 +575,6 @@ the current locale setting and use the right classes::
     use Cake\I18n\Time;
     use Cake\I18n\Number;
 
-    // Prior to 3.5 use I18n::locale()
     I18n::setLocale('fr-FR');
 
     $date = new Time('2015-04-05 23:00:00');
@@ -634,8 +630,6 @@ automatically set the locale based on the current user::
         $middleware->add(new LocaleSelectorMiddleware(['en_US', 'fr_FR']));
     }
 
-    // Prior to 3.3.0, use the DispatchFilter
-    // in config/bootstrap.php
     DispatcherFactory::add('LocaleSelector');
 
     // Restrict the locales to only en_US, fr_FR

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -33,10 +33,6 @@ Under the hood, CakePHP uses `Chronos <https://github.com/cakephp/chronos>`_
 to power its ``FrozenTime`` utility. Anything you can do with ``Chronos`` and
 ``DateTime``, you can do with ``FrozenTime`` and ``FrozenDate``.
 
-.. note::
-    Prior to 3.2.0 CakePHP used `Carbon
-    <https://github.com/briannesbitt/Carbon>`__.
-
 For more details on Chronos please see `the API documentation
 <https://api.cakephp.org/chronos/1.0/>`_.
 

--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -128,7 +128,6 @@ when a field can or cannot be empty:
 
 An example of these methods in action is::
 
-    // Prior to 3.7 you must use allowEmpty() or notEmpty().
     $validator->allowEmptyDateTime('published')
         ->allowEmptyString('title', false, 'Title cannot be empty')
         ->allowEmptyString('body', 'update', 'Body cannot be empty')

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -604,7 +604,6 @@ class like so::
 
     // In your bootstrap.php
     use Cake\Event\EventManager;
-    // Prior to 3.6 use Cake\Network\Exception\InteralErrorException
     use Cake\Http\Exception\InternalErrorException;
 
     $isCakeBakeShellRunning = (PHP_SAPI === 'cli' && isset($argv[1]) && $argv[1] === 'bake');

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -437,7 +437,6 @@ You can throw these exceptions from your controllers to indicate failure states,
 or HTTP errors. An example use of the HTTP exceptions could be rendering 404
 pages for items that have not been found::
 
-    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
     use Cake\Http\Exception\NotFoundException;
 
     public function view($id = null)

--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -144,10 +144,6 @@ you had an ``AppSessionHandler`` class,  the file should be
 ``App\Http\Session\AppSessionHandler``. You can also use session handlers
 from inside plugins. By setting the engine to ``MyPlugin.PluginSessionHandler``.
 
-.. note::
-    Prior to 3.6.0 session adapter files should be placed in
-    **src/Network/Session/AppHandler.php**.
-
 Database Sessions
 -----------------
 
@@ -327,7 +323,6 @@ In addition to the basic session object, you can also use the
 :php:class:`Cake\\View\\Helper\\SessionHelper` to interact with the session in
 your views. A basic example of session usage would be::
 
-    // Prior to 3.6.0 use session() instead.
     $name = $this->getRequest()->getSession()->read('User.name');
 
     // If you are accessing the session multiple times,

--- a/en/elasticsearch.rst
+++ b/en/elasticsearch.rst
@@ -20,8 +20,6 @@ You will need to add the following line to your application's
 
     $this->addPlugin('Cake/ElasticSearch', ['bootstrap' => true]);
 
-    // Prior to 3.6.0 you need to use Plugin::load()
-
 Additionally, you will need to configure the 'elastic' datasource connection in
 your **config/app.php** file. An example configuration would be::
 

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -37,8 +37,6 @@ adding the following statement::
 
     $this->addPlugin('Migrations');
 
-    // Prior to 3.6.0 you need to use Plugin::load()
-
 Additionally, you will need to configure the default database configuration for your
 application in your **config/app.php** file as explained in the
 :ref:`Database Configuration section <database-configuration>`.
@@ -188,10 +186,7 @@ You can also use the ``underscore_form`` as the name for your migrations i.e.
 .. versionadded:: cakephp/migrations 1.5.2
 
     As of v1.5.2 of the `migrations plugin <https://github.com/cakephp/migrations/>`_,
-    the migration filename will be automatically camelized. This version of the
-    plugin is only available with a release of CakePHP >= to 3.1. Prior to this
-    version of the plugin the migration name would be in the underscore form,
-    i.e. ``20160121164955_create_products.php``.
+    the migration filename will be automatically camelized.
 
 .. warning::
 
@@ -947,7 +942,6 @@ performing operations on those new columns.
 The CakePHP Core includes a :doc:`Schema Cache Shell <console-and-shells/schema-cache>`
 that you can use to perform this operation::
 
-    // Prior to 3.6 use orm_cache
     $ bin/cake schema_cache clear
 
 Be sure to read the :doc:`Schema Cache Shell <console-and-shells/schema-cache>`

--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -292,7 +292,6 @@ We can also define a more specific relationship using the setters::
     {
         public function initialize(array $config)
         {
-            // Prior to 3.4 version, use foreignKey() and joinType()
             $this->belongsTo('Users')
                 ->setForeignKey('user_id')
                 ->setJoinType('INNER');

--- a/en/orm/behaviors/timestamp.rst
+++ b/en/orm/behaviors/timestamp.rst
@@ -85,7 +85,3 @@ saving an entity you can mark the attribute as 'dirty'::
     // Mark the modified column as dirty making
     // the current value be set on update.
     $order->setDirty('modified', true);
-
-    // Prior to 3.4.0
-    $order->dirty('modified', true);
-

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -343,7 +343,7 @@ modifying the application's state. For these scenarios use the behavior's
 
     $this->loadModel('Articles');
 
-    // specific locale. Use locale() prior to 3.6
+    // specific locale.
     $this->Articles->setLocale('es');
 
     $article = $this->Articles->get(12);
@@ -356,7 +356,6 @@ to call the method on each table, for example::
     I18n::setLocale('en'); // reset for illustration
 
     $this->loadModel('Articles');
-    // Use locale() prior to 3.6
     $this->Articles->setLocale('es');
     $this->Articles->Categories->setLocale('es');
 
@@ -371,7 +370,6 @@ Querying Translated Fields
 TranslateBehavior does not substitute find conditions by default. You need to use
 ``translationField()`` method to compose find conditions on translated fields::
 
-    // Use locale() prior to 3.6
     $this->Articles->setLocale('es');
     $data = $this->Articles->find()->where([
         $this->Articles->translationField('title') => 'Otro Título'
@@ -440,7 +438,6 @@ default language directly to the table::
 
     $article->title = 'Mi Primer Artículo';
 
-    // Use locale() prior to 3.6
     $this->Articles->setLocale('es');
     $this->Articles->save($article);
 

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -842,7 +842,6 @@ Query logging can be enabled when configuring your connection by setting the
 ``log`` option to ``true``. You can also toggle query logging at runtime, using
 ``enableQueryLogging``::
 
-    // Prior to 3.7.0 use logQueries()
     // Turn query logging on.
     $conn->enableQueryLogging(true);
 

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -246,7 +246,6 @@ changed in an entity. For example, you may only want to validate fields when
 they change::
 
     // See if the title has been modified.
-    // Prior to 3.5 use dirty()
     $article->isDirty('title');
 
 You can also flag fields as being modified. This is handy when appending into
@@ -254,7 +253,6 @@ array fields as this wouldn't automatically mark the field as dirty, only
 exchanging completely would.::
 
     // Add a comment and mark the field as changed.
-    // Prior to 3.5 use dirty()
     $article->comments[] = $newComment;
     $article->setDirty('comments', true);
 
@@ -265,7 +263,6 @@ the original value of the field if it has been modified or its actual value.
 You can also check for changes to any field in the entity::
 
     // See if the entity has changed
-    // Prior to 3.5 use dirty()
     $article->isDirty();
 
 To remove the dirty mark from fields in an entity, you can use the ``clean()``
@@ -298,13 +295,9 @@ stored on the entity itself. You can access any validation errors using the
 
     // Get all the errors
     $errors = $user->getErrors();
-    // Prior to 3.4.0
-    $errors = $user->errors();
 
     // Get the errors for a single field.
     $errors = $user->getError('password');
-    // Prior to 3.4.0
-    $errors = $user->errors('password');
 
     // Does the entity or any nested entity have an error.
     $user->hasErrors();
@@ -320,9 +313,6 @@ on an entity, making it easier to test code that works with error messages::
         'password' => ['Password is required'],
         'username' => ['Username is required']
     ]);
-
-    // Prior to 3.4.0
-    $user->errors('password', ['Password is required.']);
 
 .. versionadded:: 3.7.0
     ``hasErrors()`` was added.

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -1430,7 +1430,6 @@ Subqueries are a powerful feature in relational databases and building them in
 CakePHP is fairly intuitive. By composing queries together, you can make
 subqueries::
 
-    // Prior to 3.6.0 use association() instead.
     $matchingComment = $articles->getAssociation('Comments')->find()
         ->select(['article_id'])
         ->distinct()

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -168,7 +168,6 @@ By default queries and result sets will return :doc:`/orm/entities` objects. You
 can retrieve basic arrays by disabling hydration::
 
     $query->enableHydration(false);
-    // Prior to 3.4.0
     $query->hydrate(false);
 
     // $data is ResultSet that contains array data.
@@ -241,8 +240,6 @@ a table::
         public function initialize(array $config)
         {
             $this->setDisplayField('title');
-            // Prior to 3.4.0
-            $this->displayField('title');
         }
     }
 
@@ -571,8 +568,6 @@ associations and filter them by conditions. To specify conditions, pass an anony
 function that receives as the first argument a query object, ``\Cake\ORM\Query``::
 
     // In a controller or table method.
-    // Prior to 3.5.0 you would use contain(['Comments' => function () { ... }])
-
     $query = $articles->find()->contain('Comments', function (Query $q) {
         return $q
             ->select(['body', 'author_id'])
@@ -651,7 +646,7 @@ Alternatively, if you have multiple associations, you can use ``enableAutoFields
     // and Tags.
     $query->select(['id', 'title'])
         ->contain(['Comments', 'Tags'])
-        ->enableAutoFields(true) // Prior to 3.4.0 use autoFields(true)
+        ->enableAutoFields(true)
         ->contain(['Users' => function(Query $q) {
             return $q->autoFields(true);
         }]);
@@ -834,7 +829,7 @@ data, you can use the ``leftJoinWith()`` function::
     $query->select(['total_comments' => $query->func()->count('Comments.id')])
         ->leftJoinWith('Comments')
         ->group(['Articles.id'])
-        ->enableAutoFields(true); // Prior to 3.4.0 use autoFields(true);
+        ->enableAutoFields(true);
 
 The results for the above query will contain the article data and the
 ``total_comments`` property for each of them.
@@ -850,7 +845,7 @@ word, per author::
             return $q->where(['Tags.name' => 'awesome']);
         })
         ->group(['Authors.id'])
-        ->enableAutoFields(true); // Prior to 3.4.0 use autoFields(true);
+        ->enableAutoFields(true);
 
 This function will not load any columns from the specified associations into the
 result set.
@@ -894,8 +889,6 @@ Dynamically changing the strategy in this way will only apply to a specific
 query. If you want to make the strategy change permanent you can do::
 
     $articles->FirstComment->setStrategy('select');
-    // Prior to 3.4.0
-    $articles->FirstComment->strategy('select');
 
 Using the ``select`` strategy is also a great way of making associations with
 tables in another database, since it would not be possible to fetch records
@@ -928,9 +921,6 @@ You can also make the strategy permanent for the association by doing::
 
     $articles->Comments->setStrategy('subquery');
 
-    // Prior to 3.4.0
-    $articles->Comments->strategy('subquery');
-
 Lazy Loading Associations
 =========================
 
@@ -955,8 +945,6 @@ a data set that does not fit into memory you can disable buffering on the query
 to stream results::
 
     $query->enableBufferedResults(false);
-    // Prior to 3.4.0
-    $query->bufferResults(false);
 
 Turning buffering off has a few caveats:
 
@@ -1174,7 +1162,7 @@ Finally, we put everything together::
     $wordCount = $articles->find()
         ->where(['published' => true])
         ->andWhere(['published_date >=' => new DateTime('2014-01-01')])
-        ->enableHydrate(false) // Prior to 3.4.0 use hydrate(false)
+        ->enableHydrate(false)
         ->mapReduce($mapper, $reducer)
         ->toArray();
 
@@ -1234,7 +1222,7 @@ of followers per user::
 And we supply our functions to a query::
 
     $fakeFriends = $friends->find()
-        ->enableHydrate(false) // Prior to 3.4.0 use hydrate(false)
+        ->enableHydrate(false)
         ->mapReduce($mapper, $reducer)
         ->toArray();
 

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -1038,7 +1038,6 @@ This functionality is achieved by using the custom types system. See the
 :ref:`adding-custom-database-types` section to find out how to build custom
 column Types::
 
-    // Only prior to 3.6, you have to add a new type map in config/bootstrap.php
     use Cake\Database\Type;
 
     Type::map('json', 'Cake\Database\Type\JsonType');
@@ -1051,9 +1050,6 @@ column Types::
         protected function _initializeSchema(TableSchema $schema)
         {
             $schema->setColumnType('preferences', 'json');
-
-            // Prior to 3.6 you should use ``columnType`` instead of ``setcolumnType``.
-            $schema->columnType('preferences', 'json');
 
             return $schema;
         }

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -49,9 +49,6 @@ method::
         public function initialize(array $config)
         {
             $this->setTable('my_table');
-
-            // Prior to 3.4.0
-            $this->table('my_table');
         }
 
     }
@@ -69,9 +66,6 @@ If you need to modify this you can use the ``setPrimaryKey()`` method::
         public function initialize(array $config)
         {
             $this->setPrimaryKey('my_id');
-
-            // Prior to 3.4.0
-            $this->primaryKey('my_id');
         }
     }
 
@@ -89,9 +83,6 @@ conventions you can use the ``setEntityClass()`` method to change things up::
         public function initialize(array $config)
         {
             $this->setEntityClass('App\Model\Entity\PO');
-
-            // Prior to 3.4.0
-            $this->entityClass('App\Model\Entity\PO');
         }
     }
 
@@ -110,9 +101,6 @@ can do this by using the ``TableRegistry`` class::
 
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
 The TableRegistry class provides the various dependencies for constructing
 a table, and maintains a registry of all the constructed table instances making
 it easier to build relations and configure the ORM. See
@@ -128,10 +116,6 @@ correctly load plugin table classes use the following::
 
     // Vendor prefixed plugin table
     $articlesTable = TableRegistry::getTableLocator()->get('VendorName/PluginName.Articles');
-
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('PluginName.Articles');
-    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
 
 .. _table-callbacks:
 

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -87,7 +87,6 @@ with CakePHP::
         {
             $user = $this->Users->newEntity();
             if ($this->request->is('post')) {
-                // Prior to 3.4.0 $this->request->data() was used.
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
@@ -312,7 +311,6 @@ currently logged in user as a reference for the created article::
     {
         $article = $this->Articles->newEntity();
         if ($this->request->is('post')) {
-            // Prior to 3.4.0 $this->request->data() was used.
             $article = $this->Articles->patchEntity($article, $this->request->getData());
             // Added this line
             $article->user_id = $this->Auth->user('id');
@@ -390,15 +388,12 @@ own.  Add the following content to your **ArticlesController.php**::
     public function isAuthorized($user)
     {
         // All registered users can add articles
-        // Prior to 3.4.0 $this->request->param('action') was used.
         if ($this->request->getParam('action') === 'add') {
             return true;
         }
 
         // The owner of an article can edit and delete it
-        // Prior to 3.4.0 $this->request->param('action') was used.
         if (in_array($this->request->getParam('action'), ['edit', 'delete'])) {
-            // Prior to 3.4.0 $this->request->params('pass.0')
             $articleId = (int)$this->request->getParam('pass.0');
             if ($this->Articles->isOwnedBy($articleId, $user['id'])) {
                 return true;

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -337,7 +337,6 @@ it::
 
     namespace App\Controller;
 
-    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
     use Cake\Http\Exception\NotFoundException;
 
     class ArticlesController extends AppController
@@ -349,7 +348,6 @@ it::
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                // Prior to 3.4.0 $this->request->data() was used.
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -295,7 +295,6 @@ First, start by creating an ``add()`` action in the
         {
             $article = $this->Articles->newEntity();
             if ($this->request->is('post')) {
-                // Prior to 3.4.0 $this->request->data() was used.
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
@@ -459,7 +458,6 @@ like::
     {
         $article = $this->Articles->get($id);
         if ($this->request->is(['post', 'put'])) {
-            // Prior to 3.4.0 $this->request->data() was used.
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -80,8 +80,7 @@ And in **templates/Users/login.php** add the following::
 
 .. note::
 
-   The ``control()`` method is available since 3.4. For prior versions you can
-   use the ``input()`` method instead.
+   The ``control()`` method is available since 3.4.
 
 Now that we have a simple login form, we should be able to log in with one of
 the users that has a hashed password.

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -102,9 +102,6 @@ attribute values or modify the behavior of a helper::
 
     class AwesomeHelper extends Helper
     {
-
-        // initialize() hook is available since 3.2. For prior versions you can
-        // override the constructor if required.
         public function initialize(array $config)
         {
             debug($config);

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -2148,8 +2148,6 @@ You can also change the templates at runtime using the ``setTemplates()`` method
         'inputContainer' => '<div class="form-control">{{content}}</div>',
     ];
     $this->Form->setTemplates($myTemplates);
-    // Prior to 3.4
-    $this->Form->templates($myTemplates);
 
 .. warning::
 
@@ -2323,8 +2321,6 @@ specific fields from the generated controls, set them to ``false`` in the
 ``$fields`` parameter::
 
     echo $this->Form->allControls(['password' => false]);
-    // Or prior to 3.4.0:
-    echo $this->Form->allInputs(['password' => false]);
 
 .. _associated-form-inputs:
 
@@ -2504,7 +2500,6 @@ widgets using the ``addWidget()`` method would look like::
     );
 
     // Using an instance - requires you to resolve dependencies.
-    // Prior to 3.6.0 use widgetRegistry() to fetch widgets.
     $autocomplete = new AutocompleteWidget(
         $this->Form->getTemplater(),
         $this->Form->getWidgetLocator()->get('text'),

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -67,8 +67,6 @@ particular method call::
 
     // Read the current template value.
     $result = $this->Paginator->getTemplates('number');
-    // Prior to 3.4
-    $result = $this->Paginator->templates('number');
 
     // Change a template
     $this->Paginator->setTemplates([

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -216,8 +216,6 @@ mappings in your controller::
     namespace App\Controller;
 
     use App\Controller\AppController;
-
-    // Prior to 3.6 use Cake\Network\Exception\NotFoundException
     use Cake\Http\Exception\NotFoundException;
 
     class VideosController extends AppController
@@ -248,8 +246,6 @@ mappings in your controller::
             $this->set('_serialize', ['videos']);
 
             // Set Force Download
-            // Prior to 3.4.0
-            // $this->response->download('report-' . date('YmdHis') . '.' . $format);
             return $this->response->withDownload('report-' . date('YmdHis') . '.' . $format);
         }
     }


### PR DESCRIPTION
We don't need to mention the old ways anymore, as the methods have all been removed.