### PR TITLE
4.x Remove versionadded & versionchanged admonitions

### DIFF
--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -146,9 +146,6 @@ your plugins.
     When adding multiple commands that use the same Command class, the ``help``
     command will display the shortest option.
 
-.. versionadded:: 3.5.0
-    The ``console`` hook was added.
-
 .. _renaming-commands:
 .. index:: nested commands, subcommands
 

--- a/en/console-and-shells/cache.rst
+++ b/en/console-and-shells/cache.rst
@@ -9,6 +9,3 @@ is available for clearing cached data your application has::
 
     // Clear all cache configs
     bin/cake cache clear_all
-
-.. versionadded:: 3.3.0
-    The cache shell was added in 3.3.0

--- a/en/console-and-shells/commands.rst
+++ b/en/console-and-shells/commands.rst
@@ -201,14 +201,6 @@ To make testing console applications easier, CakePHP comes with a
 ``ConsoleIntegrationTestTrait`` trait that can be used to test console applications
 and assert against their results.
 
-.. versionadded:: 3.5.0
-
-    The ``ConsoleIntegrationTestCase`` was added.
-
-.. versionadded:: 3.7.0
-
-    The ``ConsoleIntegrationTestCase`` class was moved into the ``ConsoleIntegrationTestTrait`` trait.
-
 To get started testing your console application, create a test case that uses the
 ``Cake\TestSuite\ConsoleIntegrationTestTrait`` trait. This trait contains a method
 ``exec()`` that is used to execute your command. You can pass the same string
@@ -449,10 +441,6 @@ To test shells that are dispatched using the ``CommandRunner`` class, enable it
 in your test case with the following method::
 
     $this->useCommandRunner();
-
-.. versionadded:: 3.5.0
-
-    The ``CommandRunner`` class was added.
 
 Assertion methods
 -----------------

--- a/en/console-and-shells/helpers.rst
+++ b/en/console-and-shells/helpers.rst
@@ -1,8 +1,5 @@
 Shell Helpers
 #############
 
-.. versionadded:: 3.1
-    Shell Helpers were added in 3.1.0
-
 Shell Helpers let you package up complex output generation code. See
 :ref:`command-helpers` for more information.

--- a/en/console-and-shells/option-parsers.rst
+++ b/en/console-and-shells/option-parsers.rst
@@ -420,9 +420,5 @@ When defining a subcommand you can use the following options:
 
 Adding subcommands can be done as part of a fluent method chain.
 
-.. versionchanged:: 3.5.0
-    When adding multi-word subcommands you can now invoke those commands using
-    ``snake_case`` in addition to the camelBacked form.
-
 .. deprecated:: 3.6.0
     Subcommands are deprecated. Instead use :ref:`nested commands <renaming-commands>`.

--- a/en/console-and-shells/plugin-shell.rst
+++ b/en/console-and-shells/plugin-shell.rst
@@ -27,9 +27,6 @@ update your ``bootstrap_cli.php`` with::
     bin/cake plugin load --cli MyPlugin
     bin/cake plugin unload --cli MyPlugin
 
-.. versionadded:: 3.4.0
-    As of 3.4.0 the ``--cli`` option is supported
-
 Unloading Plugins
 -----------------
 

--- a/en/console-and-shells/routes-shell.rst
+++ b/en/console-and-shells/routes-shell.rst
@@ -1,9 +1,6 @@
 Routes Shell
 ############
 
-.. versionadded:: 3.1
-    The RoutesShell was added in 3.1
-
 The RoutesShell provides a simple to use CLI interface for testing and debugging
 routes. You can use it to test how routes are parsed, and what URLs routing
 parameters will generate.

--- a/en/console-and-shells/shells.rst
+++ b/en/console-and-shells/shells.rst
@@ -234,8 +234,6 @@ from inside your plugin's shell.
 Passing extra parameters to the dispatched Shell
 ------------------------------------------------
 
-.. versionadded:: 3.1
-
 It can sometimes be useful to pass on extra parameters (that are not shell arguments)
 to the dispatched Shell. In order to do this, you can now pass an array to
 ``dispatchShell()``. The array is expected to have a ``command`` key as well
@@ -331,10 +329,6 @@ process::
         // Halt with an error message and error code.
         $this->abort('User cannot be found', 128);
     }
-
-.. versionadded:: 3.2
-    The abort() method was added in 3.2. In prior versions you can use
-    ``error()`` to output a message and stop execution.
 
 Status and Error Codes
 ======================

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -208,9 +208,6 @@ properties of the view before it is created::
 The above shows how you can load custom helpers, set the theme and use a custom
 view class.
 
-.. versionadded:: 3.1
-    ViewBuilder was added in 3.1
-
 Rendering a View
 ----------------
 

--- a/en/controllers/components/csrf.rst
+++ b/en/controllers/components/csrf.rst
@@ -21,12 +21,6 @@ component will throw a
     use :php:meth:`Cake\\Http\\ServerRequest::allowMethod()` to ensure the correct
     HTTP method is used.
 
-.. versionadded:: 3.1
-
-    The exception type changed from
-    :php:class:`Cake\\Network\\Exception\\ForbiddenException` to
-    :php:class:`Cake\\Network\\Exception\\InvalidCsrfTokenException`.
-
 .. deprecated:: 3.5.0
     You should use :ref:`csrf-middleware` instead of
     ``CsrfComponent``.

--- a/en/controllers/components/flash.rst
+++ b/en/controllers/components/flash.rst
@@ -32,12 +32,10 @@ use the ``set()`` method::
 
     $this->Flash->set('This is a message');
 
-.. versionadded:: 3.1
-
-    Flash messages now stack. Successive calls to ``set()`` or ``__call()`` with
-    the same key will append the messages in the ``$_SESSION``. If you want to
-    keep the old behavior (one message even after consecutive calls), set the
-    ``clear`` parameter to ``true`` when configuring the Component.
+Flash messages are appended to an array internally. Successive calls to
+``set()`` or ``__call()`` with the same key will append the messages in the
+``$_SESSION``. If you want to overwrite existing messages when setting a flash
+message, set the ``clear`` option to ``true`` when configuring the Component.
 
 FlashComponent's ``__call()`` and ``set()`` methods optionally take a second
 parameter, an array of options:
@@ -48,17 +46,15 @@ parameter, an array of options:
   ``__call()`` magic method. The element name to use for rendering.
 * ``params`` An optional array of keys/values to make available as variables
   within an element.
-
-.. versionadded:: 3.1
-
-    A new key ``clear`` was added. This key expects a ``bool`` and allows you
-    to delete all messages in the current stack and start a new one.
+* ``clear`` expects a ``bool`` and allows you to delete all messages in the
+  current stack and start a new one.
 
 An example of using these options::
 
     // In your Controller
     $this->Flash->success('The user has been saved', [
         'key' => 'positive',
+        'clear' => true,
         'params' => [
             'name' => $user->name,
             'email' => $user->email
@@ -94,8 +90,6 @@ message.
 
 HTML in Flash Messages
 ======================
-
-.. versionadded:: 3.3.3
 
 It is possible to output HTML in flash messages by using the ``'escape'`` option
 key::

--- a/en/controllers/components/pagination.rst
+++ b/en/controllers/components/pagination.rst
@@ -206,9 +206,6 @@ paginate both tags and articles at the same time::
 See the :ref:`paginator-helper-multiple` section for how to generate scoped HTML
 elements and URLs for pagination.
 
-.. versionadded:: 3.3.0
-    Multiple Pagination was added in 3.3.0
-    
 Paginating the Same Model multiple Times
 ----------------------------------------
 

--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -172,10 +172,6 @@ callbacks like ``json_decode``::
 The above will make ``$this->request->getData()`` an array of the JSON input data,
 without the additional ``true`` you'd get a set of ``stdClass`` objects.
 
-.. deprecated:: 3.1.0
-    As of 3.1.0 the ``addInputType()`` method is deprecated. You should use
-    ``config()`` to add input types at runtime.
-
 .. versionchanged:: 3.6.0
     You should prefer using :ref:`body-parser-middleware` instead of
     RequestHandlerComponent.

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -86,12 +86,6 @@ The ``$type`` parameter can have the following values:
   error.
 * 'secure' Indicates an SSL method restriction failure.
 
-.. versionadded:: cakephp/cakephp 3.2.6
-
-    As of v3.2.6 an additional parameter is included in the blackHole callback,
-    an instance of the ``Cake\Controller\Exception\SecurityException`` is
-    included as a second parameter.
-
 Restrict Actions to SSL
 =======================
 

--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -315,9 +315,6 @@ enable cached routes, provide the desired :ref:`cache configuration
 The above would use the ``routing`` cache engine to store the generated route
 collection.
 
-.. versionadded:: 3.6.0
-    Route caching was added in 3.6.0
-
 .. _security-header-middleware:
 
 Security Header Middleware
@@ -349,9 +346,6 @@ your application's middleware stack::
 
     $middlewareQueue->add($securityHeaders);
 
-.. versionadded:: 3.5.0
-    The ``SecurityHeadersMiddleware`` was added in 3.5.0
-
 .. _encrypted-cookie-middleware:
 
 Encrypted Cookie Middleware
@@ -378,9 +372,6 @@ Cookie data is encrypted with via OpenSSL using AES::
 
 The encryption algorithms and padding style used by the cookie middleware are
 backwards compatible with ``CookieComponent`` from earlier versions of CakePHP.
-
-.. versionadded:: 3.5.0
-    The ``EncryptedCookieMiddleware`` was added in 3.5.0
 
 .. _csrf-middleware:
 
@@ -448,9 +439,6 @@ When enabled, you can access the current CSRF token on the request object::
 
     $token = $this->request->getParam('_csrfToken');
 
-.. versionadded:: 3.5.0
-    The ``CsrfProtectionMiddleware`` was added in 3.5.0
-
 Integration with FormHelper
 ---------------------------
 
@@ -504,9 +492,6 @@ an option. You can also define your own parsers::
         // Use a CSV parsing library.
         return Csv::parse($body);
     });
-    
-.. versionadded:: 3.6.0
-    The ``BodyParserMiddleware`` was added in 3.6.0
 
 .. meta::
     :title lang=en: Http Middleware

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -92,9 +92,6 @@ If you want to access all the query parameters you can use
 
     $query = $this->request->getQueryParams();
 
-.. versionadded:: 3.4.0
-    ``getQueryParams()`` and ``getQuery()`` were added in 3.4.0
-
 Request Body Data
 -----------------
 
@@ -148,9 +145,6 @@ a getter/setter for environment variables without having to modify globals
 To access all the environment variables in a request use ``getServerParams()``::
 
     $env = $this->request->getServerParams();
-
-.. versionadded:: 3.4.0
-    ``getServerParams()`` was added in 3.4.0
 
 XML or JSON Data
 ----------------
@@ -282,9 +276,6 @@ There are several built-in detectors that you can use:
 * ``is('xml')`` Check to see whether the request has 'xml' extension and accept
   'application/xml' or 'text/xml' mimetype.
 
-.. versionadded:: 3.3.0
-    Detectors can take additional parameters as of 3.3.0.
-
 Session Data
 ------------
 
@@ -400,9 +391,6 @@ After proxies are trusted ``clientIp()`` will use the first IP address in the
 ``X-Forwarded-For`` header providing it is the only value that isn't from a trusted
 proxy.
 
-.. versionadded:: 3.7.0
-    ``setTrustedProxies()`` was added.
-
 Checking Accept Headers
 -----------------------
 
@@ -453,9 +441,6 @@ Request cookies can be read through a number of methods::
 
 See the :php:class:`Cake\\Http\\Cookie\\CookieCollection` documentation for how
 to work with cookie collection.
-
-.. versionadded:: 3.5.0
-    ``ServerRequest::getCookieCollection()`` was added in 3.5.0
 
 .. index:: $this->response
 
@@ -617,9 +602,6 @@ To set a string as the response body, do the following::
     // If you want a json response
     $response = $response->withType('application/json')
         ->withStringBody(json_encode(['Foo' => 'bar']));
-
-.. versionadded:: 3.4.3
-    ``withStringBody()`` was added in 3.4.3
 
 .. php:method:: withBody($body)
 
@@ -927,9 +909,6 @@ criteria are met:
 #. The request has an ``Origin`` header.
 #. The request's ``Origin`` value matches one of the allowed Origin values.
 
-.. versionadded:: 3.2
-    The ``CorsBuilder`` was added in 3.2
-
 Common Mistakes with Immutable Responses
 ========================================
 
@@ -1047,9 +1026,6 @@ collection if you modify a cookie::
     // Check state
     $cookie->isHttpOnly();
     $cookie->isSecure();
-
-.. versionadded:: 3.5.0
-    ``CookieCollection`` and ``Cookie`` were added in 3.5.0.
 
 .. meta::
     :title lang=en: Request and Response objects

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -39,10 +39,6 @@ build your own backend. The built-in caching engines are:
 Regardless of the CacheEngine you choose to use, your application interacts with
 :php:class:`Cake\\Cache\\Cache`.
 
-
-.. versionadded:: 3.7.0
-    The ``Array`` engine was added.
-
 .. _cache-configuration:
 
 Configuring Cache Engines
@@ -230,14 +226,6 @@ You can turn off cache fallbacks with ``false``::
     ]);
 
 When there is no fallback cache failures will be raised as exceptions.
-
-
-
-.. versionadded:: 3.5.0
-    Cache engine fallbacks were added.
-
-.. versionchanged:: 3.6.0
-    Fallbacks can now be disabled via ``false``
 
 Removing Configured Cache Engines
 ---------------------------------

--- a/en/core-libraries/collections.rst
+++ b/en/core-libraries/collections.rst
@@ -315,9 +315,6 @@ chunking associative arrays::
         ['c' => 3, 'd' => [4, 5]]
     ]
 
-.. versionadded:: 3.4.0
-    ``chunkWithKeys()`` was added in 3.4.0
-
 Filtering
 =========
 
@@ -475,8 +472,6 @@ for::
     // Average: 150
     $average = (new Collection($items))->avg('invoice.total');
 
-.. versionadded:: 3.5.0
-
 .. php:method:: median($matcher = null)
 
 Calculate the median value of a set of elements. Optionally provide a matcher
@@ -493,7 +488,6 @@ path, or function to extract values to generate the median for::
     // Median: 333
     $median = (new Collection($items))->median('invoice.total');
 
-.. versionadded:: 3.5.0
 
 Grouping and Counting
 ---------------------
@@ -843,9 +837,6 @@ of the each of the original columns::
          ['2014', '50', '100', '200'],
      ]
 
-.. versionadded:: 3.3.0
-    ``Collection::transpose()`` was added in 3.3.0.
-
 Withdrawing Elements
 --------------------
 
@@ -932,9 +923,6 @@ overwritten::
     $cakephpTweets = new Collection($tweets);
     $myTimeline = $cakephpTweets->appendItem($newTweet, 99);
 
-.. versionadded:: 3.6.0
-    appendItem() was added.
-
 .. php:method:: prepend(array|Traversable $items)
 
 The ``prepend()`` method will return a new collection containing the values from
@@ -942,9 +930,6 @@ both sources::
 
     $cakephpTweets = new Collection($tweets);
     $myTimeline = $cakephpTweets->prepend($phpTweets);
-
-.. versionadded:: 3.6.0
-    prepend() was added.
 
 .. php:method:: prependItem($value, $key)
 
@@ -954,10 +939,6 @@ overwritten::
 
     $cakephpTweets = new Collection($tweets);
     $myTimeline = $cakephpTweets->prependItem($newTweet, 99);
-
-.. versionadded:: 3.6.0
-    prependItem() was added.
-
 
 .. warning::
 
@@ -1174,9 +1155,6 @@ into another collection using the ``buffered()`` function::
 
 Now, when both collections are iterated, they will only call the
 extracting operation once.
-
-.. versionadded:: 3.5.0
-    Collections initialized with an array are no longer iterated lazily in order to improve performance.
 
 Making Collections Rewindable
 -----------------------------

--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -97,13 +97,6 @@ also just load an array of options::
     // Or in constructor
     $email = new Email(['from' => 'me@example.org', 'transport' => 'my_custom']);
 
-.. versionchanged:: 3.1
-    The ``default`` email profile is automatically set when an ``Email``
-    instance is created.
-
-.. deprecated:: 3.4.0
-    Use ``setProfile()`` instead of ``profile()``.
-
 Configuring Transports
 ----------------------
 
@@ -488,13 +481,8 @@ message id (since there is no host name in a CLI environment)::
 
 A valid message id can help to prevent emails ending up in spam folders.
 
-.. deprecated:: 3.4.0
-    Use ``setDomain()`` instead of ``domain()``.
-
 Creating Reusable Emails
 ========================
-
-.. versionadded:: 3.1.0
 
 Mailers allow you to create reusable emails throughout your application. They
 can also be used to contain multiple email configurations in one location. This
@@ -606,10 +594,6 @@ Add the trait to your test case to start testing emails::
     {
         use EmailTrait;
     }
-
-.. versionadded:: 3.7.0
-
-    ``Cake\TestSuite\EmailTrait`` was added.
 
 Assertion methods
 -----------------

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -143,9 +143,6 @@ After firing an event on the manager, you can retrieve it from the event list::
 Tracking can be disabled by removing the event list or calling
 :php:meth:`Cake\\Event\\EventList::trackEvents(false)`.
 
-.. versionadded:: 3.2.11
-    Event tracking and :php:class:`Cake\\Event\\EventList` were added.
-
 Core Events
 ===========
 
@@ -278,11 +275,6 @@ of a particular event pattern can be used as the basis of some action.::
 .. note::
 
     The pattern passed to the ``matchingListeners`` method is case sensitive.
-
-.. versionadded:: 3.2.3
-
-    The ``matchingListeners`` method returns an array of events matching
-    a search pattern.
 
 .. _event-priorities:
 

--- a/en/core-libraries/file-folder.rst
+++ b/en/core-libraries/file-folder.rst
@@ -241,9 +241,6 @@ Folder API
 
     Returns a path with slashes normalized for the operating system.
 
-    .. versionadded:: 3.7.0
-
-
 .. php:method:: pwd()
 
     Return current path.

--- a/en/core-libraries/form.rst
+++ b/en/core-libraries/form.rst
@@ -141,10 +141,6 @@ Values should only be defined if the request method is GET, otherwise
 you will overwrite your previous POST Data which might have validation errors
 that need corrections.
 
-
-.. versionadded:: 3.7.0
-    ``Form::setData()`` was added.
-
 Getting Form Errors
 ===================
 
@@ -156,9 +152,6 @@ Once a form has been validated you can retrieve the errors from it::
         'email' => ['A valid email address is required']
     ]
     */
-
-.. versionadded:: 3.7.0
-    ``errors()`` has been deprecated in favor of ``getErrors()``
 
 Invalidating Individual Form Fields from Controller
 ===================================================
@@ -173,10 +166,6 @@ invalidate the fields accordingly to the feedback from the remote server::
     {
         $this->_errors = $errors;
     }
-
-.. versionchanged:: 3.5.1
-    You are not required to specify ``setErrors`` anymore as this has
-    already been included in the ``Form`` class for your convenience.
 
 According to how the validator class would have returned the errors, ``$errors``
 must be in this format::

--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -97,10 +97,6 @@ translating content.
 
 .. php:function:: debug(mixed $var, boolean $showHtml = null, $showFrom = true)
 
-    .. versionchanged:: 3.3.0
-        Calling this method will return passed ``$var``, so that you can, for instance,
-        place it in return statements.
-
     If the core ``$debug`` variable is ``true``, ``$var`` is printed out.
     If ``$showHTML`` is ``true`` or left as ``null``, the data is rendered to be
     browser-friendly. If ``$showFrom`` is not set to ``false``, the debug output
@@ -116,18 +112,10 @@ translating content.
 
 .. php:function:: pr(mixed $var)
 
-    .. versionchanged:: 3.3.0
-        Calling this method will return passed ``$var``, so that you can, for instance,
-        place it in return statements.
-
     Convenience wrapper for ``print_r()``, with the addition of
     wrapping ``<pre>`` tags around the output.
 
 .. php:function:: pj(mixed $var)
-
-    .. versionchanged:: 3.3.0
-        Calling this method will return passed ``$var``, so that you can, for instance,
-        place it in return statements.
 
     JSON pretty print convenience function, with the addition of
     wrapping ``<pre>`` tags around the output.
@@ -135,9 +123,6 @@ translating content.
     It is meant for debugging the JSON representation of objects and arrays.
 
 .. php:function:: env(string $key, string $default = null)
-
-    .. versionchanged:: 3.1.1
-        The ``$default`` parameter has been added.
 
     Gets an environment variable from available sources. Used as a backup if
     ``$_SERVER`` or ``$_ENV`` are disabled.

--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -343,9 +343,6 @@ method::
     ]);
     $http->addCookie(new Cookie('session', 'abc123'));
 
-.. versionadded:: 3.5.0
-    ``addCookie()`` was added in 3.5.0
-
 .. _httpclient-response-objects:
 
 Response Objects
@@ -356,11 +353,6 @@ Response Objects
 .. php:class:: Response
 
 Response objects have a number of methods for inspecting the response data.
-
-.. versionchanged:: 3.3.0
-    As of 3.3.0 ``Cake\Http\Client\Response`` implements the `PSR-7
-    ResponseInterface
-    <http://www.php-fig.org/psr/psr-7/#3-3-psr-http-message-responseinterface>`__.
 
 Reading Response Bodies
 -----------------------

--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -508,9 +508,6 @@ the ``_fallback`` package::
         // Custom code that yields a package here.
     });
 
-.. versionadded:: 3.4.0
-    Replacing the ``_fallback`` loader was added in 3.4.0
-
 Plurals and Context in Custom Translators
 -----------------------------------------
 

--- a/en/core-libraries/security.rst
+++ b/en/core-libraries/security.rst
@@ -119,17 +119,11 @@ data from one of the following sources:
 If neither source is available a warning will be emitted and an unsafe value
 will be used for backwards compatibility reasons.
 
-.. versionadded:: 3.2.3
-    The randomBytes method was added.
-
 .. php:staticmethod:: randomString($length)
 
 Get a random string ``$length`` long from a secure random source. This method
 draws from the same random source as ``randomBytes()`` and will encode the data
 as a hexadecimal string.
-
-.. versionadded:: 3.6.0
-    The randomString method was added.
 
 .. meta::
     :title lang=en: Security

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -171,9 +171,6 @@ The following calendar types are supported:
 * coptic
 * ethiopic
 
-.. versionadded:: 3.1
-    Non-gregorian calendar support was added in 3.1
-
 .. note::
     For constant strings i.e. IntlDateFormatter::FULL Intl uses ICU library
     that feeds its data from CLDR (http://cldr.unicode.org/) which version
@@ -337,8 +334,6 @@ Dates
 =====
 
 .. php:class: Date
-
-.. versionadded:: 3.2
 
 The ``Date`` class in CakePHP implements the same API and methods as
 :php:class:`Cake\\I18n\\Time` does. The main difference between ``Time`` and

--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -90,9 +90,6 @@ If you have multiple fields that are required, you can define them as a list::
         ]
     ]);
 
-.. versionadded:: 3.3.0
-    ``requirePresence()`` accepts an array of fields as of 3.3.0
-
 Allowing Empty Fields
 ---------------------
 
@@ -150,9 +147,6 @@ like::
 See the `Validator API documentation
 <https://api.cakephp.org/3.x/class-Cake.Validation.Validator.html>`_ for the
 full set of validator methods.
-
-.. versionadded:: 3.2
-    Rule building methods were added in 3.2.0
 
 .. _custom-validation-rules:
 
@@ -316,10 +310,6 @@ This would require the ``full_name`` field to be present only in case the user
 wants to create a subscription, while the ``email`` field would always be
 required, since it would also be needed when canceling a subscription.
 
-.. versionadded:: 3.1.1
-    The callable support for ``requirePresence()`` was added in 3.1.1
-
-
 
 Marking Rules as the Last to Run
 --------------------------------
@@ -396,8 +386,6 @@ in the future, you can use the ``addDefaultProvider()`` method as follows::
     therefore **config/bootstrap.php** is the best place to set up your
     default providers.
 
-.. versionadded:: 3.5.0
-
 You can use the `Localized plugin <https://github.com/cakephp/localized>`_ to
 get providers based on countries. With this plugin, you'll be able to validate
 model fields, depending on a country, ie::
@@ -435,8 +423,6 @@ There are a few methods that are common to all classes, defined through the
 
 Nesting Validators
 ------------------
-
-.. versionadded:: 3.0.5
 
 When validating :doc:`/core-libraries/form` with nested data, or when working
 with models that contain array data types, it is necessary to validate the
@@ -479,9 +465,6 @@ conditional application::
     );
 
 The error message for a nested validator can be found in the ``_nested`` key.
-
-.. versionadded:: 3.6.0
-    message and conditions for nested validators were added.
 
 .. _reusable-validators:
 

--- a/en/core-libraries/xml.rst
+++ b/en/core-libraries/xml.rst
@@ -69,8 +69,6 @@ objects with ``loadHtml()``::
 By default entity loading and huge document parsing are disabled. These modes
 can be enabled with the ``loadEntities`` and ``parseHuge`` options respectively.
 
-.. versionadded:: 3.7.0
-
 Transforming a XML String in Array
 ==================================
 

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -112,9 +112,6 @@ Asset.timestamp
     - (bool) ``true`` - Appends the timestamp when debug is ``true``
     - (string) 'force' - Always appends the timestamp.
 
-    .. versionchanged:: 3.6.0
-        As of 3.6.0, you can override this global setting when linking assets
-        using the ``timestamp`` option.
 Asset.cacheTime
     Sets the asset cache time. This determines the http header ``Cache-Control``'s
     ``max-age``, and the http header's ``Expire``'s time for assets.
@@ -278,9 +275,6 @@ data from the environment::
 The second value passed to the env function is the default value. This value
 will be used if no environment variable exists for the given key.
 
-.. versionchanged:: 3.5.0
-    dotenv library support was added to the application skeleton.
-
 Configure Class
 ===============
 
@@ -347,9 +341,6 @@ back::
 
 If ``$key`` is left null, all values in Configure will be returned.
 
-.. versionchanged:: 3.5.0
-    The ``$default`` parameter was added in 3.5.0
-
 .. php:staticmethod:: readOrFail($key)
 
 Reads configuration data just like :php:meth:`Cake\\Core\\Configure::read`
@@ -363,9 +354,6 @@ exist, a :php:class:`RuntimeException` will be thrown::
 
     // Yields:
     ['name' => 'Pizza, Inc.', 'slogan' => 'Pizza for your body and soul'];
-
-.. versionadded:: 3.1.7
-    ``Configure::readOrFail()`` was added in 3.1.7
 
 Checking to see if Configuration Data is Defined
 ------------------------------------------------
@@ -406,9 +394,6 @@ exist, a :php:class:`RuntimeException` will be thrown::
 
     // Yields:
     ['name' => 'Pizza, Inc.', 'slogan' => 'Pizza for your body and soul'];
-
-.. versionadded:: 3.6.0
-    ``Configure::readOrFail()`` was added in 3.6.0
 
 Reading and writing configuration files
 =======================================

--- a/en/development/debugging.rst
+++ b/en/development/debugging.rst
@@ -24,13 +24,6 @@ default.
 Output from this function is only shown if the core ``$debug`` variable
 has been set to ``true``.
 
-.. versionadded:: 3.3.0
-
-    Calling this method will return passed ``$var``, so that you can, for instance,
-    place it in return statements, for example::
-
-        return debug($data); // will return $data in any case.
-
 Also see ``dd()``, ``pr()`` and ``pj()``.
 
 .. php:function:: stackTrace()
@@ -106,10 +99,6 @@ you can mask specific keys::
         'password' => 'xxxxx',
         'awsKey' => 'yyyyy',
     ]);
-
-.. versionadded:: 3.4.0
-
-    Output masking was added in 3.4.0
 
 Logging With Stack Traces
 =========================

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -149,9 +149,6 @@ prefix. You could create the following class::
 This controller would only be used when an error is encountered in a prefixed
 controller, and allows you to define prefix specific logic/templates as needed.
 
-.. versionadded:: 3.7.0
-    Prefixed error controllers were added.
-
 Change the ExceptionRenderer
 ============================
 
@@ -381,10 +378,6 @@ exceptions for HTTP methods
 
     Used for doing a 403 Forbidden error.
 
-.. versionadded:: 3.1
-
-    InvalidCsrfTokenException has been added.
-
 .. php:exception:: InvalidCsrfTokenException
 
     Used for doing a 403 error caused by an invalid CSRF token.
@@ -401,19 +394,13 @@ exceptions for HTTP methods
 
     Used for doing a 406 Not Acceptable error.
 
-    .. versionadded:: 3.1.7 NotAcceptableException has been added.
-
 .. php:exception:: ConflictException
 
     Used for doing a 409 Conflict error.
 
-    .. versionadded:: 3.1.7 ConflictException has been added.
-
 .. php:exception:: GoneException
 
     Used for doing a 410 Gone error.
-
-    .. versionadded:: 3.1.7 GoneException has been added.
 
 For more details on HTTP 4xx error status codes see :rfc:`2616#section-10.4`.
 
@@ -428,8 +415,6 @@ For more details on HTTP 4xx error status codes see :rfc:`2616#section-10.4`.
 .. php:exception:: ServiceUnavailableException
 
     Used for doing a 503 Service Unavailable error.
-
-    .. versionadded:: 3.1.7 Service Unavailable has been added.
 
 For more details on HTTP 5xx error status codes see :rfc:`2616#section-10.5`.
 
@@ -573,8 +558,6 @@ In addition, CakePHP uses the following exceptions:
 
     An entity couldn't be saved/deleted while using :php:meth:`Cake\\ORM\\Table::saveOrFail()` or
     :php:meth:`Cake\\ORM\\Table::deleteOrFail()`.
-
-    .. versionadded:: 3.4.1 PersistenceFailedException has been added.
 
 .. php:namespace:: Cake\Datasource\Exception
 

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -820,9 +820,6 @@ parameter when generating URLs::
         '_host' => 'images.example.com',
     ]);
 
-.. versionadded:: 3.4.0
-    The ``_host`` option was added in 3.4.0
-
 .. index:: file extensions
 .. _file-extensions:
 
@@ -1053,9 +1050,6 @@ compatible with :ref:`prefix-routing`.
 
     While you can nest resources as deeply as you require, it is not recommended
     to nest more than 2 resources together.
-
-.. versionadded:: 3.3
-    The ``prefix`` option was added to ``resources()`` in 3.3.
 
 Limiting the Routes Created
 ---------------------------

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -581,8 +581,6 @@ If you want to use a different connection use::
         public $import = ['table' => 'articles', 'connection' => 'other'];
     }
 
-.. versionadded:: 3.1.7
-
 Usually, you have a Table class along with your fixture, as well. You can also
 use that to retrieve the table name::
 
@@ -800,10 +798,6 @@ and Components, CakePHP offers a specialized ``IntegrationTestTrait`` trait.
 Using this trait in your controller test cases allows you to
 test controllers from a high level.
 
-.. versionadded:: 3.7.0
-
-    The ``IntegrationTestCase`` class was moved into the ``IntegrationTestTrait`` trait.
-
 If you are unfamiliar with integration testing, it is a testing approach that
 makes it easy to test multiple units in concert. The integration testing
 features in CakePHP simulate an HTTP request being handled by your application.
@@ -921,9 +915,6 @@ All of the methods except ``get()`` and ``delete()`` accept a second parameter
 that allows you to send a request body. After dispatching a request you can use
 the various assertions provided by ``IntegrationTestTrait`` or PHPUnit to
 ensure your request had the correct side-effects.
-
-.. versionadded:: 3.5.0
-    ``options()`` and ``head()`` were added in 3.5.0.
 
 Setting up the Request
 ----------------------
@@ -1048,10 +1039,6 @@ can use ``configRequest()`` to set the correct environment variables::
         'environment' => ['HTTPS' => 'on']
     ]);
 
-.. versionadded:: 3.1.2
-    The ``enableCsrfToken()`` and ``enableSecurityToken()`` methods were added
-    in 3.1.2
-
 Integration Testing PSR-7 Middleware
 ------------------------------------
 
@@ -1085,9 +1072,6 @@ You should also take care to try and use :ref:`application-bootstrap` to load
 any plugins containing events/routes. Doing so will ensure that your
 events/routes are connected for each test case.
 
-.. versionadded:: 3.3.0
-    PSR-7 Middleware and the ``useHttpServer()`` method were added in 3.3.0.
-
 Testing with Encrypted Cookies
 ------------------------------
 
@@ -1102,10 +1086,6 @@ helper methods for interacting with encrypted cookies in your test cases::
     $this->get('/bookmarks/index');
 
     $this->assertCookieEncrypted('An updated value', 'my_cookie');
-
-.. versionadded:: 3.1.7
-
-    ``assertCookieEncrypted`` and ``cookieEncrypted`` were added in 3.1.7.
 
 Testing Flash Messages
 ----------------------
@@ -1135,12 +1115,6 @@ As of 3.7.0 there are additional test helpers for flash messages::
 
     // Assert the second flash message element
     $this->assertFlashElementAt(1, 'Flash/error');
-
-.. versionadded:: 3.4.7
-    ``enableRetainFlashMessages()`` was added in 3.4.7
-
-.. versionadded:: 3.7.0
-    Flash message assertions were added.
 
 Testing a JSON Responding Controller
 ------------------------------------
@@ -1211,8 +1185,6 @@ allow the underlying error to bubble up. You can use
 In the above example, the test would fail and the underlying exception message
 and stack trace would be displayed instead of the rendered error page being
 checked.
-
-.. versionadded:: 3.5.0
 
 Assertion methods
 -----------------
@@ -1635,11 +1607,6 @@ global events does not require passing the event manager::
 
     $this->assertEventFired('My.Global.Event');
     $this->assertEventFiredWith('My.Global.Event', 'user', 1);
-
-.. versionadded:: 3.2.11
-
-    Event tracking, ``assertEventFired()``, and ``assertEventFiredWith`` were
-    added.
 
 Testing Email
 =============

--- a/en/migrations.rst
+++ b/en/migrations.rst
@@ -183,11 +183,6 @@ Migration names can follow any of the following patterns:
 You can also use the ``underscore_form`` as the name for your migrations i.e.
 ``create_products``.
 
-.. versionadded:: cakephp/migrations 1.5.2
-
-    As of v1.5.2 of the `migrations plugin <https://github.com/cakephp/migrations/>`_,
-    the migration filename will be automatically camelized.
-
 .. warning::
 
     Migration names are used as migration class names, and thus may collide with
@@ -337,8 +332,6 @@ will generate::
 Specifying field length
 -----------------------
 
-.. versionadded:: cakephp/migrations 1.4
-
 If you need to specify a field length, you can do it within brackets in the
 field type, ie::
 
@@ -445,8 +438,6 @@ log table as migrated.
 Generating a diff between two database states
 =============================================
 
-.. versionadded:: cakephp/migrations 1.6.0
-
 You can generate a migrations file that will group all the differences between
 two database states using the ``migration_diff`` bake template. To do so, you
 can use the following command::
@@ -552,8 +543,6 @@ just like for the ``migrate`` command.
 ``mark_migrated`` : Marking a migration as migrated
 ---------------------------------------------------
 
-.. versionadded:: 1.4.0
-
 It can sometimes be useful to mark a set of migrations as migrated without
 actually running them.
 In order to do this, you can use the ``mark_migrated`` command.
@@ -624,10 +613,6 @@ As for migrations, a ``bake`` interface is provided for seed files::
     # You can specify an alternative connection when generating a seeder.
     $ bin/cake bake seed Articles --connection connection
 
-.. versionadded:: cakephp/migrations 1.6.4
-
-    Options ``--data``, ``--limit`` and ``--fields`` were added to export
-    data from your database.
 
 As of 1.6.4, the ``bake seed`` command allows you to create a seed file with
 data exported from your database by using the ``--data`` flag::
@@ -675,8 +660,6 @@ that the same seeder can be applied multiple times.
 
 Calling a Seeder from another Seeder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: cakephp/migrations 1.6.2
 
 Usually when seeding, the order in which to insert the data must be respected
 to not encounter constraints violations. Since Seeders are executed in the
@@ -735,8 +718,6 @@ execution to the migrations relative to that plugin::
 
 Running Migrations in a non-shell environment
 =============================================
-
-.. versionadded:: cakephp/migrations 1.2.0
 
 Since the release of version 1.2 of the migrations plugin, you can run
 migrations from a non-shell environment, directly from an app, by using the new
@@ -963,8 +944,6 @@ In your migration file, you can do the following::
 
 Skipping the ``schema.lock`` file generation
 --------------------------------------------
-
-.. versionadded:: cakephp/migrations 1.6.5
 
 In order for the diff feature to work, a **.lock** file is generated everytime
 you migrate, rollback or bake a snapshot, to keep track of the state of your

--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -261,9 +261,6 @@ interface requires a single method to be implemented::
 The ``TranslateBehavior`` has a non-trivial implementation of this interface
 that you might want to refer to.
 
-.. versionadded:: 3.3.0
-    The ability for behaviors to participate in marshalling was added in 3.3.0
-
 Removing Loaded Behaviors
 =========================
 

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -122,6 +122,3 @@ then updates the counter of the *previously* associated item.
     configured in association options and set the ``cascadeCallbacks`` configuration
     option to true. See how to configure a custom join table
     :ref:`using-the-through-option`.
-
-.. versionchanged:: 3.6.0
-    Returning ``false`` to skip updates was added.

--- a/en/orm/behaviors/tree.rst
+++ b/en/orm/behaviors/tree.rst
@@ -227,8 +227,6 @@ as the scope::
 Recovering with custom sort field
 =================================
 
-.. versionadded:: 3.0.14
-
 By default, recover() sorts the items using the primary key. This works great
 if this is a numeric (auto increment) column, but can lead to weird results if you
 use UUIDs.

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -372,15 +372,6 @@ automatically convert input parameters from ``DateTime`` instances into a
 timestamp or formatted datestrings. Likewise, 'binary' columns will accept file
 handles, and generate file handles when reading data.
 
-.. versionchanged:: 3.3.0
-    The ``json`` type was added.
-
-.. versionchanged:: 3.5.0
-    The ``smallinteger`` and ``tinyinteger`` types were added.
-
-.. versionchanged:: 3.6.0
-    The ``binaryuuid`` type was added.
-
 .. _adding-custom-database-types:
 
 Adding Custom Types
@@ -451,9 +442,6 @@ the type mapping. During our application bootstrap we should do the following::
 
     Type::map('json', 'App\Database\Type\JsonType');
 
-.. versionadded:: 3.3.0
-    The JsonType described in this example was added to the core.
-
 We can then overload the reflected schema data to use our new type, and
 CakePHP's database layer will automatically convert our JSON data when creating
 queries. You can use the custom types you've created by mapping the types in
@@ -476,9 +464,6 @@ your Table's :ref:`_initializeSchema() method <saving-complex-types>`::
 
 Mapping Custom Datatypes to SQL Expressions
 -------------------------------------------
-
-.. versionadded:: 3.3.0
-    Support for mapping custom data types to SQL expressions was added in 3.3.0.
 
 The previous example maps a custom datatype for a 'json' column type which is
 easily represented as a string in a SQL statement. Complex SQL data
@@ -586,9 +571,6 @@ to our table class <saving-complex-types>`.
 
 Enabling Immutable DateTime Objects
 -----------------------------------
-
-.. versionadded:: 3.2
-    Immutable date/time objects were added in 3.2.
 
 Because Date/Time objects are easily mutated in place, CakePHP allows you to
 enable immutable value objects. This is best done in your application's

--- a/en/orm/deleting-data.rst
+++ b/en/orm/deleting-data.rst
@@ -102,5 +102,3 @@ If you want to track down the entity that failed to save, you can use the
 
 As this internally performs a :php:meth:`Cake\\ORM\\Table::delete()` call, all
 corresponding delete events will be triggered.
-
-.. versionadded:: 3.4.1

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -125,9 +125,6 @@ a field contains a 'non-empty' value::
     $article->isEmpty('user_id');  // true
     $article->hasValue('user_id'); // false
 
-.. versionadded:: 3.6.0
-    The ``hasValue()`` and ``isEmpty()`` methods were added in 3.6.0
-
 Accessors & Mutators
 ====================
 
@@ -279,13 +276,6 @@ To get a list of all dirty fields of an ``Entity`` you may call::
 
     $dirtyFields = $entity->getDirty();
 
-.. versionadded:: 3.4.3
-
-    ``getDirty()`` has been added.
-
-.. versionadded:: 3.5.0
-    ``isDirty()``, ``setDirty()`` were added.
-
 Validation Errors
 =================
 
@@ -313,9 +303,6 @@ on an entity, making it easier to test code that works with error messages::
         'password' => ['Password is required'],
         'username' => ['Username is required']
     ]);
-
-.. versionadded:: 3.7.0
-    ``hasErrors()`` was added.
 
 .. _entities-mass-assignment:
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -264,17 +264,15 @@ Set the second parameter of ``order()`` (as well as ``orderAsc()`` or ``orderDes
     $query = $articles->find()
         ->order(['created' => 'DESC'], Query::OVERWRITE);
 
-.. versionadded:: 3.0.12
+The ``orderAsc`` and ``orderDesc`` methods can be used when you need to sort on
+complex expressions::
 
-    In addition to ``order``, the ``orderAsc`` and ``orderDesc`` methods can be
-    used when you need to sort on complex expressions::
-
-        $query = $articles->find();
-        $concat = $query->func()->concat([
-            'title' => 'identifier',
-            'synopsis' => 'identifier'
-        ]);
-        $query->orderAsc($concat);
+    $query = $articles->find();
+    $concat = $query->func()->concat([
+        'title' => 'identifier',
+        'synopsis' => 'identifier'
+    ]);
+    $query->orderAsc($concat);
 
 To limit the number of rows or set the row offset you can use the ``limit()``
 and ``page()`` methods::
@@ -308,9 +306,6 @@ purpose::
         ->select(['slug' => $query->func()->concat(['title' => 'identifier', '-', 'id' => 'identifier'])])
         ->select($articlesTable); // Select all fields from articles
 
-.. versionadded:: 3.1
-    Passing a table object to select() was added in 3.1.
-
 If you want to select all but a few fields on a table, you can use
 ``selectAllExcept()``::
 
@@ -321,9 +316,6 @@ If you want to select all but a few fields on a table, you can use
 
 You can also pass an ``Association`` object when working with contained
 associations.
-
-.. versionadded:: 3.6.0
-    The ``selectAllExcept()`` method was added.
 
 .. _using-sql-functions:
 
@@ -364,14 +356,6 @@ A number of commonly used functions can be created with the ``func()`` method:
 - ``dateAdd()`` Add the time unit to the date expression.
 - ``dayOfWeek()`` Returns a FunctionExpression representing a call to SQL
   WEEKDAY function.
-
-.. versionadded:: 3.1
-
-    ``extract()``, ``dateAdd()`` and ``dayOfWeek()`` methods have been added.
-
-.. versionadded:: 3.7
-
-    ``rand()`` was added.
 
 When providing arguments for SQL functions, there are two kinds of parameters
 you can use, literal arguments and bound parameters. Identifier/Literal parameters allow
@@ -925,10 +909,6 @@ use the ``identifier()`` method::
 
     To prevent SQL injections, Identifier expressions should never have
     untrusted data passed into them.
-
-.. versionadded:: 3.6.0
-
-    ``Query::identifier()`` was added in 3.6.0
 
 Automatically Creating IN Clauses
 ---------------------------------

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -651,9 +651,6 @@ Alternatively, if you have multiple associations, you can use ``enableAutoFields
             return $q->autoFields(true);
         }]);
 
-.. versionadded:: 3.1
-    Selecting columns via an association object was added in 3.1
-
 Sorting Contained Associations
 ------------------------------
 
@@ -754,9 +751,6 @@ associations::
 Again, the only difference is that no additional columns will be added to the
 result set, and no ``_matchingData`` property will be set.
 
-.. versionadded:: 3.1
-    Query::innerJoinWith() was added in 3.1
-
 Using notMatching
 -----------------
 
@@ -814,9 +808,6 @@ commented by a certain user::
 Keep in mind that contrary to the ``matching()`` function, ``notMatching()``
 will not add any data to the ``_matchingData`` property in the results.
 
-.. versionadded:: 3.1
-    Query::notMatching() was added in 3.1
-
 Using leftJoinWith
 ------------------
 
@@ -849,9 +840,6 @@ word, per author::
 
 This function will not load any columns from the specified associations into the
 result set.
-
-.. versionadded:: 3.1
-    Query::leftJoinWith() was added in 3.1
 
 .. end-filtering
 
@@ -1064,9 +1052,6 @@ can load additional associations using ``loadInto()``::
 
 You can eager load additional data into a single entity, or a collection of
 entities.
-
-.. versionadded: 3.1
-    Table::loadInto() was added in 3.1
 
 .. _map-reduce:
 

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -275,9 +275,6 @@ When converting belongsToMany data, you can disable the new entity creation, by
 using the ``onlyIds`` option. When enabled, this option restricts belongsToMany
 marshalling to only use the ``_ids`` key and ignore all other data.
 
-.. versionadded:: 3.1.0
-    The ``onlyIds`` option was added in 3.1.0
-
 Converting HasMany Data
 -----------------------
 
@@ -310,9 +307,6 @@ new parent record you can use the ``_ids`` format::
 When converting hasMany data, you can disable the new entity creation, by using
 the ``onlyIds`` option. When enabled, this option restricts hasMany marshalling
 to only use the ``_ids`` key and ignore all other data.
-
-.. versionadded:: 3.1.0
-    The ``onlyIds`` option was added in 3.1.0
 
 Converting Multiple Records
 ---------------------------
@@ -1107,8 +1101,6 @@ If you want to track down the entity that failed to save, you can use the
 As this internally perfoms a :php:meth:`Cake\\ORM\\Table::save()` call, all
 corresponding save events will be triggered.
 
-.. versionadded:: 3.4.1
-
 Saving Multiple Entities
 ========================
 
@@ -1133,8 +1125,6 @@ be an array of entities created using ``newEntities()`` / ``patchEntities()``.
     $result = $articles->saveMany($entities);
 
 The result will be updated entities on success or ``false`` on failure.
-
-.. versionadded:: 3.2.8
 
 Bulk Updates
 ============

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -26,9 +26,6 @@ fields with errors will not be present in the returned entity::
         // Entity failed validation.
     }
 
-.. versionadded:: 3.4.0
-    The ``getErrors()`` function was added.
-
 When building an entity with validation enabled the following occurs:
 
 1. The validator object is created.
@@ -416,9 +413,6 @@ unique checks using ``allowMultipleNulls``::
         ['allowMultipleNulls' => false]
     ));
 
-.. versionadded:: 3.3.0
-    The ``allowNullableNulls`` and ``allowMultipleNulls`` options were added.
-
 Association Count Rules
 -----------------------
 
@@ -443,9 +437,6 @@ Note that ``validCount`` returns ``false`` if the property is not countable or d
 
     // The save operation will fail if tags is null.
     $rules->add($rules->validCount('tags', 0, '<=', 'You must not have any tags'));
-
-.. versionadded:: 3.3.0
-    The ``validCount()`` method was added in 3.3.0.
 
 Using Entity Methods as Rules
 -----------------------------

--- a/en/views.rst
+++ b/en/views.rst
@@ -303,9 +303,6 @@ specified block.::
     // Assigning an empty string will also clear the sidebar block.
     $this->assign('sidebar', '');
 
-.. versionadded:: 3.2
-    View::reset() was added in 3.2
-
 Assigning a block's content is often useful when you want to convert a view
 variable into a block. For example, you may want to use a block for the page
 title, and sometimes assign the title as a view variable in the controller::
@@ -674,8 +671,6 @@ or another plugin, use the following::
 
 Routing prefix and Elements
 ---------------------------
-
-.. versionadded:: 3.0.1
 
 If you have a Routing prefix configured, the Element path resolution can switch
 to a prefix location, as Layouts and action View do.

--- a/en/views/cells.rst
+++ b/en/views/cells.rst
@@ -254,9 +254,6 @@ messages could look like::
 The above cell would paginate the ``Messages`` model using :ref:`scoped
 pagination parameters <paginating-multiple-queries>`.
 
-.. versionadded:: 3.5.0
-    ``Cake\Datasource\Paginator`` was added in 3.5.0.
-
 Cell Options
 ============
 

--- a/en/views/helpers/breadcrumbs.rst
+++ b/en/views/helpers/breadcrumbs.rst
@@ -5,8 +5,6 @@ Breadcrumbs
 
 .. php:class:: BreadcrumbsHelper(View $view, array $config = [])
 
-.. versionadded:: 3.3.6
-
 BreadcrumbsHelper provides a way to easily deal with the creation and rendering
 of a breadcrumbs trail for your app.
 
@@ -192,9 +190,6 @@ when you want to transform the crumbs and overwrite the list::
     })->toArray();
 
     $this->Breadcrumbs->reset()->add($crumbs);
-
-.. versionadded:: 3.4.0
-    The ``reset()`` method was added in 3.4.0
 
 .. meta::
     :title lang=en: BreadcrumbsHelper

--- a/en/views/helpers/flash.rst
+++ b/en/views/helpers/flash.rst
@@ -45,20 +45,12 @@ You can also override any of the options that were set in FlashComponent::
     When building custom flash message templates, be sure to properly HTML
     encode any user data. CakePHP won't escape flash message parameters for you.
 
-.. versionadded:: 3.1
-
-    The :doc:`FlashComponent </controllers/components/flash>` now
-    stacks messages. If you set multiple flash messages, when you call
-    ``render()``, each message will be rendered in its own elements, in the
-    order they were set.
 
 For more information about the available array options, please refer to the
 :doc:`FlashComponent </controllers/components/flash>` section.
 
 Routing Prefix and Flash Messages
 =================================
-
-.. versionadded:: 3.0.1
 
 If you have a Routing prefix configured, you can now have your Flash elements
 stored in **templates/{Prefix}/Element/Flash**. This way, you can have

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -169,8 +169,6 @@ Valid values:
 Getting form values from the query string
 -----------------------------------------
 
-.. versionadded:: 3.4.0
-
 A FormHelper's values sources define where its rendered elements, such as
 input-tags, receive their values from.
 
@@ -700,8 +698,8 @@ as follows:
 
 * ``'default'`` - Used to set a default value for the control field. The
   value is used if the data passed to the form does not contain a value for the
-  field (or if no data is passed at all). An explicit default value will
-  override any default values defined in the schema.
+  field (or if no data is passed at all). If no default value is provided, the
+  column's default value will be used.
 
   Example usage::
 
@@ -736,11 +734,6 @@ as follows:
 In addition to the above options, you can mixin any HTML attribute you wish to
 use. Any non-special option name will be treated as an HTML attribute, and
 applied to the generated HTML control element.
-
-.. versionchanged:: 3.3.0
-    As of 3.3.0, FormHelper will automatically use any default values defined
-    in your database schema. You can disable this behavior by setting
-    the ``schemaDefault`` option to ``false``.
 
 Creating Input Elements
 =======================
@@ -1829,8 +1822,6 @@ Example::
 Displaying validation messages in HTML5 validity messages
 ---------------------------------------------------------
 
-.. versionadded:: 3.7.0
-
 If the ``autoSetCustomValidity`` FormHelper option is set to ``true``, error messages for
 the field's required and notBlank validation rules will be used in lieu of the default
 browser HTML5 required messages. Enabling the option will add the ``onvalid`` and ``oninvalid``
@@ -2229,9 +2220,6 @@ Output:
         <input name="password" id="password" type="password">
         <span class="help">At least 8 characters long.</span>
     </div>
-
-.. versionadded:: 3.1
-    The templateVars option was added in 3.1.0
 
 Moving Checkboxes & Radios Outside of a Label
 ---------------------------------------------

--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -317,10 +317,6 @@ PaginatorHelper can be used to create pagination link tags in your page
     // Create next/prev & first/last links for the current model.
     echo $this->Paginator->meta(['first' => true, 'last' => true]);
 
-.. versionadded:: 3.4.0
-
-    The ``first`` and ``last`` options were added in 3.4.0
-
 Checking the Pagination State
 =============================
 
@@ -347,8 +343,6 @@ Checking the Pagination State
 .. php:method:: total(string $model = null)
 
     Returns the total number of pages for the provided model.
-
-    .. versionadded:: 3.4.0
 
 Creating a Page Counter
 =======================
@@ -420,9 +414,6 @@ Create a dropdown control that changes the ``limit`` query parameter::
     echo $this->Paginator->limitControl([25 => 25, 50 => 50], $user->perPage);
 
 The generated form and control will automatically submit on change.
-
-.. versionadded:: 3.5.0
-    The ``limitControl()`` method was added in 3.5.0
 
 Configuring Pagination Options
 ==============================
@@ -572,9 +563,6 @@ to ``PaginatorHelper``, or use ``options()`` to set the default model::
 
 By using the ``model`` option, ``PaginatorHelper`` will automatically use the
 ``scope`` defined in when the query was paginated.
-
-.. versionadded:: 3.3.0
-    Multiple Pagination was added in 3.3.0
 
 .. meta::
     :title lang=en: PaginatorHelper


### PR DESCRIPTION
Remove the 3.x related callouts as they are not useful in a 4.x world.