### PR TITLE
4.x Update Beforefilter and other event listeners

### DIFF
--- a/en/bake/development.rst
+++ b/en/bake/development.rst
@@ -19,10 +19,10 @@ be used::
     <?php
     // config/bootstrap_cli.php
 
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use Cake\Event\EventManager;
 
-    EventManager::instance()->on('Bake.initialize', function (Event $event) {
+    EventManager::instance()->on('Bake.initialize', function (EventInterface $event) {
         $view = $event->getSubject();
 
         // In my bake templates, allow the use of the MySpecial helper
@@ -44,10 +44,10 @@ variables used in the bake templates::
     <?php
     // config/bootstrap_cli.php
 
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use Cake\Event\EventManager;
 
-    EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
+    EventManager::instance()->on('Bake.beforeRender', function (EventInterface $event) {
         $view = $event->getSubject();
 
         // Use $rows for the main data variable in indexes
@@ -82,9 +82,9 @@ you can use the following event::
 
     EventManager::instance()->on(
         'Bake.beforeRender.Controller.controller',
-        function (Event $event) {
+        function (EventInterface $event) {
             $view = $event->getSubject();
-            if ($view->viewVars['name'] == 'Users') {
+            if ($view->get('name') == 'Users') {
                 // add the login and logout actions to the Users controller
                 $view->set('actions', [
                     'login',

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -478,7 +478,7 @@ methods are implemented by your controllers
     listeners of the same event from being called. You must explicitly
     :ref:`stop the event <stopping-events>`.
 
-.. php:method:: beforeRender(Event $event)
+.. php:method:: beforeRender(EventInterface $event)
 
     Called during the ``Controller.beforeRender`` event which occurs after
     controller action logic, but before the view is rendered. This callback is
@@ -486,7 +486,7 @@ methods are implemented by your controllers
     :php:meth:`~Cake\\Controller\\Controller::render()` manually before the end
     of a given action.
 
-.. php:method:: afterFilter(Event $event)
+.. php:method:: afterFilter(EventInterface $event)
 
     Called during the ``Controller.shutdown`` event which is triggered after
     every controller action, and after rendering is complete. This is the last

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -464,7 +464,7 @@ Controller Callback Methods
 By default the following callback methods are connected to related events if the
 methods are implemented by your controllers
 
-.. php:method:: beforeFilter(Event $event)
+.. php:method:: beforeFilter(EventInterface $event)
 
     Called during the ``Controller.initialize`` event which occurs before every
     action in the controller.  It's a handy place to check for an active session
@@ -498,8 +498,8 @@ also provide a similar set of callbacks.
 Remember to call ``AppController``'s callbacks within child controller callbacks
 for best results::
 
-    //use Cake\Event\Event;
-    public function beforeFilter(Event $event)
+    //use Cake\Event\EventInterface;
+    public function beforeFilter(EventInterface $event)
     {
         parent::beforeFilter($event);
     }

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -50,7 +50,7 @@ You can configure components at runtime using the ``config()`` method. Often,
 this is done in your controller's ``beforeFilter()`` method. The above could
 also be expressed as::
 
-    public function beforeFilter(Event $event)
+    public function beforeFilter(EventInterface $event)
     {
         $this->Auth->config('authorize', ['controller']);
         $this->Auth->config('loginAction', ['controller' => 'Users', 'action' => 'login']);
@@ -288,27 +288,27 @@ Component Callbacks
 Components also offer a few request life-cycle callbacks that allow them to
 augment the request cycle.
 
-.. php:method:: beforeFilter(Event $event)
+.. php:method:: beforeFilter(EventInterface $event)
 
     Is called before the controller's
     beforeFilter method, but *after* the controller's initialize() method.
 
-.. php:method:: startup(Event $event)
+.. php:method:: startup(EventInterface $event)
 
     Is called after the controller's beforeFilter
     method but before the controller executes the current action
     handler.
 
-.. php:method:: beforeRender(Event $event)
+.. php:method:: beforeRender(EventInterface $event)
 
     Is called after the controller executes the requested action's logic,
     but before the controller renders views and layout.
 
-.. php:method:: shutdown(Event $event)
+.. php:method:: shutdown(EventInterface $event)
 
     Is called before output is sent to the browser.
 
-.. php:method:: beforeRedirect(Event $event, $url, Response $response)
+.. php:method:: beforeRedirect(EventInterface $event, $url, Response $response)
 
     Is invoked when the controller's redirect
     method is called but before any further action. If this method

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -365,13 +365,13 @@ generate these API tokens randomly using libraries from CakePHP::
 
     use Cake\Auth\DefaultPasswordHasher;
     use Cake\Utility\Text;
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use Cake\ORM\Table;
     use Cake\Utility\Security;
 
     class UsersTable extends Table
     {
-        public function beforeSave(Event $event)
+        public function beforeSave(EventInterface $event)
         {
             $entity = $event->getData('entity');
 
@@ -433,12 +433,12 @@ from the normal password hash::
     namespace App\Model\Table;
 
     use Cake\Auth\DigestAuthenticate;
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use Cake\ORM\Table;
 
     class UsersTable extends Table
     {
-        public function beforeSave(Event $event)
+        public function beforeSave(EventInterface $event)
         {
             $entity = $event->getData('entity');
 

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -779,7 +779,7 @@ Deciding When to run Authentication
 -----------------------------------
 
 In some cases you may want to use ``$this->Auth->user()`` in the
-``beforeFilter(Event $event)`` method. This is achievable by using the
+``beforeFilter()`` method. This is achievable by using the
 ``checkAuthIn`` config key. The following changes which event for which initial
 authentication checks should be done::
 

--- a/en/controllers/components/security.rst
+++ b/en/controllers/components/security.rst
@@ -44,7 +44,7 @@ components in your ``initialize()`` method.
 Handling Blackhole Callbacks
 ============================
 
-.. php:method:: blackHole(object $controller, string $error = '', SecurityException $exception = null)
+.. php:method:: blackHole(Controller $controller, string $error = '', ?SecurityException $exception = null)
 
 If an action is restricted by the Security Component it is
 'black-holed' as an invalid request which will result in a 400 error
@@ -55,7 +55,7 @@ in the controller.
 By configuring a callback method you can customize how the blackhole process
 works::
 
-    public function beforeFilter(Event $event)
+    public function beforeFilter(EventInterface $event)
     {
         parent::beforeFilter($event);
         

--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -531,7 +531,7 @@ instructions. For example, we could add the following to our ``UserMailer``::
         ];
     }
 
-    public function onRegistration(Event $event, EntityInterface $entity, ArrayObject $options)
+    public function onRegistration(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
         if ($entity->isNew()) {
             $this->send('welcome', [$entity]);

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -336,7 +336,7 @@ the afterRender callback::
 The listeners of the ``View.afterRender`` callback should have the following
 signature::
 
-    function (Event $event, $viewFileName)
+    function (EventInterface $event, $viewFileName)
 
 Each value provided to the Event constructor will be converted into function
 parameters in the order they appear in the data array. If you use an associative

--- a/en/debug-kit.rst
+++ b/en/debug-kit.rst
@@ -240,7 +240,7 @@ Panel Hook Methods
 You can also implement the following hook methods to customize how your panel
 behaves and appears:
 
-* ``shutdown(Event $event)`` This method typically collects and prepares the
+* ``shutdown(EventInterface $event)`` This method typically collects and prepares the
   data for the panel. Data is generally stored in ``$this->_data``.
 * ``summary()`` Can return a string of summary data to be displayed in the
   toolbar even when a panel is collapsed. Often this is a counter, or short

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -121,6 +121,7 @@ prefix. You could create the following class::
     namespace App\Controller\Admin;
 
     use App\Controller\AppController;
+    use Cake\Event\EventInterface;
 
     class ErrorController extends AppController
     {
@@ -137,10 +138,10 @@ prefix. You could create the following class::
         /**
          * beforeRender callback.
          *
-         * @param \Cake\Event\Event $event Event.
+         * @param \Cake\Event\EventInterface $event Event.
          * @return void
          */
-        public function beforeRender(Event $event)
+        public function beforeRender(EventInterface $event)
         {
             $this->viewBuilder()->setTemplatePath('Error');
         }

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -1512,7 +1512,7 @@ In your controller's ``beforeFilter()`` method you can call
 ``parseNamedParams()`` to extract any named parameters from the passed
 arguments::
 
-    public function beforeFilter(Event $event)
+    public function beforeFilter(EventInterface $event)
     {
         parent::beforeFilter($event);
         $this->request = Router::parseNamedParams($this->request);

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1363,7 +1363,7 @@ controllers that use it. Here is our example component located in
             }
         }
 
-        public function startup(Event $event)
+        public function startup(EventInterface $event)
         {
             $this->setController($event->getSubject());
         }
@@ -1553,7 +1553,7 @@ Expanding on the Orders example, say we have the following tables::
             ];
         }
 
-        public function removeFromCart(Event $event)
+        public function removeFromCart(EventInterface $event)
         {
             $order = $event->getData('order');
             $this->delete($order->cart_id);

--- a/en/elasticsearch.rst
+++ b/en/elasticsearch.rst
@@ -54,7 +54,7 @@ class in elasticsearch::
 
 You can then use your type class in your controllers::
 
-    public function beforeFilter(Event $event)
+    public function beforeFilter(EventInterface $event)
     {
         parent::beforeFilter($event);
         // Load the Type using the 'Elastic' provider.

--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -148,7 +148,7 @@ behavior should now look like::
 
     use ArrayObject;
     use Cake\Datasource\EntityInterface;
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use Cake\ORM\Behavior;
     use Cake\ORM\Entity;
     use Cake\ORM\Query;
@@ -169,7 +169,7 @@ behavior should now look like::
             $entity->set($config['slug'], Text::slug($value, $config['replacement']));
         }
 
-        public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+        public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options)
         {
             $this->slug($entity);
         }
@@ -185,7 +185,7 @@ The above code shows a few interesting features of behaviors:
 
 To prevent the saving from continuing simply stop event propagation in your callback::
 
-    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
         if (...) {
             $event->stopPropagation();

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -578,11 +578,11 @@ use the ``Model.beforeMarshal`` event. This event lets you manipulate the
 request data just before entities are created::
 
     // Include use statements at the top of your file.
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use ArrayObject;
 
     // In a table or behavior class
-    public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
+    public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options)
     {
         if (isset($data['username'])) {
             $data['username'] = mb_strtolower($data['username']);
@@ -603,11 +603,11 @@ Validation is triggered just after this event is finished. A common example of
 changing the data before it is validated is trimming all fields before saving::
 
     // Include use statements at the top of your file.
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
     use ArrayObject;
 
     // In a table or behavior class
-    public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
+    public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options)
     {
         foreach ($data as $key => $value) {
             if (is_string($value)) {

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -156,7 +156,7 @@ Event List
 initialize
 ----------
 
-.. php:method:: initialize(Event $event, ArrayObject $data, ArrayObject $options)
+.. php:method:: initialize(EventInterface $event, ArrayObject $data, ArrayObject $options)
 
 The ``Model.initialize`` event is fired after the constructor and initialize
 methods are called. The ``Table`` classes do not listen to this event by
@@ -192,7 +192,7 @@ This will call the ``initializeEvent`` when any ``Table`` class is constructed.
 beforeMarshal
 -------------
 
-.. php:method:: beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
+.. php:method:: beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options)
 
 The ``Model.beforeMarshal`` event is fired before request data is converted
 into entities. See the :ref:`before-marshal` documentation for more information.
@@ -200,7 +200,7 @@ into entities. See the :ref:`before-marshal` documentation for more information.
 beforeFind
 ----------
 
-.. php:method:: beforeFind(Event $event, Query $query, ArrayObject $options, $primary)
+.. php:method:: beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary)
 
 The ``Model.beforeFind`` event is fired before each find operation. By stopping
 the event and supplying a return value you can bypass the find operation
@@ -221,7 +221,7 @@ been replaced with the :ref:`map-reduce` features and entity constructors.
 buildValidator
 --------------
 
-.. php:method:: buildValidator(Event $event, Validator $validator, $name)
+.. php:method:: buildValidator(EventInterface $event, Validator $validator, $name)
 
 The ``Model.buildValidator`` event is fired when ``$name`` validator is created.
 Behaviors, can use this hook to add in validation methods.
@@ -229,7 +229,7 @@ Behaviors, can use this hook to add in validation methods.
 buildRules
 ----------
 
-.. php:method:: buildRules(Event $event, RulesChecker $rules)
+.. php:method:: buildRules(EventInterface $event, RulesChecker $rules)
 
 The ``Model.buildRules`` event is fired after a rules instance has been
 created and after the table's ``buildRules()`` method has been called.
@@ -237,7 +237,7 @@ created and after the table's ``buildRules()`` method has been called.
 beforeRules
 -----------
 
-.. php:method:: beforeRules(Event $event, EntityInterface $entity, ArrayObject $options, $operation)
+.. php:method:: beforeRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation)
 
 The ``Model.beforeRules`` event is fired before an entity has had rules applied. By
 stopping this event, you can halt the rules checking and set the result
@@ -246,7 +246,7 @@ of applying rules.
 afterRules
 ----------
 
-.. php:method:: afterRules(Event $event, EntityInterface $entity, ArrayObject $options, $result, $operation)
+.. php:method:: afterRules(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation)
 
 The ``Model.afterRules`` event is fired after an entity has rules applied. By
 stopping this event, you can return the final value of the rules checking
@@ -255,7 +255,7 @@ operation.
 beforeSave
 ----------
 
-.. php:method:: beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+.. php:method:: beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options)
 
 The ``Model.beforeSave`` event is fired before each entity is saved. Stopping
 this event will abort the save operation. When the event is stopped the result
@@ -265,14 +265,14 @@ How to stop an event is documented :ref:`here <stopping-events>`.
 afterSave
 ---------
 
-.. php:method:: afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
+.. php:method:: afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options)
 
 The ``Model.afterSave`` event is fired after an entity is saved.
 
 afterSaveCommit
 ---------------
 
-.. php:method:: afterSaveCommit(Event $event, EntityInterface $entity, ArrayObject $options)
+.. php:method:: afterSaveCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options)
 
 The ``Model.afterSaveCommit`` event is fired after the transaction in which the
 save operation is wrapped has been committed. It's also triggered for non atomic
@@ -283,7 +283,7 @@ not triggered if a transaction is started before calling save.
 beforeDelete
 ------------
 
-.. php:method:: beforeDelete(Event $event, EntityInterface $entity, ArrayObject $options)
+.. php:method:: beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options)
 
 The ``Model.beforeDelete`` event is fired before an entity is deleted. By
 stopping this event you will abort the delete operation. When the event is stopped the result
@@ -293,14 +293,14 @@ How to stop an event is documented :ref:`here <stopping-events>`.
 afterDelete
 -----------
 
-.. php:method:: afterDelete(Event $event, EntityInterface $entity, ArrayObject $options)
+.. php:method:: afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options)
 
 The ``Model.afterDelete`` event is fired after an entity has been deleted.
 
 afterDeleteCommit
 -----------------
 
-.. php:method:: afterDeleteCommit(Event $event, EntityInterface $entity, ArrayObject $options)
+.. php:method:: afterDeleteCommit(EventInterface $event, EntityInterface $entity, ArrayObject $options)
 
 The ``Model.afterDeleteCommit`` event is fired after the transaction in which the
 delete operation is wrapped has been is committed. It's also triggered for non

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -61,12 +61,12 @@ with CakePHP::
     namespace App\Controller;
 
     use App\Controller\AppController;
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
 
     class UsersController extends AppController
     {
 
-        public function beforeFilter(Event $event)
+        public function beforeFilter(EventInterface $event)
         {
             parent::beforeFilter($event);
             $this->Auth->allow('add');
@@ -159,7 +159,7 @@ To add this component to your application open your
             ]);
         }
 
-        public function beforeFilter(Event $event)
+        public function beforeFilter(EventInterface $event)
         {
             $this->Auth->allow(['index', 'view', 'display']);
         }
@@ -184,13 +184,13 @@ the users add function and implement the login and logout action::
     namespace App\Controller;
 
     use App\Controller\AppController;
-    use Cake\Event\Event;
+    use Cake\Event\EventInterface;
 
     class UsersController extends AppController
     {
         // Other methods..
 
-        public function beforeFilter(Event $event)
+        public function beforeFilter(EventInterface $event)
         {
             parent::beforeFilter($event);
             // Allow users to register and logout.

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -80,7 +80,7 @@ You can also use your controller's ``beforeRender`` method to load helpers::
 
     class ArticlesController extends AppController
     {
-        public function beforeRender(Event $event)
+        public function beforeRender(EventInterface $event)
         {
             parent::beforeRender($event);
             $this->viewBuilder()->helpers(['MyHelper']);
@@ -153,7 +153,7 @@ you can set those in your controller's beforeRender callback::
 
     class PostsController extends AppController
     {
-        public function beforeRender(Event $event)
+        public function beforeRender(EventInterface $event)
         {
             parent::beforeRender($event);
             $builder = $this->viewBuilder();
@@ -377,34 +377,34 @@ subscribe your helper to the relevant event. Unlike previous versions of CakePHP
 you should *not* call ``parent`` in your callbacks, as the base Helper class
 does not implement any of the callback methods.
 
-.. php:method:: beforeRenderFile(Event $event, $viewFile)
+.. php:method:: beforeRenderFile(EventInterface $event, $viewFile)
 
     Is called before each view file is rendered. This includes elements,
     views, parent views and layouts.
 
-.. php:method:: afterRenderFile(Event $event, $viewFile, $content)
+.. php:method:: afterRenderFile(EventInterface $event, $viewFile, $content)
 
     Is called after each view file is rendered. This includes elements, views,
     parent views and layouts. A callback can modify and return ``$content`` to
     change how the rendered content will be displayed in the browser.
 
-.. php:method:: beforeRender(Event $event, $viewFile)
+.. php:method:: beforeRender(EventInterface $event, $viewFile)
 
     The beforeRender method is called after the controller's beforeRender method
     but before the controller renders view and layout. Receives the file being
     rendered as an argument.
 
-.. php:method:: afterRender(Event $event, $viewFile)
+.. php:method:: afterRender(EventInterface $event, $viewFile)
 
     Is called after the view has been rendered but before layout rendering has
     started.
 
-.. php:method:: beforeLayout(Event $event, $layoutFile)
+.. php:method:: beforeLayout(EventInterface $event, $layoutFile)
 
     Is called before layout rendering starts. Receives the layout filename as an
     argument.
 
-.. php:method:: afterLayout(Event $event, $layoutFile)
+.. php:method:: afterLayout(EventInterface $event, $layoutFile)
 
     Is called after layout rendering is complete. Receives the layout filename
     as an argument.

--- a/en/views/themes.rst
+++ b/en/views/themes.rst
@@ -13,15 +13,9 @@ To use themes, set the theme name in your controller's action or
 
     class ExamplesController extends AppController
     {
-        // For CakePHP before 3.1
-        public $theme = 'Modern';
-
-        public function beforeRender(\Cake\Event\Event $event)
+        public function beforeRender(\Cake\Event\EventInterface $event)
         {
             $this->viewBuilder()->setTheme('Modern');
-
-            // For CakePHP before 3.5
-            $this->viewBuilder()->theme('Modern');
         }
     }
 


### PR DESCRIPTION
* Use EventInterface typehint.
* Fix view usage
* Remove a few more 'before' examples.