### PR TITLE
Update middleware.rst

### DIFF
--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -418,18 +418,14 @@ By applying the ``CsrfProtectionMiddleware`` to your Application middleware stac
 
 By applying the ``CsrfProtectionMiddleware`` to routing scopes, you can include or exclude specific route groups::
 
-    // in src/Application.php
+    // in config/routes.php
     use Cake\Http\Middleware\CsrfProtectionMiddleware;
-
-    public function routes($routes) {
+    
+    Router::scope('/', function (RouteBuilder $routes) {
         $options = [
             // ...
         ];
         $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware($options));
-    }
-
-    // in config/routes.php
-    Router::scope('/', function (RouteBuilder $routes) {
         $routes->applyMiddleware('csrf');
     });    
     


### PR DESCRIPTION
I tried registering the CSRF middleware for specific routing scopes in application.php as shown, but this produced missing-route messages for all routes. Curiously, "cake routes" still showed the routes correctly. (using cakephp 3.7.4) (Also see https://github.com/cakephp/cakephp/issues/12457)