### PR TITLE
Add link to authorization docs

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -75,6 +75,7 @@ Contents
     :maxdepth: 3
     :caption: Plugins
 
+    authorization <https://book.cakephp.org/authorization/>
     chronos
     debug-kit
     migrations


### PR DESCRIPTION
The authorization plugin is the first plugin to have its own documentation mini-site. If this is well received I'll migrate other existing plugin docs to this style.