### PR TITLE
Note about CSRF protection and stateless requests

### DIFF
--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -457,8 +457,8 @@ When enabled, you can access the current CSRF token on the request object::
 .. note::
 
     You should apply the CSRF protection middleware only for URLs which handle stateful
-    requests using cookies/session. For stateless requests, for e.g. when developing an API,
-    are not affected by CSRF so the middleware should be not be applied for those URLs.
+    requests using cookies/session. Stateless requests, for e.g. when developing an API,
+    are not affected by CSRF so the middleware does not need to be applied for those URLs.
     
 Integration with FormHelper
 ---------------------------

--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -454,6 +454,12 @@ When enabled, you can access the current CSRF token on the request object::
 .. versionadded:: 3.5.0
     The ``CsrfProtectionMiddleware`` was added in 3.5.0
 
+.. note::
+
+    You should apply the CSRF protection middleware only for URLs which handle stateful
+    requests using cookies/session. For stateless requests, for e.g. when developing an API,
+    are not affected by CSRF so the middleware should be not be applied for those URLs.
+    
 Integration with FormHelper
 ---------------------------
 


### PR DESCRIPTION
I have see too many newbies on slack/IRC waste time trying to get CSRF tokens for their stateless API URLs.