### PR TITLE
Improve Shell deprecation/replacement visiblity

### DIFF
--- a/en/appendices/3-6-migration-guide.rst
+++ b/en/appendices/3-6-migration-guide.rst
@@ -174,7 +174,7 @@ Configure
 Console
 =======
 
-A new way to build CLI tools has been added. Shell & Tasks have several
+A new way to build CLI tools has been added. Shells & Tasks have several
 shortcomings that are hard to correct without breaking compatibility.
 ``Cake\Console\Command`` will replace ``Shell`` long term as the recommended way
 to build console applications. See the :doc:`/console-and-shells/commands`

--- a/en/console-and-shells.rst
+++ b/en/console-and-shells.rst
@@ -49,6 +49,10 @@ comes with an executable in the **bin** directory:
 
     For Windows, the command needs to be ``bin\cake`` (note the backslash).
 
+.. deprecated:: 3.6.0
+    Shells are deprecated as of 3.6.0, but will not be removed until 5.x.
+    Use :doc:`/console-and-shells/commands` instead.
+
 Running the Console with no arguments produces this help message::
 
     Welcome to CakePHP v3.6.0 Console

--- a/en/console-and-shells/commands.rst
+++ b/en/console-and-shells/commands.rst
@@ -8,6 +8,9 @@ CakePHP comes with a number of built-in commands for speeding up your
 development, and automating routine tasks. You can use these same libraries to
 create commands for your application and plugins.
 
+.. versionadded:: 3.6.0
+    Commands were added to replace Shells long term. Shell & Tasks have several shortcomings that are hard to correct without breaking compatibility.
+
 Creating a Command
 ==================
 

--- a/en/console-and-shells/commands.rst
+++ b/en/console-and-shells/commands.rst
@@ -9,7 +9,7 @@ development, and automating routine tasks. You can use these same libraries to
 create commands for your application and plugins.
 
 .. versionadded:: 3.6.0
-    Commands were added to replace Shells long term. Shell & Tasks have several shortcomings that are hard to correct without breaking compatibility.
+    Commands were added to replace Shells long term. Shells & Tasks have several shortcomings that are hard to correct without breaking compatibility.
 
 Creating a Command
 ==================


### PR DESCRIPTION
I almost overlooked when ``Shell`` would be removed. This should make it more clear.