### PR TITLE
Debug has a higher level

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -384,8 +384,8 @@ appropriate log level.
 .. php:staticmethod:: error($message, $scope = [])
 .. php:staticmethod:: warning($message, $scope = [])
 .. php:staticmethod:: notice($message, $scope = [])
-.. php:staticmethod:: debug($message, $scope = [])
 .. php:staticmethod:: info($message, $scope = [])
+.. php:staticmethod:: debug($message, $scope = [])
 
 Logging Trait
 =============


### PR DESCRIPTION
Just changing the order moving debug as the highest level instead info as it was in the list. [rfc3164](https://tools.ietf.org/html/rfc3164)