### PR TITLE
[ja] add missing xml view example in json-and-xml-views.rst

### DIFF
--- a/ja/views/json-and-xml-views.rst
+++ b/ja/views/json-and-xml-views.rst
@@ -180,7 +180,7 @@ JsonView クラスは、JSON の生成に使用するビットマスクを変更
 ``_jsonOptions`` 変数をサポートします。このオプションの有効な値は
 `json_encode <http://php.net/json_encode>`_  を参照してください。
 
-例えば、一貫した JSON 形式で CakePHP エンティティーの検証エラーをシリアライズするには ::
+例えば、一貫した JSON 形式で CakePHP エンティティーの検証エラーをシリアライズするには::
 
     // コントローラーのアクションの中で、保存に失敗した時
     $this->set('errors', $articles->errors());

--- a/ja/views/json-and-xml-views.rst
+++ b/ja/views/json-and-xml-views.rst
@@ -146,7 +146,7 @@ XmlView クラスは、XML の生成に使用するオプション（例: ``tags
 ``XmlView`` の使用例は `sitemap.xml
 <https://www.sitemaps.org/protocol.html>`_ を生成することです。
 このドキュメントタイプでは ``_rootNode`` を変更し属性を設定する必要があります。
-属性は ``@`` プレフィックスを使用して定義されます。::
+属性は ``@`` プレフィックスを使用して定義されます。 ::
 
     public function sitemap()
     {

--- a/ja/views/json-and-xml-views.rst
+++ b/ja/views/json-and-xml-views.rst
@@ -180,7 +180,7 @@ JsonView クラスは、JSON の生成に使用するビットマスクを変更
 ``_jsonOptions`` 変数をサポートします。このオプションの有効な値は
 `json_encode <http://php.net/json_encode>`_  を参照してください。
 
-例えば、一貫した JSON 形式で CakePHP エンティティーの検証エラーをシリアライズするには::
+例えば、一貫した JSON 形式で CakePHP エンティティーの検証エラーをシリアライズするには ::
 
     // コントローラーのアクションの中で、保存に失敗した時
     $this->set('errors', $articles->errors());

--- a/ja/views/json-and-xml-views.rst
+++ b/ja/views/json-and-xml-views.rst
@@ -143,6 +143,34 @@ XML ビューの作成
 XmlView クラスは、XML の生成に使用するオプション（例: ``tags`` vs ``attributes`` ）を
 変更するための ``_xmlOptions`` 変数をサポートしています。
 
+``XmlView`` の使用例は `sitemap.xml
+<https://www.sitemaps.org/protocol.html>`_ を生成することです。
+このドキュメントタイプでは ``_rootNode`` を変更し属性を設定する必要があります。
+属性は ``@`` プレフィックスを使用して定義されます。::
+
+    public function sitemap()
+    {
+        $pages = $this->Pages->find();
+        $urls = [];
+        foreach ($pages as $page) {
+            $urls[] = [
+                'loc' => Router::url(['controller' => 'Pages', 'action' => 'view', $page->slug, '_full' => true]),
+                'lastmod' => $page->modified->format('Y-m-d'),
+                'changefreq' => 'daily',
+                'priority' => '0.5'
+            ];
+        }
+
+        // 生成されたドキュメントにカスタムルートノードを定義します。
+        $this->set('_rootNode', 'urlset');
+        $this->set([
+            // ルートノードで属性を定義します。
+            '@xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+            'url' => $urls
+        ]);
+        $this->set('_serialize', ['@xmlns', 'url']);
+    }
+
 JSON ビューの作成
 =================
 


### PR DESCRIPTION
add missing xml view example in json-and-xml-views.rst

refs: https://github.com/cakephp/docs/blob/f0ace7131cba1faffe0a50fdca2a3eaed09b3e37/en/views/json-and-xml-views.rst#L152