### PR TITLE
Add info Type::map() changes, into 3.6 Migration Guide.

### DIFF
--- a/en/appendices/3-6-migration-guide.rst
+++ b/en/appendices/3-6-migration-guide.rst
@@ -55,6 +55,12 @@ features will continue to function until 4.0.0 after which they will be removed.
   ``getContain()`` instead.
 * The getter part of ``Cake\Datasource\QueryInterface::repository()``
   is deprecated. Use ``getRepository()`` instead.
+* The getter part of ``Cake\Database\Type::map()`` is deprecated. Use
+  ``getMap()`` instead.
+* ``Cake\Database\Type::map()`` to set complete types map is deprecated. Use
+  ``setMap()`` instead.
+* Passing ``$className`` as object to ``Cake\Database\Type::map()`` is deprecated. Use
+  ``set()`` instead.
 
 Several classes were *renamed*. Their old names will continue to work until 4.0,
 but will emit deprecation warnings:


### PR DESCRIPTION
Some calls of ``Cake\Database\Type::map()`` has been deprecated at CakePHP 3.6.2 and above, but documented not yet.

https://github.com/cakephp/cakephp/commit/ea567d9cadd0289c213706a5ec94e37320025a5f