### PR TITLE
Update deprecated since version for Filesystem

### DIFF
--- a/en/core-libraries/file-folder.rst
+++ b/en/core-libraries/file-folder.rst
@@ -7,7 +7,7 @@ The Folder and File utilities are convenience classes to help you read from and
 write/append to files; list files within a folder and other common directory
 related tasks.
 
-.. deprecated:: 5.0
+.. deprecated:: 4.0
     The ``File`` and ``Folder`` classes will be removed in 5.0
 
 Basic Usage


### PR DESCRIPTION
According to the migration guide the [Filesystem package will be deprecated from version 4.0](https://book.cakephp.org/4.0/en/appendices/4-0-migration-guide.html#filesystem), but in the guide it is showing as deprecated since 5.0.