### PR TITLE
[3.x]Specify the version of python to use for the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - texlive-lang-all
 
 language: python
+python: '2.7'
 
 env:
   matrix:


### PR DESCRIPTION
CI build is broken from Apr 17, 2019 10:24 PM.
The default version of python used for building has changed:
https://changelog.travis-ci.com/upcoming-python-default-version-update-96873