### PR TITLE
Mark authcomponent as deprecated

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -35,7 +35,6 @@ Contents
     :maxdepth: 3
     :caption: Using CakePHP
 
-    controllers/components/authentication
     bake
     core-libraries/caching
     console-and-shells

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -10,6 +10,12 @@ pluggable way to do these tasks. AuthComponent allows you to combine
 authentication objects and authorization objects to create flexible
 ways of identifying and checking user authorization.
 
+
+.. deprecated:: 4.0.0
+    The AuthComponent is deprecated as of 4.0.0 and will be replaced by the
+    `authorization <https://book.cakephp.org/authorization/>`__
+    and `authentication <https://book.cakephp.org/authentication/>`__ plugins.
+
 .. _authentication-objects:
 
 Suggested Reading Before Continuing


### PR DESCRIPTION
While it still has a long life, communicate the change early and link to the newly published docs.