### PR TITLE
Improve date & time parts keys discoverability

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1585,6 +1585,12 @@ These options are concerning the date-related methods - i.e. ``year()``,
 * ``'orderYear'`` - The order of year values in the year select picker.
   Possible values are ``'asc'`` and ``'desc'``. Defaults to ``'desc'``.
 
+* ``'year', 'month', 'day'`` - These options allow you to control which control
+  elements are generated or not. By setting any of these options to ``false``
+  you can disable the generation of that specific that select picker (if by
+  default it would be rendered in the used method). In addition each option
+  allows you to pass HTML attributes to that specific ``select`` element.
+
 .. _time-options:
 
 Options for Time-Related Controls
@@ -1614,6 +1620,12 @@ These options are concerning the time-related methods - ``hour()``,
 
 * ``second`` - Applies to ``dateTime()`` and ``time()``. Set to ``true`` to
   enable the seconds drop down. Defaults to ``false``.
+
+* ``'hour', 'minute', 'second', 'meridian'`` - These options allow you to control
+  which control elements are generated or not. By setting any of these options to
+  ``false`` you can disable the generation of that specific that select picker
+  (if by default it would be rendered in the used method). In addition each option
+  allows you to pass HTML attributes to that specific ``select`` element.
 
 Creating DateTime Controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Today, I was asked whether it is possible to not show the day field of a date input. I couldn't find it at first. After some search, I did, though.
This hopefully improves the discoverablity of these keys.