### PR TITLE
[ja] add an example of assertFileResponse and change example in helpers/form.rst

### DIFF
--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -1230,6 +1230,9 @@ CakePHP の組込み JsonView で、 ``debug`` が有効になっている場合
     $this->assertResponseContains('You won!');
     $this->assertResponseNotContains('You lost!');
 
+    // 返されたファイルをアサート
+    $this->assertFileResponse('/absolute/path/to/file.ext');
+
     // 3.7.0 で追加
     $this->assertHeaderNotContains('Content-Type', 'xml');
 

--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -1233,9 +1233,6 @@ CakePHP の組込み JsonView で、 ``debug`` が有効になっている場合
     // 返されたファイルをアサート
     $this->assertFileResponse('/absolute/path/to/file.ext');
 
-    // 3.7.0 で追加
-    $this->assertHeaderNotContains('Content-Type', 'xml');
-
     // レイアウトをアサート
     $this->assertLayout('default');
 
@@ -1247,6 +1244,9 @@ CakePHP の組込み JsonView で、 ``debug`` が有効になっている場合
 
     // レスポンスヘッダーをアサート
     $this->assertHeader('Content-Type', 'application/json');
+
+    // 3.7.0 で追加
+    $this->assertHeaderNotContains('Content-Type', 'xml');
 
     // ビュー変数をアサート
     $user =  $this->viewVariable('user');

--- a/ja/views/helpers/form.rst
+++ b/ja/views/helpers/form.rst
@@ -233,22 +233,25 @@ FormHelper の値ソースは、input タグなどの描画される要素がど
 ``url`` オプションを使うと、フォームを現在のコントローラーやアプリケーションの別のコントローラーの
 特定のアクションに向けることができます。
 
-例えば、フォームを現在のコントローラーの ``login()`` アクションに向けるには、次のような
+例えば、フォームを現在のコントローラーの ``publish()`` アクションに向けるには、次のような
 ``$options`` 配列を与えます。 ::
 
-    echo $this->Form->create($article, ['url' => ['action' => 'login']]);
+    echo $this->Form->create($article, ['url' => ['action' => 'publish']]);
 
 出力結果:
 
 .. code-block:: html
 
-    <form method="post" action="/users/login">
+    <form method="post" action="/articles/publish">
 
 目的のフォームアクションが現在のコントローラーにない場合は、フォームアクションの完全な URL を指定できます。
 出力される URL は CakePHP アプリケーションに対する相対になります。 ::
 
     echo $this->Form->create(null, [
-        'url' => ['controller' => 'Articles', 'action' => 'publish']
+        'url' => [
+            'controller' => 'Articles',
+            'action' => 'publish'
+        ]
     ]);
 
 出力結果:


### PR DESCRIPTION
This PR contains following

- add an example of assertFileResponse in testing.rst
    - https://github.com/cakephp/docs/pull/6040
- change 'publish' from 'login' in helpers/form.rst
    - https://github.com/cakephp/docs/pull/6038
