### PR TITLE
Update examples to conform to coding standards

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -232,7 +232,7 @@ newer, using the ``remember()`` method would look like::
 
         public function newest() {
             $model = $this;
-            return Cache::remember('newest_posts', function() use ($model){
+            return Cache::remember('newest_posts', function () use ($model){
                 return $model->find('all', array(
                     'order' => 'Post.updated DESC',
                     'limit' => 10
@@ -468,7 +468,7 @@ Cache API
         class Articles extends AppModel {
             function all() {
                 $model = $this;
-                return Cache::remember('all_articles', function() use ($model){
+                return Cache::remember('all_articles', function () use ($model){
                     return $model->find('all');
                 });
             }


### PR DESCRIPTION
There's a couple of examples of `Cache::remember()` being used without a space after the closure's `function` keyword which is required by the CakePHP coding standards (pointing this out as it has tripped a few of my colleagues up).