### PR TITLE
Formatting fix for 3.8 migration guide.

### DIFF
--- a/en/appendices/3-8-migration-guide.rst
+++ b/en/appendices/3-8-migration-guide.rst
@@ -43,7 +43,7 @@ Console
 -------
 
 * ``Command::executeCommand()`` was added. This method makes it simple to call
- another command from the current one.
+another command from the current one.
 
 Datasource
 ----------


### PR DESCRIPTION
Current layout is broken. 

<img width="765" alt="Screen Shot 2019-04-30 at 2 34 09 PM" src="https://user-images.githubusercontent.com/280825/56991495-0dd58500-6b55-11e9-92eb-09a667f21819.png">

This should fix that.