### PR TITLE
fix 3.8 migration guide style

### DIFF
--- a/en/appendices/3-8-migration-guide.rst
+++ b/en/appendices/3-8-migration-guide.rst
@@ -33,17 +33,17 @@ New Features
 ============
 
 Collection
-==========
+----------
 
-* ``CollectionTrait`` now uses the ``newCollection`` method to create clones
-  now. This allows sub-classes to have collection methods create instances of
+* ``CollectionTrait`` now uses the ``newCollection`` method to create clones.
+  This allows sub-classes to have collection methods create instances of
   themselves instead of using ``Collection``.
 
 Console
 -------
 
 * ``Command::executeCommand()`` was added. This method makes it simple to call
- another command from the current one.
+  another command from the current one.
 
 Datasource
 ----------


### PR DESCRIPTION
fix styles in 3.8 migration guide.

- sub title Collection
- delete duplicated "now"
- fix build error as below

```
/data/en/appendices/3-8-migration-guide.rst:46: WARNING: Bullet list ends without a blank line; unexpected unindent.
```
