### PR TITLE
4.x - use lower case

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -538,10 +538,10 @@ Overriding Plugin Templates from Inside Your Application
 You can override any plugin views from inside your app using special paths. If
 you have a plugin called 'ContactManager' you can override the template files of the
 plugin with application specific view logic by creating files using the
-following template **templates/Plugin/[Plugin]/[Controller]/[view].php**. For the
+following template **templates/plugin/[Plugin]/[Controller]/[view].php**. For the
 Contacts controller you could make the following file::
 
-    templates/Plugin/ContactManager/Contacts/index.php
+    templates/plugin/ContactManager/Contacts/index.php
 
 Creating this file would allow you to override
 **plugins/ContactManager/templates/Contacts/index.php**.


### PR DESCRIPTION
you should use  lower case when overriding Plugin Templates