### PR TITLE
Fixed typo in fr/console-and-shells/repl.rst

### DIFF
--- a/fr/console-and-shells/repl.rst
+++ b/fr/console-and-shells/repl.rst
@@ -19,9 +19,6 @@ des requêtes en utilisant les models de votre application::
     App : App
     Path: /Users/mark/projects/cakephp-app/src/
     ---------------------------------------------------------------
-    // Prior to 3.6.0
-    >>> $articles = Cake\ORM\TableRegistry::getTableLocator()->get('Articles');
-
     >>> $articles = Cake\ORM\TableRegistry::getTableLocator()->get('Articles');
     // object(Cake\ORM\Table)(
     //


### PR DESCRIPTION
This fixes an issue from https://github.com/cakephp/docs/pull/6065.  I didn't make the change earlier as I was waiting for feedback, but the full pull request was merged.

This aligns the change with the other languages.