### PR TITLE
Added prior TableRegistry::get() example back to en

### DIFF
--- a/en/orm.rst
+++ b/en/orm.rst
@@ -38,6 +38,9 @@ table we could do::
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6.0
+    $articles = TableRegistry::get('Articles);
+
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     $query = $articles->find();
@@ -71,6 +74,9 @@ to it using the :php:class:`~Cake\\ORM\\Locator\\TableLocator` through :php:clas
     // Now $articles is an instance of our ArticlesTable class.
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
+    // Prior to 3.6.0
+    $articles = TableRegistry::get('Articles);
+
 Now that we have a concrete table class, we'll probably want to use a concrete
 entity class. Entity classes let you define accessor and mutator methods, define
 custom logic for individual records and much more. We'll start off by adding the
@@ -90,6 +96,9 @@ name by default. Now that we have created our entity class, when we
 load entities from the database we'll get instances of our new Article class::
 
     use Cake\ORM\TableRegistry;
+
+    // Prior to 3.6.0
+    $articles = TableRegistry::get('Articles);
 
     // Now an instance of ArticlesTable.
     $articles = TableRegistry::getTableLocator()->get('Articles');


### PR DESCRIPTION
I guess only en version of orm.rst was updated when TableRegistry::get() was deprecated.  Since all the other versions have been been updated to include both prior and new example, re-adding here.

This seems important since this is the first place you'll read about ORM the TableRegistry::get() deprecation is relatively new for 3.x.