### PR TITLE
Fixed chronos documentation moved link.

### DIFF
--- a/fr/chronos.rst
+++ b/fr/chronos.rst
@@ -1,4 +1,4 @@
 Chronos
 =======
 
-Cette page a été `déplacée <https://book.cakephp.org/chronos/1.x/fr/>__.
+Cette page a été `déplacée <https://book.cakephp.org/chronos/1.x/fr/>`_.

--- a/ja/chronos.rst
+++ b/ja/chronos.rst
@@ -1,4 +1,4 @@
 Chronos
 #######
 
-このページは移動 `しました<https://book.cakephp.org/chronos/1.x/ja/>`__.
+このページは移動 `しました <https://book.cakephp.org/chronos/1.x/ja/>`_.


### PR DESCRIPTION
The other pull request was sloppy.  This is smaller and cleaner.

You shouldn't find this page unless you're switching documentation languages while on chronos.html, but fixing it anyway.