### PR TITLE
[ja] Fixes documentation links

### DIFF
--- a/ja/bake.rst
+++ b/ja/bake.rst
@@ -1,4 +1,4 @@
 Bake コンソール
 ################
 
-このページは移動 `しました<https://book.cakephp.org/bake/1.x/ja/>`__.
+このページは `移動しました <https://book.cakephp.org/bake/1.x/ja/>`_.

--- a/ja/bake/development.rst
+++ b/ja/bake/development.rst
@@ -1,4 +1,4 @@
 Bake の拡張
 ###########
 
-このページは移動 `しました<https://book.cakephp.org/bake/1.x/ja/development.html>`__.
+このページは `移動しました <https://book.cakephp.org/bake/1.x/ja/development.html>`_.

--- a/ja/bake/usage.rst
+++ b/ja/bake/usage.rst
@@ -1,4 +1,4 @@
 Bake でコード生成
 ##################
 
-このページは移動 `しました<https://book.cakephp.org/bake/1.x/ja/usage.html>`__.
+このページは `移動しました <https://book.cakephp.org/bake/1.x/ja/usage.html>`_.

--- a/ja/contents.rst
+++ b/ja/contents.rst
@@ -78,7 +78,7 @@
 
     authorization <https://book.cakephp.org/authorization/>
     authentication <https://book.cakephp.org/authentication/>
-    Bake <https://book.cakephp.org/bake/1.x/ja>
+    Bake <https://book.cakephp.org/bake/1.x/ja/>
     Chronos <https://book.cakephp.org/chronos/1.x/ja/>
     Debug Kit <https://book.cakephp.org/debugkit/3.x/ja/>
     migrations

--- a/ja/debug-kit.rst
+++ b/ja/debug-kit.rst
@@ -1,4 +1,4 @@
 Debug Kit
 #########
 
-このページは移動 `しました<https://book.cakephp.org/debugkit/3.x/ja/>`__.
+このページは `移動しました <https://book.cakephp.org/debugkit/3.x/ja/>`_.


### PR DESCRIPTION
fixes Bake plugin's documentation link in sidebar and moved document link.