### PR TITLE
Updated Dockerfile to debian:stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Updated Dockerfile to match deploy.Dockerfile.  As explained in the comment, jessie is deprecated and the package server moved which can cause issues.

https://github.com/cakephp/docs/issues/6063#issuecomment-491132106

This should have no functional difference since it's already used in deploy.Dockerfile. Did not notice any new errors/failures.

