### PR TITLE
Fix example output of PaginatorHelper::prev()

### DIFF
--- a/en/views/helpers/paginator.rst
+++ b/en/views/helpers/paginator.rst
@@ -267,7 +267,7 @@ pages in the paged data set.
 
     .. code-block:: html
 
-        <li class="prev disabled"><span>&lt;&lt; previous</span></li>
+        <li class="prev disabled"><a href="" onclick="return false;">&lt;&lt; previous</a></li>
 
     To change the templates used by this method see :ref:`paginator-templates`.
 


### PR DESCRIPTION
The docs show that a `<span>` tag is output by default, but the [current](https://github.com/cakephp/cakephp/blob/1cb44d4ba4675332248bc53af2729c5083529374/src/View/Helper/PaginatorHelper.php#L70) version of the helper uses an `<a>` tag instead.