### PR TITLE
Use full namespace for ServerRequest. in 4-0-migration-guide

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -78,10 +78,10 @@ Datasources
 Http
 ----
 
-* ``ServerRequest::referer()`` now defaults the ``local``
+* ``Cake\Http\ServerRequest::referer()`` now defaults the ``local``
   parameter to true, instead of false. This makes using referer headers safer as
   they will be constrained to your application's domain by default.
-* The default value of ``ServerRequest::getParam()`` when a parameter is missing
+* The default value of ``Cake\Http\ServerRequest::getParam()`` when a parameter is missing
   is now ``null`` and not ``false``.
 * ``Cake\Http\Client\Request::body()`` has been removed. Use ``getBody()`` or
   ``withBody()`` instead.


### PR DESCRIPTION
Use full namespace for ServerRequest.