### PR TITLE
Added instructions to retrieve socket file path

### DIFF
--- a/en/phinx/configuration.rst
+++ b/en/phinx/configuration.rst
@@ -211,9 +211,8 @@ network connections. The socket path is configured with ``unix_socket``:
             unix_socket: /var/run/mysql/mysql.sock
             charset: utf8
 
-.. note::
- 
-    Use the following bash command in Linux environment to retrieve socket file path:
+
+Use the following bash command in Linux environment to retrieve socket file path to use `unix_socket`:
  
 .. code-block:: bash
 

--- a/en/phinx/configuration.rst
+++ b/en/phinx/configuration.rst
@@ -212,7 +212,7 @@ network connections. The socket path is configured with ``unix_socket``:
             charset: utf8
 
 
-Use the following bash command in a Linux environment to retrieve the socket file path to use for `unix_socket`:
+Use the following bash command in a Linux environment to retrieve the socket file path to use for ``unix_socket``:
  
 .. code-block:: bash
 

--- a/en/phinx/configuration.rst
+++ b/en/phinx/configuration.rst
@@ -216,8 +216,16 @@ Use the following bash command in a Linux environment to retrieve the socket fil
  
 .. code-block:: bash
 
-    find / -name .s.PGSQL.5432 -ls 2>&1 | grep -v "Permission denied" # For PostGreSQL
-    find / -name mysql.sock -ls 2>&1 | grep -v "Permission denied" # For MySQL
+    # For PostGreSQL
+    find / -name .s.PGSQL.5432 -ls 2>&1 | grep -v "Permission denied"
+    # For MySQL
+    find / -name mysql.sock -ls 2>&1 | grep -v "Permission denied" 
+
+Alternatively, mysql.sock file can also be retrieved from ``MySQL Shell``
+
+.. code-block:: sql
+
+    SHOW VARIABLES LIKE 'socket';
 
 
 External Variables

--- a/en/phinx/configuration.rst
+++ b/en/phinx/configuration.rst
@@ -211,6 +211,16 @@ network connections. The socket path is configured with ``unix_socket``:
             unix_socket: /var/run/mysql/mysql.sock
             charset: utf8
 
+.. note::
+ 
+    Use the following bash command in Linux environment to retrieve socket file path:
+ 
+.. code-block:: bash
+
+    find / -name .s.PGSQL.5432 -ls 2>&1 | grep -v "Permission denied" # For PostGreSQL
+    find / -name mysql.sock -ls 2>&1 | grep -v "Permission denied" # For MySQL
+
+
 External Variables
 ------------------
 

--- a/en/phinx/configuration.rst
+++ b/en/phinx/configuration.rst
@@ -212,7 +212,7 @@ network connections. The socket path is configured with ``unix_socket``:
             charset: utf8
 
 
-Use the following bash command in Linux environment to retrieve socket file path to use `unix_socket`:
+Use the following bash command in a Linux environment to retrieve the socket file path to use for `unix_socket`:
  
 .. code-block:: bash
 


### PR DESCRIPTION
Resolves #6135

Refers to [issue 351 at migrations](https://github.com/cakephp/migrations/issues/351) where a developer could have had the assistance in finding the socket file to use `unix_socket`.