### PR TITLE
Add return type declaration to validationDefault

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -438,7 +438,7 @@ using :ref:`a validator <validating-request-data>`::
     use Cake\Validation\Validator;
 
     // Add the following method.
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): Validator
     {
         $validator
             ->allowEmptyString('title', false)


### PR DESCRIPTION
When trying to run the CMS tutorial on 4.x-dev I was getting a compatibility error with `ValidationAwareTrait::validationDefault()` Added the return type declaration to match, and my small woes were gone. :)