### PR TITLE
Added code to make tag_string accessible

### DIFF
--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -339,6 +339,7 @@ can add a virtual/computed field to the entity. In
     // the Collection class
     use Cake\Collection\Collection;
 
+    // Update the accessible property to contain `tag_string`
     protected $_accessible = [
         //other fields...
         'tag_string' => true

--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -339,6 +339,11 @@ can add a virtual/computed field to the entity. In
     // the Collection class
     use Cake\Collection\Collection;
 
+    protected $_accessible = [
+        //other fields...
+        'tag_string' => true
+    ];
+
     protected function _getTagString()
     {
         if (isset($this->_properties['tag_string'])) {


### PR DESCRIPTION
The tag_string needs to be declared as accessible for the code in the tutorial to correctly save the newly created comma separated list of tags for the article. The example code in the 'Adding a Computed Field' section has been updated to demonstrate this.