### PR TITLE
Update tableheader example

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -61,6 +61,8 @@ View
   ``XmlView`` are
   now deprecated. Instead you should use
   ``viewBuilder()->setOption($optionName, $optionValue)`` to set these options.
+* ``HtmlHelper::tableHeaders()`` now prefers header cells with attributes to be
+  defined as a nested list. e.g ``['Title', ['class' => 'special']]``.
 
 Breaking Changes
 ================

--- a/en/views/helpers/html.rst
+++ b/en/views/helpers/html.rst
@@ -658,8 +658,8 @@ defaults provided in the ``$thOptions``::
 
     echo $this->Html->tableHeaders([
         'id',
-        ['Name' => ['class' => 'highlight']],
-        ['Date' => ['class' => 'sortable']]
+        ['Name', ['class' => 'highlight']],
+        ['Date', ['class' => 'sortable']]
     ]);
 
 Output:


### PR DESCRIPTION
Update the tableheader example to use undeprecated usage. Doing this in 4.x as I feel it is simpler than having to put a `// prior to` flag in the 3.next docs.

Fixes #6162