### PR TITLE
Add info for FC shimming

### DIFF
--- a/en/appendices.rst
+++ b/en/appendices.rst
@@ -12,6 +12,14 @@ introduced in each version and the migration path between versions.
 
     appendices/3-x-migration-guide
 
+FC shimming
+===========
+Forward compatible shimming can prepare your 3.x app for the next major release (4.x).
+
+If you already want to shim 4.x behavior in 3.x, check out
+the `Shim plugin <https://github.com/dereuromark/cakephp-shim>`__ that can help mitigate some BC breaking changes.
+The closer your 3.x app is to 4.x, the smaller will be the diff of changes, and the smoother will be the final upgrade.
+
 General Information
 ===================
 

--- a/en/appendices.rst
+++ b/en/appendices.rst
@@ -12,8 +12,8 @@ introduced in each version and the migration path between versions.
 
     appendices/3-x-migration-guide
 
-FC shimming
-===========
+Forwards Compatibility Shimming
+=========================
 Forward compatible shimming can prepare your 3.x app for the next major release (4.x).
 
 If you already want to shim 4.x behavior in 3.x, check out


### PR DESCRIPTION
Forward compatible shimming can prepare a 3.x app for the next major release (4.x).