### PR TITLE
Initialize method Call in Shell

### DIFF
--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -128,10 +128,10 @@ However, you want to allow caching for non-AJAX requests. The
 following would accomplish that::
 
         if ($this->request->is('ajax')) {
-            // Before 3.4.0
-            $this->response->disableCache();
-            // From 3.4.0
+            
             $this->response->withDisabledCache();
+            // Prior to 3.4.0
+            $this->response->disableCache();
         }
         // Continue Controller action
 

--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -129,7 +129,7 @@ following would accomplish that::
 
         if ($this->request->is('ajax')) {
             
-            $this->response = $this->response->withDisabledCache();
+            $this->response->withDisabledCache();
             // Prior to 3.4.0
             $this->response->disableCache();
         }

--- a/en/controllers/components/request-handling.rst
+++ b/en/controllers/components/request-handling.rst
@@ -129,7 +129,7 @@ following would accomplish that::
 
         if ($this->request->is('ajax')) {
             
-            $this->response->withDisabledCache();
+            $this->response = $this->response->withDisabledCache();
             // Prior to 3.4.0
             $this->response->disableCache();
         }


### PR DESCRIPTION
In Shell, while loading the models inside the initialize method alone is not sufficient. The initialize method should be call to the concerned Shell method to use the Models.