### PR TITLE
Update cells.rst

### DIFF
--- a/en/views/cells.rst
+++ b/en/views/cells.rst
@@ -244,7 +244,7 @@ messages could look like::
                 ]
             );
 
-            $paging = $paginator->getPagingParams() + (array)$request->getParam('paging');
+            $paging = $paginator->getPagingParams() + (array)$this->request->getParam('paging');
             $this->request = $this->request->withParam('paging', $paging));
 
             $this->set('favorites', $results);


### PR DESCRIPTION
On this line
$paging = $paginator->getPagingParams() + (array)$request->getParam('paging');
modified by
$paging = $paginator->getPagingParams() + (array)$this->request->getParam('paging');
because the former was throwing fatal error.