### PR TITLE
Link added to point to a direct solution

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -708,7 +708,7 @@ methods being combined with ``AND``. The resulting SQL would look like:
 .. deprecated:: 3.5.0
     As of 3.5.0 the ``orWhere()`` method is deprecated. This method creates
     hard to predict SQL based on the current query state.
-    Use ``where()`` instead as it has more predictable and easier
+    Use ``where()`` (see: https://api.cakephp.org/3.8/source-class-Cake.Database.Query.html#758-886) instead as it has more predictable and easier
     to understand behavior.
 
 However, if we wanted to use both ``AND`` & ``OR`` conditions we could do the


### PR DESCRIPTION
when you go to a search engine because you read: "deprecation warning" in one of your projects you usually search for "orWhere cakephp", which points you to the actual site and the deprecation message, but the most simple solution is wide away, thatswhy i propose to set a direct link to the simplest solution from here.