### PR TITLE
Updating Plugin.php example

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -392,12 +392,16 @@ like::
         public function middleware($middleware)
         {
             // Add middleware here.
+            $middleware = parent::middleware($middleware);
+            
             return $middleware;
         }
 
         public function console($commands)
         {
             // Add console commands here.
+            $commands = parent::console($commands);
+            
             return $commands;
         }
 


### PR DESCRIPTION
Updating Plugin.php example to call parent function on middleware and commands to prevent users from not having middleware and/or commands being loaded correctly.