### PR TITLE
Added support for validating generated epub files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,16 @@ RUN apt-get update && apt-get install -y \
     texlive-fonts-recommended \
     texlive-lang-all \
     latexmk \
+    openjdk-8-jdk \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
+
+ADD https://github.com/w3c/epubcheck/releases/download/v4.2.2/epubcheck-4.2.2.zip /epubcheck/epubcheck.zip
+RUN unzip /epubcheck/epubcheck.zip -d /epubcheck \
+  && mv /epubcheck/epubcheck-4.2.2/* /epubcheck
 
 WORKDIR /data
 VOLUME "/data"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ PDF_LANGS = en es fr pt
 
 DEST = website
 
+EPUB_ARGS =
+
 # Dependencies to perform before running other builds.
 # Clone the en/Makefile everywhere.
 SPHINX_DEPENDENCIES = $(foreach lang, $(LANGS), $(lang)/Makefile)
@@ -69,6 +71,9 @@ populate-index-%: $(SPHINX_DEPENDENCIES)
 rebuild-index-%: $(SPHINX_DEPENDENCIES)
 	curl -XDELETE $(ES_HOST)/documentation/3-0-$*
 	php scripts/populate_search_index.php $* $(ES_HOST)
+
+epub-check-%: build/epub/$*
+	java -jar /epubcheck/epubcheck.jar build/epub/$*/CakePHP.epub $(EPUB_ARGS)
 
 website-dirs:
 	# Make the directory if its not there already.


### PR DESCRIPTION
This adds a Makefile target to run the W3C EPUB spec validation tool against any of the generated .epub files.

https://github.com/w3c/epubcheck

There is a validator website where you can upload files, but it is slow.