### PR TITLE
Updated TableRegistry::get() deprecation examples

### DIFF
--- a/en/orm.rst
+++ b/en/orm.rst
@@ -38,9 +38,7 @@ table we could do::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     $query = $articles->find();
@@ -72,10 +70,8 @@ to it using the :php:class:`~Cake\\ORM\\Locator\\TableLocator` through :php:clas
     use Cake\ORM\TableRegistry;
 
     // Now $articles is an instance of our ArticlesTable class.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
 Now that we have a concrete table class, we'll probably want to use a concrete
 entity class. Entity classes let you define accessor and mutator methods, define
@@ -97,10 +93,8 @@ load entities from the database we'll get instances of our new Article class::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
     // Now an instance of ArticlesTable.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
 

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -62,9 +62,7 @@ The preferred way of getting new entities is using the ``newEntity()`` method fr
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $article = TableRegistry::get('Articles')->newEntity();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity();
 
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity([

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -23,9 +23,7 @@ Query builder that does not include ORM features, if necessary. See the
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Start a new query.
@@ -45,9 +43,7 @@ Selecting Rows From A Table
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $query = TableRegistry::get('Articles')->find();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $query = TableRegistry::getTableLocator()->get('Articles')->find();
 
     foreach ($query as $article) {

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -24,9 +24,7 @@ passing it to the ``save()`` method in the ``Table`` class::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->newEntity();
 
@@ -46,9 +44,7 @@ that purpose::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->get(12); // Return article with id 12
 
@@ -64,9 +60,7 @@ Saving With Associations
 
 By default the ``save()`` method will also save one level of associations::
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $author = $articlesTable->Authors->findByUserName('mark')->first();
 
@@ -139,9 +133,8 @@ that the ORM uses. The Table class provides an easy and efficient way to convert
 one or many entities from request data. You can convert a single entity using::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Validate and convert to an Entity object
@@ -180,9 +173,8 @@ When building forms that save nested associations, you need to define which
 associations should be marshalled::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // New entity with nested associations
@@ -196,9 +188,8 @@ The above indicates that the 'Tags', 'Comments' and 'Users' for the Comments
 should be marshalled. Alternatively, you can use dot notation for brevity::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // New entity with nested associations using dot notation
@@ -216,9 +207,8 @@ Associated data is also validated by default unless told otherwise. You may also
 change the validation set to be used per association::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Bypass validation on Tags association and
@@ -348,9 +338,8 @@ When creating forms that create/update multiple records at once you can use
 ``newEntities()``::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($this->request->getData());
 
@@ -401,9 +390,8 @@ such case, you can use the ``accessibleFields`` option. It could be useful to
 keep ids of associated entities::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
@@ -437,9 +425,8 @@ persisted. You can merge an array of raw data into an existing entity using the
 ``patchEntity()`` method::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $this->request->getData());
@@ -454,9 +441,8 @@ before it is copied to the entity. The mechanism is explained in the
 patching an entity, pass the ``validate`` option as follows::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $data, ['validate' => false]);
@@ -579,9 +565,8 @@ present in the entity, you can collect the primary keys and execute a batch
 delete for those not in the list::
 
     // In a controller.
-    // Prior to 3.6.0
-    $comments = TableRegistry::get('Comments');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $comments = TableRegistry::getTableLocator()->get('Comments');
     $present = (new Collection($entity->comments))->extract('id')->filter()->toList();
     $comments->deleteAll([
@@ -598,9 +583,8 @@ entities: Matches are done by the primary key field value and missing matches in
 the original entities array will be removed and not present in the result::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $list = $articles->find('popular')->toList();
     $patched = $articles->patchEntities($list, $this->request->getData());
@@ -741,15 +725,14 @@ Saving Entities
 When saving request data to your database you need to first hydrate a new entity
 using ``newEntity()`` for passing into ``save()``. For example::
 
-  // In a controller
-  // Prior to 3.6.0
-  $articles = TableRegistry::get('Articles');
+    // In a controller
 
-  $articles = TableRegistry::getTableLocator()->get('Articles');
-  $article = $articles->newEntity($this->request->getData());
-  if ($articles->save($article)) {
-      // ...
-  }
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
+    $article = $articles->newEntity($this->request->getData());
+    if ($articles->save($article)) {
+        // ...
+    }
 
 The ORM uses the ``isNew()`` method on an entity to determine whether or not an
 insert or update should be performed. If the ``isNew()`` method returns ``true``
@@ -762,9 +745,7 @@ and the entity has a primary key value, an 'exists' query will be issued. The
 Once you've loaded some entities you'll probably want to modify them and update
 your database. This is a pretty simple exercise in CakePHP::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->find('all')->where(['id' => 2])->first();
 
@@ -883,9 +864,7 @@ the singular, :ref:`underscored <inflector-methods-summary>` version of the asso
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Users']
@@ -908,9 +887,7 @@ singular, :ref:`underscored <inflector-methods-summary>` version of the associat
         ]
     ];
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity($data, [
         'associated' => ['Profiles']
@@ -932,9 +909,7 @@ plural, :ref:`underscored <inflector-methods-summary>` version of the associatio
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Comments']
@@ -988,9 +963,7 @@ the plural, :ref:`underscored <inflector-methods-summary>` version of the associ
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Tags']
@@ -1235,9 +1208,7 @@ be an array of entities created using ``newEntities()`` / ``patchEntities()``.
         ],
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($data);
     $result = $articles->saveMany($entities);

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -108,10 +108,8 @@ can do this by using the ``TableRegistry`` class::
     // In a controller or table method.
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
 The TableRegistry class provides the various dependencies for constructing
 a table, and maintains a registry of all the constructed table instances making
@@ -124,14 +122,12 @@ being triggered as a default class is used instead of your actual class. To
 correctly load plugin table classes use the following::
 
     // Plugin table
+    // Prior to 3.6 use TableRegistry::get('PluginName.Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('PluginName.Articles');
 
     // Vendor prefixed plugin table
+    // Prior to 3.6 use TableRegistry::get('VendorName/PluginName.Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('VendorName/PluginName.Articles');
-
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('PluginName.Articles');
-    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
 
 .. _table-callbacks:
 


### PR DESCRIPTION
I made the original change to update the deprecated TableRegistry::get() example earlier this year for my team.  But, I followed an example that kept the full source code for the deprecated statement.

I think this looks weird and makes the code awkward to read and copy.  This changes it to use a comment which is less obtrusive and keeps the code cleaner.

Hopefully people find the database intro pages easier to read with this.