### PR TITLE
Updated TableRegistry::get() examples for translations

### DIFF
--- a/en/appendices/orm-migration.rst
+++ b/en/appendices/orm-migration.rst
@@ -160,9 +160,7 @@ several purposes.
 
 It is possible to alter queries further, after calling ``find``::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
     $query->where(['author_id' => 1])->order(['title' => 'DESC']);

--- a/en/console-and-shells/commands.rst
+++ b/en/console-and-shells/commands.rst
@@ -356,9 +356,7 @@ Modify your test case to the following snippet of code::
             $this->exec('update_table Users');
             $this->assertExitCode(Command::CODE_SUCCESS);
 
-            // Prior to 3.6.0
-            $user = TableRegistry::get('Users')->get(1);
-
+            // Prior to 3.6 use TableRegistry::get('Users')
             $user = TableRegistry::getTableLocator()->get('Users')->get(1);
             $this->assertSame($user->modified->timestamp, $now->timestamp);
 
@@ -441,9 +439,7 @@ incorrect response. Remove the ``testUpdateModified`` method and, add the follow
         $this->exec('update_table Users', ['y']);
         $this->assertExitCode(Command::CODE_SUCCESS);
 
-        // Prior to 3.6.0
-        $user = TableRegistry::get('Users')->get(1);
-
+        // Prior to 3.6 use TableRegistry::get('Users')
         $user = TableRegistry::getTableLocator()->get('Users')->get(1);
         $this->assertSame($user->modified->timestamp, $now->timestamp);
 
@@ -452,9 +448,7 @@ incorrect response. Remove the ``testUpdateModified`` method and, add the follow
 
     public function testUpdateModifiedUnsure()
     {
-        // Prior to 3.6.0
-        $user = TableRegistry::get('Users')->get(1);
-
+        // Prior to 3.6 use TableRegistry::get('Users')
         $user = TableRegistry::getTableLocator()->get('Users')->get(1);
         $original = $user->modified->timestamp;
 
@@ -462,9 +456,7 @@ incorrect response. Remove the ``testUpdateModified`` method and, add the follow
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('You need to be sure.');
 
-        // Prior to 3.6.0
-        $user = TableRegistry::get('Users')->get(1);
-
+        // Prior to 3.6 use TableRegistry::get('Users')
         $user = TableRegistry::getTableLocator()->get('Users')->get(1);
         $this->assertSame($original, $user->timestamp);
     }

--- a/en/intro.rst
+++ b/en/intro.rst
@@ -37,9 +37,7 @@ The model objects can be thought of as "Friend", "User", "Comment", or
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -55,9 +53,7 @@ something like::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -393,7 +393,7 @@ like::
         {
             // Add middleware here.
             $middleware = parent::middleware($middleware);
-            
+
             return $middleware;
         }
 
@@ -401,7 +401,7 @@ like::
         {
             // Add console commands here.
             $commands = parent::console($commands);
-            
+
             return $commands;
         }
 
@@ -604,10 +604,8 @@ You can use ``TableRegistry`` to load your plugin tables using the familiar
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('ContactManager.Contacts')
     $contacts = TableRegistry::getTableLocator()->get('ContactManager.Contacts');
-
-    // Prior to 3.6.0
-    $contacts = TableRegistry::get('ContactManager.Contacts');
 
 Alternatively, from a controller context, you can use::
 

--- a/es/intro.rst
+++ b/es/intro.rst
@@ -39,9 +39,7 @@ tabla ``usuarios`` podríamos hacer lo siguiente::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $usuarios = TableRegistry::get('Usuarios');
-
+    // Prior to 3.6 use TableRegistry::get('Usuarios')
     $usuarios = TableRegistry::getTableLocator()->get('Usuarios');
     $query = $usuarios->find();
     foreach ($query as $row) {
@@ -57,9 +55,7 @@ algo como::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $usuarios = TableRegistry::get('Usuarios');
-
+    // Prior to 3.6 use TableRegistry::get('Usuarios')
     $usuarios = TableRegistry::getTableLocator()->get('Usuarios');
     $usuario = $usuarios->newEntity(['email' => 'mark@example.com']);
     $usuarios->save($usuario);

--- a/es/orm.rst
+++ b/es/orm.rst
@@ -34,9 +34,7 @@ comenzar a utilizar el ORM. Por ejemplo si quisieramos leer datos de nuestra tab
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
     foreach ($query as $row) {
@@ -62,10 +60,8 @@ Una vez que tú clase fue creada, puedes obtener una referencia a esta usando :p
     use Cake\ORM\TableRegistry;
 
     // Now $articles is an instance of our ArticlesTable class.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
 Ahora que tenemos una clase Table concreta, probablemente querramos usar una clase Entity concreta.
 Las clases Entity permiten definir métodos de acceso y mutación, lógica para registros individuales y mucho mas.
@@ -85,10 +81,8 @@ carguemos entidades de nuestra base de datos, vamos a obtener instancias de nues
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
     // Now an instance of ArticlesTable.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
 

--- a/es/orm/behaviors/tree.rst
+++ b/es/orm/behaviors/tree.rst
@@ -40,9 +40,7 @@ Active el Tree behavior agregándolo a la Tabla donde usted desea almacenar los 
 
 Tras agregarlas, puede dejar que CakePHP construya la estructura interna si la tabla ya contiene algunos registros::
 
-    // Prior to 3.6.0
-    $categories = TableRegistry::get('Categories');
-
+    // Prior to 3.6 use TableRegistry::get('Categories')
     $categories = TableRegistry::getTableLocator()->get('Categories');
     $categories->recover();
 

--- a/fr/appendices/orm-migration.rst
+++ b/fr/appendices/orm-migration.rst
@@ -181,9 +181,7 @@ objet Query; cela sert dans plusieurs cas.
 Il est possible de modifier les requêtes plus tard, après avoir appeler
 ``find``::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
     $query->where(['author_id' => 1])->order(['title' => 'DESC']);

--- a/fr/core-libraries/events.rst
+++ b/fr/core-libraries/events.rst
@@ -265,9 +265,7 @@ et écouter seulement l'événement dont vous avez réellement besoin::
     // Si envoi d'emails
     use Cake\Mailer\Email;
 
-    // Prior to 3.6.0
-    TableRegistry::get('ThirdPartyPlugin.Feedbacks')
-
+    // Prior to 3.6 use TableRegistry::get('ThirdPartyPlugin.Feedbacks')
     TableRegistry::getTableLocator()->get('ThirdPartyPlugin.Feedbacks')
         ->eventManager()
         ->on('Model.afterSave', function($event, $entity)

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -788,10 +788,9 @@ maintenant à ceci::
         public function setUp()
         {
             parent::setUp();
-            $this->Articles = TableRegistry::getTableLocator()->get('Articles');
 
-            // Prior to 3.6.0
-            $this->Articles = TableRegistry::get('Articles');
+            // Prior to 3.6 use TableRegistry::get('Articles')
+            $this->Articles = TableRegistry::getTableLocator()->get('Articles');
         }
 
         public function testFindPublished()
@@ -944,9 +943,7 @@ Créez un fichier nommé **ArticlesControllerTest.php** dans votre répertoire
             $this->post('/articles', $data);
             $this->assertResponseSuccess();
 
-            // Prior to 3.6.0
-            $articles = TableRegistry::get('Articles');
-
+            // Prior to 3.6 use TableRegistry::get('Articles')
             $articles = TableRegistry::getTableLocator()->get('Articles');
             $query = $articles->find()->where(['title' => $data['title']]);
             $this->assertEquals(1, $query->count());
@@ -1590,9 +1587,7 @@ morceau de code suivant::
             $this->exec('my_console update_modified Users');
             $this->assertExitCode(Shell::CODE_SUCCESS);
 
-            // Prior to 3.6.0
-            $user = TableRegistry::get('Users')->get(1);
-
+            // Prior to 3.6 use TableRegistry::get('Users')
             $user = TableRegistry::getTableLocator()->get('Users')->get(1);
             $this->assertSame($user->modified->timestamp, $now->timestamp);
 
@@ -2006,10 +2001,9 @@ puis que l'entity ``$order`` a été passée dans les données de l'événement:
         public function setUp()
         {
             parent::setUp();
-            $this->Orders = TableRegistry::getTableLocator()->get('Orders');
 
-            // Prior to 3.6.0
-            $this->Orders = TableRegistry::get('Orders');
+            // Prior to 3.6 use TableRegistry::get('Orders')
+            $this->Orders = TableRegistry::getTableLocator()->get('Orders');
 
             // enable event tracking
             $this->Orders->eventManager()->setEventList(new EventList());

--- a/fr/intro.rst
+++ b/fr/intro.rst
@@ -43,9 +43,7 @@ pourrions faire::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -62,9 +60,7 @@ nous ferions ceci::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/fr/orm.rst
+++ b/fr/orm.rst
@@ -43,9 +43,7 @@ charger des données de la table ``articles``, vous pourriez faire::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     $query = $articles->find();
@@ -79,10 +77,8 @@ obtenez une référence vers celle-ci en utilisant
     use Cake\ORM\TableRegistry;
 
     // Maintenant $articles est une instance de notre classe ArticlesTable.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
 Maintenant que nous avons une classe de table concrète, nous allons
 probablement vouloir utiliser une classe entity concrète. Les classes Entity
@@ -108,9 +104,7 @@ de notre nouvelle classe Article::
     use Cake\ORM\TableRegistry;
 
     // Maintenant une instance de ArticlesTable.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
 

--- a/fr/orm/behaviors/tree.rst
+++ b/fr/orm/behaviors/tree.rst
@@ -56,9 +56,7 @@ les données hiérarchisées dans::
 Une fois ajoutées, vous pouvez laisser CakePHP construire la structure interne
 si la table contient déjà quelques lignes::
 
-    // Prior to 3.6.0
-    $categories = TableRegistry::get('Categories');
-
+    // Prior to 3.6 use TableRegistry::get('Categories')
     $categories = TableRegistry::getTableLocator()->get('Categories');
     $categories->recover();
 

--- a/fr/orm/entities.rst
+++ b/fr/orm/entities.rst
@@ -66,9 +66,7 @@ Une autre approche pour récupérer une nouvelle entity est d'utiliser la métho
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $article = TableRegistry::get('Articles')->newEntity();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity();
 
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity([

--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -25,9 +25,7 @@ fonctionnalités de l'ORM, si nécessaire. Consultez la section
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Commence une nouvelle requête.
@@ -47,9 +45,7 @@ Récupérer les Lignes d'une Table
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $query = TableRegistry::get('Articles')->find();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $query = TableRegistry::getTableLocator()->get('Articles')->find();
 
     foreach ($query as $article) {

--- a/fr/orm/retrieving-data-and-resultsets.rst
+++ b/fr/orm/retrieving-data-and-resultsets.rst
@@ -405,9 +405,7 @@ des articles publiés, nous ferions ce qui suit::
     }
 
     // Dans un controller ou dans une méthode table.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('published');
 
@@ -419,9 +417,7 @@ vous avez à la fois les finders 'published' et 'recent', vous pouvez faire
 ce qui suit::
 
     // Dans un controller ou dans une méthode de table.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('published')->find('recent');
 
@@ -450,9 +446,7 @@ pourriez faire::
     $query = $this->Users->findAllByUsername('joebob');
 
     // Dans une méthode de table
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     // Les deux appels suivants sont équivalents.
     $query = $users->findByUsername('joebob');
@@ -1056,9 +1050,7 @@ pouvez extraire une liste des tags uniques sur une collection d'articles en
 exécutant::
 
     // Dans un controller ou une méthode de table.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find()->contain(['Tags']);
 
@@ -1082,9 +1074,7 @@ avec des ensembles de données::
     });
 
     // Crée un tableau associatif depuis les propriétés du résultat
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $results = $articles->find()->contain(['Authors'])->all();
 

--- a/fr/orm/saving-data.rst
+++ b/fr/orm/saving-data.rst
@@ -26,9 +26,7 @@ créer une nouvelle entity et de la passer à la méthode ``save()`` de la class
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->newEntity();
 
@@ -48,9 +46,7 @@ but::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->get(12); // Retourne l'article avec l'id 12
 
@@ -68,9 +64,7 @@ Enregistrements avec Associations
 Par défaut, la méthode ``save()`` ne sauvegardera qu'un seul niveau
 d'association::
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $author = $articlesTable->Authors->findByUserName('mark')->first();
 
@@ -189,9 +183,8 @@ Table facilite la conversion d'une ou de plusieurs entities à partir des
 données requêtées. Vous pouvez convertir une entity unique en utilisant::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     // Valide et convertit en un objet Entity
     $entity = $articles->newEntity($this->request->getData());
@@ -225,9 +218,8 @@ imbriquées, vous devez définir quelles associations doivent être prises en
 compte::
 
     // Dans un controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Nouvelle entity avec des associations imbriquées
@@ -242,9 +234,8 @@ Comments doivent être prises en compte. D'une autre façon, vous pouvez utilise
 la notation par point pour être plus bref::
 
     // Dans un controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Nouvelle entity avec des associations imbriquées en utilisant
@@ -265,9 +256,8 @@ contraire ne lui soit spécifié. Vous pouvez également changer l'ensemble
 de validation utilisé par association::
 
     // Dans un controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Ne fait pas la validation pour l'association Tags et
@@ -396,9 +386,8 @@ Lorsque vous créez des formulaires de création/mise à jour d'enregistrements
 multiples en une seule opération vous pouvez utiliser ``newEntities()``::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($this->request->getData());
 
@@ -451,9 +440,8 @@ propriété ``_accessible``. Dans ce cas, vous pouvez utiliser l'option
 associations existantes entre certaines entities::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
@@ -488,9 +476,8 @@ fusionner un tableau de données brutes dans une entity existante en utilisant l
 méthode ``patchEntity()``::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $this->request->getData());
@@ -506,9 +493,8 @@ validation lors du patch d'une entity, passez l'option ``validate`` comme
 montré ci-dessous::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $data, ['validate' => false]);
@@ -645,9 +631,8 @@ les clés primaires et exécuter une suppression batch pour celles qui ne sont
 pas dans la liste::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $comments = TableRegistry::get('Comments');
 
+    // Prior to 3.6 use TableRegistry::get('Comments')
     $comments = TableRegistry::getTableLocator()->get('Comments');
     $present = (new Collection($entity->comments))->extract('id')->filter()->toArray();
     $comments->deleteAll([
@@ -666,9 +651,8 @@ manquantes dans le tableau original des entities seront retirées et non
 présentes dans les résultats::
 
     // Dans un controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $list = $articles->find('popular')->toArray();
     $patched = $articles->patchEntities($list, $this->request->getData());
@@ -811,15 +795,14 @@ Quand vous sauvegardez les données requêtées dans votre base de données, vou
 devez d'abord hydrater une nouvelle entity en utilisant ``newEntity()`` pour
 passer dans ``save()``. Pare exemple::
 
-  // Dans un controller
-  // Prior to 3.6.0
-  $articles = TableRegistry::get('Articles');
+    // Dans un controller
 
-  $articles = TableRegistry::getTableLocator()->get('Articles');
-  $article = $articles->newEntity($this->request->getData());
-  if ($articles->save($article)) {
-      // ...
-  }
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
+    $article = $articles->newEntity($this->request->getData());
+    if ($articles->save($article)) {
+        // ...
+    }
 
 L'ORM utilise la méthode ``isNew()`` sur une entity pour déterminer si oui ou
 non une insertion ou une mise à jour doit être faite. Si la méthode
@@ -833,9 +816,7 @@ Une fois que vous avez chargé quelques entities, vous voudrez probablement les
 modifier et les mettre à jour dans votre base de données. C'est un exercice
 simple dans CakePHP::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->find('all')->where(['id' => 2])->first();
 
@@ -976,9 +957,7 @@ Par exemple::
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Users']
@@ -1003,9 +982,7 @@ Par exemple::
         ]
     ];
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity($data, [
         'associated' => ['Profiles']
@@ -1029,9 +1006,7 @@ Par exemple::
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Comments']
@@ -1083,9 +1058,7 @@ Par exemple::
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Tags']
@@ -1314,9 +1287,7 @@ options que celles acceptées par ``save()``::
         ],
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($data);
     $result = $articles->saveMany($entities);

--- a/fr/orm/table-objects.rst
+++ b/fr/orm/table-objects.rst
@@ -114,7 +114,8 @@ instance de la table. Vous pouvez faire ceci en utilisant la classe
     // Dans un controller ou dans une méthode de table.
     use Cake\ORM\TableRegistry;
 
-    $articles = TableRegistry::get('Articles');
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
 
 La classe TableRegistry fournit les divers dépendances pour construire la table,
 et maintient un registre de toutes les instances de table construites,
@@ -128,10 +129,12 @@ une classe par défaut est utilisée à la place de votre classe souhaitée. Pou
 charger correctement les classes table de votre plugin, utilisez ce qui suit::
 
     // Table de plugin
-    $articlesTable = TableRegistry::get('PluginName.Articles');
+    // Prior to 3.6 use TableRegistry::get('PluginName.Articles')
+    $articlesTable = TableRegistry::getTableLocator()->get('PluginName.Articles');
 
     // Table de plugin préfixé par Vendor
-    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
+    // Prior to 3.6 use TableRegistry::get('VendorName/PluginName.Articles')
+    $articlesTable = TableRegistry::getTableLocator()->get('VendorName/PluginName.Articles');
 
 .. _table-callbacks:
 

--- a/fr/plugins.rst
+++ b/fr/plugins.rst
@@ -482,10 +482,8 @@ en utilisant l'habituelle :term:`syntaxe de plugin`::
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('ContactManager.Contacts')
     $contacts = TableRegistry::getTableLocator()->get('ContactManager.Contacts');
-
-    // Prior to 3.6.0
-    $contacts = TableRegistry::get('ContactManager.Contacts');
 
 Si vous êtes dans un Controller, vous pouvez aussi utiliser::
 

--- a/ja/appendices/orm-migration.rst
+++ b/ja/appendices/orm-migration.rst
@@ -150,9 +150,7 @@ Query オブジェクトを返すということです。これにはいくつ�
 
 ``find`` を呼び出した後、さらにクエリーを変更することができます。 ::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
     $query->where(['author_id' => 1])->order(['title' => 'DESC']);

--- a/ja/console-and-shells/commands.rst
+++ b/ja/console-and-shells/commands.rst
@@ -331,9 +331,7 @@ Commabd クラスは、大部分の作業を行う ``execute()`` メソッドを
             $this->exec('update_table Users');
             $this->assertExitCode(Command::CODE_SUCCESS);
 
-            // Prior to 3.6.0
-            $user = TableRegistry::get('Users')->get(1);
-
+            // Prior to 3.6 use TableRegistry::get('Users')
             $user = TableRegistry::getTableLocator()->get('Users')->get(1);
             $this->assertSame($user->modified->timestamp, $now->timestamp);
 
@@ -414,9 +412,7 @@ Commabd クラスは、大部分の作業を行う ``execute()`` メソッドを
         $this->exec('update_table Users', ['y']);
         $this->assertExitCode(Command::CODE_SUCCESS);
 
-        // Prior to 3.6.0
-        $user = TableRegistry::get('Users')->get(1);
-
+        // Prior to 3.6 use TableRegistry::get('Users')
         $user = TableRegistry::getTableLocator()->get('Users')->get(1);
         $this->assertSame($user->modified->timestamp, $now->timestamp);
 
@@ -425,9 +421,7 @@ Commabd クラスは、大部分の作業を行う ``execute()`` メソッドを
 
     public function testUpdateModifiedUnsure()
     {
-        // Prior to 3.6.0
-        $user = TableRegistry::get('Users')->get(1);
-
+        // Prior to 3.6 use TableRegistry::get('Users')
         $user = TableRegistry::getTableLocator()->get('Users')->get(1);
         $original = $user->modified->timestamp;
 
@@ -435,9 +429,7 @@ Commabd クラスは、大部分の作業を行う ``execute()`` メソッドを
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('You need to be sure.');
 
-        // Prior to 3.6.0
-        $user = TableRegistry::get('Users')->get(1);
-
+        // Prior to 3.6 use TableRegistry::get('Users')
         $user = TableRegistry::getTableLocator()->get('Users')->get(1);
         $this->assertSame($original, $user->timestamp);
     }

--- a/ja/intro.rst
+++ b/ja/intro.rst
@@ -31,9 +31,7 @@ CakePHP は基礎的な構造をクラス名、ファイル名、DB のテーブ
 
     use Cake\ORM\TableRegistry;
 
-    // 3.6.0 より前
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -48,9 +46,7 @@ CakePHP は基礎的な構造をクラス名、ファイル名、DB のテーブ
 
     use Cake\ORM\TableRegistry;
 
-    // 3.6.0 より前
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/ja/orm/behaviors/tree.rst
+++ b/ja/orm/behaviors/tree.rst
@@ -51,9 +51,7 @@ TreeBehavior は、オーバーヘッドをほとんどかけることなく照�
 テーブルがすでにいくつかの行を保持している場合、一度追加すると
 CakePHP は内部構造を構築することができます。 ::
 
-    // Prior to 3.6.0
-    $categories = TableRegistry::get('Categories');
-
+    // Prior to 3.6 use TableRegistry::get('Categories')
     $categories = TableRegistry::getTableLocator()->get('Categories');
     $categories->recover();
 

--- a/ja/orm/entities.rst
+++ b/ja/orm/entities.rst
@@ -59,9 +59,7 @@ CakePHP の ORM を使うためにエンティティークラスを生成する�
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $article = TableRegistry::get('Articles')->newEntity();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity();
 
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity([

--- a/ja/orm/query-builder.rst
+++ b/ja/orm/query-builder.rst
@@ -23,9 +23,7 @@ SQL インジェクション攻撃から守っています。
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // 新しいクエリーを始めます。
@@ -44,9 +42,7 @@ SQL インジェクション攻撃から守っています。
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $query = TableRegistry::get('Articles')->find();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $query = TableRegistry::getTableLocator()->get('Articles')->find();
 
     foreach ($query as $article) {

--- a/ja/orm/retrieving-data-and-resultsets.rst
+++ b/ja/orm/retrieving-data-and-resultsets.rst
@@ -368,9 +368,7 @@ fineder メソッドは、あなたが作成したい finder の名前が ``Foo`
     }
 
     // コントローラーやテーブルのメソッド内で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('ownedBy', ['user' => $userEntity]);
 
@@ -380,9 +378,7 @@ Finder の 'stack' (重ね呼び) もまた、複雑なクエリーを難なく�
 'published' と 'recent' の両方の Finder を持っているとすると、次のようになります。 ::
 
     // コントローラーやテーブルのメソッド内で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('published')->find('recent');
 
@@ -415,9 +411,7 @@ CakePHP の ORM は動的に構築する Finder メソッドを提供します�
     $query = $this->Users->findAllByUsername('joebob');
 
     // テーブルメソッドの中
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     // 下記の２つは同じ
     $query = $users->findByUsername('joebob');
@@ -950,9 +944,7 @@ serialize が簡単にできるだけでなく、結果セットは 'Collection'
 使えます。たとえば、記事 (Article) のコレクションにあるタグ (Tag) をユニークに取り出すことができます。 ::
 
     // コントローラーやテーブルのメソッド内で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find()->contain(['Tags']);
 
@@ -975,9 +967,7 @@ serialize が簡単にできるだけでなく、結果セットは 'Collection'
     });
 
     // 結果のプロパティーから連想配列を作成する
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $results = $articles->find()->contain(['Authors'])->all();
 

--- a/ja/orm/saving-data.rst
+++ b/ja/orm/saving-data.rst
@@ -25,9 +25,7 @@
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->newEntity();
 
@@ -46,9 +44,7 @@
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->get(12); // id 12 の記事を返します
 
@@ -64,9 +60,7 @@ CakePHP は挿入または更新のいずれの処理を行うかを ``isNew()``
 
 既定では ``save()`` メソッドはアソシエーションの一階層目も保存します。 ::
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $author = $articlesTable->Authors->findByUserName('mark')->first();
 
@@ -138,9 +132,8 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
 簡単で効果的な方法を提供します。単一のエンティティーの変換には次の方法を使います。 ::
 
     // コントローラーの中で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // 検証して Entity オブジェクトに変換します。
@@ -180,9 +173,8 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
 どのアソシエーションが変換されるべきかを定義する必要があります。 ::
 
     // コントローラーの中で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // 入れ子になったアソシエーション付きの新しいエンティティー
@@ -196,9 +188,8 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
 を示しています。代わりに、簡潔にするためにドット記法を使うことができます。 ::
 
     // コントローラーの中で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // ドット記法を用いた、入れ子になったアソシエーション付きの新しいエンティティー
@@ -216,9 +207,8 @@ Table クラスは、リクエストデータを一つまたは複数のエン�
 アソシエーションごとに使われる検証セットを変更することもできます。 ::
 
     // コントローラーの中で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Tags アソシエーションの検証を回避して
@@ -341,9 +331,8 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 を使うことができます。 ::
 
     // コントローラーの中で。
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($this->request->getData());
 
@@ -393,9 +382,8 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 これは関連付けられたエンティティーの ID を維持するために便利かもしれません。 ::
 
     // コントローラーの中で
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
@@ -428,9 +416,8 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 生データの配列を既存のエンティティーにマージすることができます。 ::
 
     // コントローラーの中で。
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $this->request->getData());
@@ -445,9 +432,8 @@ belongsToMany の変換を ``_ids`` キーの使用のみに制限して、他�
 オプションを渡してください。 ::
 
     // コントローラーの中で。
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $data, ['validate' => false]);
@@ -568,9 +554,8 @@ hasMany の belongsToMany アソシエーションについても同じことが
 を削除したいのであれば、その主キーを集約してリストにないものの一括削除を実行してください。 ::
 
     // コントローラーの中で。
-    // Prior to 3.6.0
-    $comments = TableRegistry::get('Comments');
 
+    // Prior to 3.6 use TableRegistry::get('Comments')
     $comments = TableRegistry::getTableLocator()->get('Comments');
     $present = (new Collection($entity->comments))->extract('id')->filter()->toList();
     $comments->deleteAll([
@@ -587,9 +572,8 @@ hasMany と belongsToMany アソシエーションに対してのパッチのた
 結果配列から取り除かれて現れない、というように複数のエンティティーにパッチをあてます。 ::
 
     // コントローラーの中で。
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $list = $articles->find('popular')->toList();
     $patched = $articles->patchEntities($list, $this->request->getData());
@@ -727,15 +711,14 @@ CakePHP の検証機能をどう使うかについてより詳しい情報があ
 ``newEntity()`` を使って新しいエンティティーをハイドレートする必要があります。
 例えばこうです。 ::
 
-  // コントローラーのの中で
-  // Prior to 3.6.0
-  $articles = TableRegistry::get('Articles');
+    // コントローラーのの中で
 
-  $articles = TableRegistry::getTableLocator()->get('Articles');
-  $article = $articles->newEntity($this->request->getData());
-  if ($articles->save($article)) {
-      // ...
-  }
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
+    $article = $articles->newEntity($this->request->getData());
+    if ($articles->save($article)) {
+        // ...
+    }
 
 ORM は、挿入か更新のいずれが実行されるべきかを決定するために、エンティティーの ``isNew()``
 メソッドを使用します。もし ``isNew()`` が真を返し、エンティティーが主キー値を持っていれば、
@@ -747,9 +730,7 @@ ORM は、挿入か更新のいずれが実行されるべきかを決定する�
 いくつかのエンティティーが読み出した後は、おそらくそれらを変更して、
 データベースを更新したいでしょう。これは CakePHP では実に単純な課題です。 ::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->find('all')->where(['id' => 2])->first();
 
@@ -866,9 +847,8 @@ belongsTo アソシエーションを保存する時は、 ORM は単一の入�
             'username' => 'mark'
         ]
     ];
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Users']
@@ -891,9 +871,8 @@ hasOne アソシエーションを保存する時は、 ORM は単一の入れ�
             'twitter' => '@cakephp'
         ]
     ];
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity($data, [
         'associated' => ['Profiles']
@@ -915,9 +894,8 @@ hasMany アソシエーションを保存する時は、 ORM はエンティテ�
             ['body' => '私は実にこれが好きだ。']
         ]
     ];
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Comments']
@@ -969,9 +947,8 @@ belongsToMany アソシエーションを保存する時は、 ORM はエンテ�
             ['tag' => 'Framework']
         ]
     ];
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Tags']
@@ -1180,9 +1157,8 @@ belongsToMany アソシエーションのそれぞれのエンティティーは
             'published' => 1
         ],
     ];
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($data);
     $result = $articles->saveMany($entities);

--- a/ja/orm/table-objects.rst
+++ b/ja/orm/table-objects.rst
@@ -105,10 +105,8 @@
     // コントローラーやテーブルのメソッド内で
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // 3.6.0 より前
-     $articles = TableRegistry::get('Articles');
 
 TableRegistry クラスはテーブルを作るための様々な依存関係を提供します。
 そして、作成されたすべてのテーブルインスタンスの設定を維持し、リレーションの構築と
@@ -120,15 +118,12 @@ ORM の設定を簡単にしてくれます。詳細は :ref:`table-registry-usa
 正しくロードするために、次のように使用してください。 ::
 
     // プラグインの Table
+    // Prior to 3.6 use TableRegistry::get('PluginName.Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('PluginName.Articles');
 
     // ベンダープレフィックス付きのプラグイン Table
+    // Prior to 3.6 use TableRegistry::get('VendorName/PluginName.Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('VendorName/PluginName.Articles');
-
-
-    // 3.6.0 より前
-    $articlesTable = TableRegistry::get('PluginName.Articles');
-    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
 
 .. _table-callbacks:
 

--- a/ja/plugins.rst
+++ b/ja/plugins.rst
@@ -577,10 +577,8 @@ bake で作っていないプラグインなら、クラスを自動的に読み
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('ContactManager.Contacts')
     $contacts = TableRegistry::getTableLocator()->get('ContactManager.Contacts');
-
-    // Prior to 3.6.0
-    $contacts = TableRegistry::get('ContactManager.Contacts');
 
 あるいは、コントローラーの処理の中で以下のように使用できます。 ::
 

--- a/kr/intro.rst
+++ b/kr/intro.rst
@@ -28,9 +28,7 @@ SNS의 경우 모델 계층은 사용자 저장, 친구 저장, 사용자 사진
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -44,9 +42,7 @@ SNS의 경우 모델 계층은 사용자 저장, 친구 저장, 사용자 사진
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/pt/intro.rst
+++ b/pt/intro.rst
@@ -39,9 +39,7 @@ poderiamos fazer::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -57,9 +55,7 @@ assim::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/pt/orm.rst
+++ b/pt/orm.rst
@@ -42,9 +42,7 @@ usar o ORM. Por exemplo, se quiséssemos carregar alguns dados da nossa tabela
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
     foreach ($query as $row) {
@@ -74,11 +72,10 @@ uma referência para esta utilizando o :php:class:`~Cake\\ORM\\TableRegistry`
 como antes::
 
     use Cake\ORM\TableRegistry;
-    // Agora $articles é uma instância de nossa classe ArticlesTable.
-    $articles = TableRegistry::getTableLocator()->get('Articles');
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
+    // Agora $articles é uma instância de nossa classe ArticlesTable.
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
 
 Agora que temos uma classe de tabela concreta, nós provavelmente vamos querer
 usar uma classe de entidade concreta. As classes de entidade permitem definir
@@ -102,10 +99,8 @@ nossa nova classe Article::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
     // Agora uma instância de ArticlesTable.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
 

--- a/pt/orm/behaviors/tree.rst
+++ b/pt/orm/behaviors/tree.rst
@@ -41,9 +41,7 @@ Você ativa o comportamento da árvore, adicionando-o a tabela que deseja armaze
 
 Uma vez adicionado, você pode deixar o CakePHP construir a estrutura interna se a tabela já estiver pronta::
 
-    // Prior to 3.6.0
-    $categories = TableRegistry::get('Categories');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $categories = TableRegistry::getTableLocator()->get('Categories');
     $categories->recover();
 

--- a/pt/orm/entities.rst
+++ b/pt/orm/entities.rst
@@ -63,9 +63,7 @@ Outro maneira de obter novas entidades é usando o método ``newEntity()`` dos o
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $article = TableRegistry::get('Articles')->newEntity();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity();
 
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity([

--- a/pt/orm/retrieving-data-and-resultsets.rst
+++ b/pt/orm/retrieving-data-and-resultsets.rst
@@ -353,9 +353,8 @@ Neste exemplo mostramos como encontrarmos um artigo quando este estiver publicad
     }
 
     // No controller ou table.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('ownedBy', ['user' => $userEntity]);
     //Retorne todos os artigos, quero que seja de meu usuário, porém somente os já publicados.
@@ -366,9 +365,8 @@ Sem esforço você pode expressar algumas consultas complexas. Assumindo que voc
 tem ambas as buscas 'published' e 'recent', poderia fazer assim::
 
     // No controller ou table.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('published')->find('recent');
     //Busque todos os artigos, dentre eles encontre os publicados, e retorne somente os recentes.
@@ -393,9 +391,8 @@ Por exemplo, se você quer buscar usuários por seu nome gostará de::
     $query = $this->Users->findAllByUsername('joebob');
 
     // Na tabela
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
 
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     // Duas chamadas também iguais.
     $query = $users->findByUsername('joebob');
@@ -930,9 +927,8 @@ do. For example, you can extract a list of unique tags on a collection of
 articles by running::
 
     // In a controller or table method.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find()->contain(['Tags']);
 
@@ -955,9 +951,8 @@ Some other examples of the collection methods being used with result sets are::
     });
 
     // Create an associative array from result properties
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $results = $articles->find()->contain(['Authors'])->all();
 

--- a/pt/orm/saving-data.rst
+++ b/pt/orm/saving-data.rst
@@ -24,9 +24,7 @@ e passando ela pro método ``save()`` na classe ``Table``::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->newEntity();
 
@@ -46,9 +44,7 @@ esse propósito::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->get(12); // Return article with id 12
 
@@ -64,9 +60,7 @@ Salvando com Associações
 
 Por padrão o método ``save()`` também salvará associações de um nível::
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $author = $articlesTable->Authors->findByUserName('mark')->first();
 
@@ -181,9 +175,8 @@ uma ou várias entidades dos dados de requisição. Você pode converter uma ent
 usando::
 
     //No controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Valida e converte em um objeto do tipo Entity
@@ -222,9 +215,8 @@ Ao criar formulários que salvam associações aninhadas, você precisa definir
 quais associações devem ser convertidas::
 
     // No controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Nova entidade com associações aninhadas
@@ -239,9 +231,8 @@ ser convertidos. Alternativamente, você pode usar a notação de ponto
 (dot notation) por brevidade::
 
     // No controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Nova entidade com associações aninhada usando notação de ponto
@@ -259,9 +250,8 @@ Os dados associados também são validados por padrão, a menos que seja informa
 contrário. Você também pode alterar o conjunto de validação a ser usada por associação::
 
     // No controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Pular validação na associação de Tags e
@@ -384,9 +374,8 @@ Ao criar formulários que cria/atualiza vários registros ao mesmo tempo, você 
 o método ``newEntities()``::
 
     // No controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($this->request->getData());
 
@@ -437,9 +426,8 @@ Nesse caso , você pode usar a opção ``accessibleFields``. Isso pode ser útil
 manter ids de entidades associadas::
 
     // No controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
@@ -472,9 +460,8 @@ Você pode mesclar um array de dados bruto em uma entidade existente usando o m�
 ``patchEntity()``::
 
     // No controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $this->request->getData());
@@ -489,9 +476,8 @@ antes de ser copiado para entidade. O mecanismo é explicado na seção
 o opção ``validate`` assim::
 
     // No controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $data, ['validate' => false]);
@@ -614,9 +600,8 @@ presentes na entidade, você pode coletar as chaves primárias e executar uma ex
 de lote para esses que não estão na lista::
 
     // Num controller.
-    // Prior to 3.6.0
-    $comments = TableRegistry::get('Comments');
 
+    // Prior to 3.6 use TableRegistry::get('Comments')
     $comments = TableRegistry::getTableLocator()->get('Comments');
     $present = (new Collection($entity->comments))->extract('id')->filter()->toArray();
     $comments->deleteAll([
@@ -633,9 +618,8 @@ As comparação são feitas pelo valor do campo da chave primária e as correspo
 faltam no array das entidades originais serão removidas e não estarão presentes no resultado::
 
     // Num controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $list = $articles->find('popular')->toArray();
     $patched = $articles->patchEntities($list, $this->request->getData());
@@ -774,15 +758,14 @@ Salvando Entidades
 Ao salvar dados de requisição no seu banco de dados, você primeiro precisa hidratar (hydrate)
 uma nova entidade usando ``newEntity()`` para passar no ``save()``. Por exemplo::
 
-  // Num controller
-  // Prior to 3.6.0
-  $articles = TableRegistry::get('Articles');
+    // Num controller
 
-  $articles = TableRegistry::getTableLocator()->get('Articles');
-  $article = $articles->newEntity($this->request->getData());
-  if ($articles->save($article)) {
-      // ...
-  }
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
+    $article = $articles->newEntity($this->request->getData());
+    if ($articles->save($article)) {
+        // ...
+    }
 
 O ORM usa o método ``isNew()`` em uma entidade para determinar quando um insert ou update
 deve ser realizado ou não. Se o método ``isNew()`` retorna ``true`` e a entidade tiver um valor
@@ -794,9 +777,7 @@ informando a opção ``'checkExisting' => false`` no argumento ``$options``::
 Uma vez, que você carregou algumas entidades, você provavelmente desejará modificar elas e
 atualizar em seu banco de dados. Este é um exercício bem simples no CakePHP::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->find('all')->where(['id' => 2])->first();
 
@@ -913,9 +894,7 @@ Por exemplo::
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Users']
@@ -939,9 +918,7 @@ Por exemplo::
         ]
     ];
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity($data, [
         'associated' => ['Profiles']
@@ -964,9 +941,7 @@ Por exemplo::
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Comments']
@@ -1013,9 +988,7 @@ Por exemplo::
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Tags']
@@ -1227,9 +1200,7 @@ podem ser um array de entidades criadas usando ``newEntities()`` / ``patchEntiti
         ],
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($data);
     $result = $articles->saveMany($entities);

--- a/pt/plugins.rst
+++ b/pt/plugins.rst
@@ -456,10 +456,8 @@ Você pode usar ``TableRegistry`` para carregar suas tabelas de plugins usando o
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('ContactManager.Contacts')
     $contacts = TableRegistry::getTableLocator()->get('ContactManager.Contacts');
-
-    // Prior to 3.6.0
-    $contacts = TableRegistry::get('ContactManager.Contacts');
 
 Alternativamente, a partir de um contexto de controller, você pode usar::
 

--- a/ru/intro.rst
+++ b/ru/intro.rst
@@ -40,9 +40,7 @@ CakePHP предоставляет базовую организационную
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -58,9 +56,7 @@ CakePHP предоставляет базовую организационную
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/ru/orm.rst
+++ b/ru/orm.rst
@@ -40,9 +40,7 @@ CakePHP имеет встроенное объектно-реляционное 
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     $query = $articles->find();
@@ -75,10 +73,8 @@ CakePHP имеет встроенное объектно-реляционное 
     use Cake\ORM\TableRegistry;
 
     // Теперь $articles экземпляр класса ArticlesTable.
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
 Теперь, когда у нас есть конкретный класс таблицы, мы возможно захотим использовать
 конкретный класс одной записи таблицы (сущности). Класс сущности позволяют определить
@@ -102,9 +98,7 @@ CakePHP имеет встроенное объектно-реляционное 
     use Cake\ORM\TableRegistry;
 
     // $articles объект класса ArticlesTable.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
 

--- a/ru/orm/behaviors/tree.rst
+++ b/ru/orm/behaviors/tree.rst
@@ -54,9 +54,7 @@ TreeBehavior ('Поведение деревьев') помогает вам п�
 После добавления, вы уже можете позволить CakePHP построить внутреннюю
 структуру, если в вашей таблице уже есть несколько строк::
 
-    // Prior to 3.6.0
-    $categories = TableRegistry::get('Categories');
-
+    // Prior to 3.6 use TableRegistry::get('Categories')
     $categories = TableRegistry::getTableLocator()->get('Categories');
     $categories->recover();
 

--- a/ru/orm/table-objects.rst
+++ b/ru/orm/table-objects.rst
@@ -111,10 +111,8 @@
     // В контроллере и методе.
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
-
-    // До 3.6.0
-    $articles = TableRegistry::get('Articles');
 
 Класс ``TableRegistry`` предоставляет различные зависимости для построения
 таблицы и ведёт реестр всех созданных экземпляров таблиц, что упрощает
@@ -126,14 +124,12 @@
 допустить, следуйте следующим примерам::
 
     // Таблица плагина
+    // Prior to 3.6 use TableRegistry::get('PluginName.Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('PluginName.Articles');
 
     // Таблица плагина с префиксом vendor'а
+    // Prior to 3.6 use TableRegistry::get('VendorName/PluginName.Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('VendorName/PluginName.Articles');
-
-    // До 3.6.0
-    $articlesTable = TableRegistry::get('PluginName.Articles');
-    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
 
 .. _table-callbacks:
 

--- a/ru/plugins.rst
+++ b/ru/plugins.rst
@@ -464,10 +464,8 @@ CakePHP будет также включать маршруты, которые 
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('ContactManager.Contacts')
     $contacts = TableRegistry::getTableLocator()->get('ContactManager.Contacts');
-
-    // Prior to 3.6.0
-    $contacts = TableRegistry::get('ContactManager.Contacts');
 
 Кроме того, из контекста контроллера вы можете использовать::
 

--- a/tl/appendices/orm-migration.rst
+++ b/tl/appendices/orm-migration.rst
@@ -160,9 +160,7 @@ several purposes.
 
 It is possible to alter queries further, after calling ``find``::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
     $query->where(['author_id' => 1])->order(['title' => 'DESC']);

--- a/tl/development/testing.rst
+++ b/tl/development/testing.rst
@@ -746,10 +746,9 @@ now looks like this::
         public function setUp()
         {
             parent::setUp();
-            $this->Articles = TableRegistry::getTableLocator()->get('Articles');
 
-            // Prior to 3.6.0
-            $this->Articles = TableRegistry::get('Articles');
+            // Prior to 3.6 use TableRegistry::get('Articles')
+            $this->Articles = TableRegistry::getTableLocator()->get('Articles');
         }
 
         public function testFindPublished()
@@ -897,9 +896,7 @@ Create a file named **ArticlesControllerTest.php** in your
             $this->post('/articles', $data);
             $this->assertResponseSuccess();
 
-            // Prior to 3.6.0
-            $articles = TableRegistry::get('Articles');
-
+            // Prior to 3.6 use TableRegistry::get('Articles')
             $articles = TableRegistry::getTableLocator()->get('Articles');
             $query = $articles->find()->where(['title' => $data['title']]);
             $this->assertEquals(1, $query->count());
@@ -1454,9 +1451,7 @@ snippet of code::
             $this->exec('my_console update_modified Users');
             $this->assertExitCode(Shell::CODE_SUCCESS);
 
-            // Prior to 3.6.0
-            $user = TableRegistry::get('Users')->get(1);
-
+            // Prior to 3.6 use TableRegistry::get('Users')
             $user = TableRegistry::getTableLocator()->get('Users')->get(1);
             $this->assertSame($user->modified->timestamp, $now->timestamp);
 
@@ -1856,10 +1851,9 @@ the event data::
         public function setUp()
         {
             parent::setUp();
-            $this->Orders = TableRegistry::getTableLocator()->get('Orders');
 
-            // Prior to 3.6.0
-            $this->Orders = TableRegistry::get('Orders');
+            // Prior to 3.6 use TableRegistry::get('Orders')
+            $this->Orders = TableRegistry::getTableLocator()->get('Orders');
 
             // enable event tracking
             $this->Orders->eventManager()->setEventList(new EventList());

--- a/tl/intro.rst
+++ b/tl/intro.rst
@@ -37,9 +37,7 @@ The model objects can be thought of as "Friend", "User", "Comment", or
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -55,9 +53,7 @@ something like::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);

--- a/tl/orm.rst
+++ b/tl/orm.rst
@@ -38,9 +38,7 @@ table we could do::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     $query = $articles->find();
@@ -72,9 +70,7 @@ to it using the :php:class:`~Cake\\ORM\\TableRegistry` as before::
     use Cake\ORM\TableRegistry;
 
     // Now $articles is an instance of our ArticlesTable class.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
 Now that we have a concrete table class, we'll probably want to use a concrete
@@ -98,9 +94,7 @@ load entities from the database we'll get instances of our new Article class::
     use Cake\ORM\TableRegistry;
 
     // Now an instance of ArticlesTable.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find();
 

--- a/tl/orm/behaviors/tree.rst
+++ b/tl/orm/behaviors/tree.rst
@@ -53,9 +53,7 @@ hierarchical data in::
 Once added, you can let CakePHP build the internal structure if the table is
 already holding some rows::
 
-    // Prior to 3.6.0
-    $categories = TableRegistry::get('Categories');
-
+    // Prior to 3.6 use TableRegistry::get('Categories')
     $categories = TableRegistry::getTableLocator()->get('Categories');
     $categories->recover();
 

--- a/tl/orm/entities.rst
+++ b/tl/orm/entities.rst
@@ -62,9 +62,7 @@ The preferred way of getting new entities is using the ``newEntity()`` method fr
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $article = TableRegistry::get('Articles')->newEntity();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity();
 
     $article = TableRegistry::getTableLocator()->get('Articles')->newEntity([

--- a/tl/orm/query-builder.rst
+++ b/tl/orm/query-builder.rst
@@ -23,8 +23,7 @@ Query builder that does not include ORM features, if necessary. See the
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
+    // Prior to 3.6 use TableRegistry::get('Articles')
 
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
@@ -45,9 +44,7 @@ Selecting Rows From A Table
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $query = TableRegistry::get('Articles')->find();
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $query = TableRegistry::getTableLocator()->get('Articles')->find();
 
     foreach ($query as $article) {

--- a/tl/orm/retrieving-data-and-resultsets.rst
+++ b/tl/orm/retrieving-data-and-resultsets.rst
@@ -379,9 +379,8 @@ would do the following::
     }
 
     // In a controller or table method.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('ownedBy', ['user' => $userEntity]);
 
@@ -391,9 +390,8 @@ customize the finder operation with relevant application logic. You can also
 you have both the 'published' and 'recent' finders, you could do the following::
 
     // In a controller or table method.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('published')->find('recent');
 
@@ -419,9 +417,8 @@ find a user by username you could do::
     $query = $this->Users->findAllByUsername('joebob');
 
     // In a table method
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $users = TableRegistry::getTableLocator()->get('Users');
     // The following two calls are equal.
     $query = $users->findByUsername('joebob');
@@ -991,9 +988,8 @@ do. For example, you can extract a list of unique tags on a collection of
 articles by running::
 
     // In a controller or table method.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find()->contain(['Tags']);
 
@@ -1016,9 +1012,8 @@ Some other examples of the collection methods being used with result sets are::
     });
 
     // Create an associative array from result properties
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $results = $articles->find()->contain(['Authors'])->all();
 

--- a/tl/orm/saving-data.rst
+++ b/tl/orm/saving-data.rst
@@ -24,9 +24,7 @@ passing it to the ``save()`` method in the ``Table`` class::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->newEntity();
 
@@ -46,9 +44,7 @@ that purpose::
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $article = $articlesTable->get(12); // Return article with id 12
 
@@ -64,9 +60,7 @@ Saving With Associations
 
 By default the ``save()`` method will also save one level of associations::
 
-    // Prior to 3.6.0
-    $articlesTable = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articlesTable = TableRegistry::getTableLocator()->get('Articles');
     $author = $articlesTable->Authors->findByUserName('mark')->first();
 
@@ -139,9 +133,8 @@ that the ORM uses. The Table class provides an easy and efficient way to convert
 one or many entities from request data. You can convert a single entity using::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Validate and convert to an Entity object
@@ -180,9 +173,8 @@ When building forms that save nested associations, you need to define which
 associations should be marshalled::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // New entity with nested associations
@@ -196,9 +188,8 @@ The above indicates that the 'Tags', 'Comments' and 'Users' for the Comments
 should be marshalled. Alternatively, you can use dot notation for brevity::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // New entity with nested associations using dot notation
@@ -216,9 +207,8 @@ Associated data is also validated by default unless told otherwise. You may also
 change the validation set to be used per association::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
 
     // Bypass validation on Tags association and
@@ -342,9 +332,8 @@ When creating forms that create/update multiple records at once you can use
 ``newEntities()``::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($this->request->getData());
 
@@ -395,9 +384,8 @@ such case, you can use the ``accessibleFields`` option. It could be useful to
 keep ids of associated entities::
 
     // In a controller
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entity = $articles->newEntity($this->request->getData(), [
         'associated' => [
@@ -431,9 +419,8 @@ persisted. You can merge an array of raw data into an existing entity using the
 ``patchEntity()`` method::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $this->request->getData());
@@ -448,9 +435,8 @@ before it is copied to the entity. The mechanism is explained in the
 patching an entity, pass the ``validate`` option as follows::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->get(1);
     $articles->patchEntity($article, $data, ['validate' => false]);
@@ -573,9 +559,8 @@ present in the entity, you can collect the primary keys and execute a batch
 delete for those not in the list::
 
     // In a controller.
-    // Prior to 3.6.0
-    $comments = TableRegistry::get('Comments');
 
+    // Prior to 3.6 use TableRegistry::get('Comments')
     $comments = TableRegistry::getTableLocator()->get('Comments');
     $present = (new Collection($entity->comments))->extract('id')->filter()->toArray();
     $comments->deleteAll([
@@ -592,9 +577,8 @@ entities: Matches are done by the primary key field value and missing matches in
 the original entities array will be removed and not present in the result::
 
     // In a controller.
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
 
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $list = $articles->find('popular')->toArray();
     $patched = $articles->patchEntities($list, $this->request->getData());
@@ -732,15 +716,14 @@ Saving Entities
 When saving request data to your database you need to first hydrate a new entity
 using ``newEntity()`` for passing into ``save()``. For example::
 
-  // In a controller
-  // Prior to 3.6.0
-  $articles = TableRegistry::get('Articles');
+    // In a controller
 
-  $articles = TableRegistry::getTableLocator()->get('Articles');
-  $article = $articles->newEntity($this->request->getData());
-  if ($articles->save($article)) {
-      // ...
-  }
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator()->get('Articles');
+    $article = $articles->newEntity($this->request->getData());
+    if ($articles->save($article)) {
+        // ...
+    }
 
 The ORM uses the ``isNew()`` method on an entity to determine whether or not an
 insert or update should be performed. If the ``isNew()`` method returns ``true``
@@ -753,9 +736,7 @@ and the entity has a primary key value, an 'exists' query will be issued. The
 Once you've loaded some entities you'll probably want to modify them and update
 your database. This is a pretty simple exercise in CakePHP::
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->find('all')->where(['id' => 2])->first();
 
@@ -873,9 +854,7 @@ the singular, :ref:`underscored <inflector-methods-summary>` version of the asso
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Users']
@@ -898,9 +877,7 @@ singular, :ref:`underscored <inflector-methods-summary>` version of the associat
         ]
     ];
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity($data, [
         'associated' => ['Profiles']
@@ -922,9 +899,7 @@ plural, :ref:`underscored <inflector-methods-summary>` version of the associatio
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Comments']
@@ -976,9 +951,7 @@ the plural, :ref:`underscored <inflector-methods-summary>` version of the associ
         ]
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $article = $articles->newEntity($data, [
         'associated' => ['Tags']
@@ -1189,9 +1162,7 @@ be an array of entities created using ``newEntities()`` / ``patchEntities()``.
         ],
     ];
 
-    // Prior to 3.6.0
-    $articles = TableRegistry::get('Articles');
-
+    // Prior to 3.6 use TableRegistry::get('Articles')
     $articles = TableRegistry::getTableLocator()->get('Articles');
     $entities = $articles->newEntities($data);
     $result = $articles->saveMany($entities);

--- a/tl/orm/table-objects.rst
+++ b/tl/orm/table-objects.rst
@@ -108,7 +108,8 @@ can do this by using the ``TableRegistry`` class::
     // In a controller or table method.
     use Cake\ORM\TableRegistry;
 
-    $articles = TableRegistry::get('Articles');
+    // Prior to 3.6 use TableRegistry::get('Articles')
+    $articles = TableRegistry::getTableLocator::get('Articles');
 
 The TableRegistry class provides the various dependencies for constructing
 a table, and maintains a registry of all the constructed table instances making
@@ -121,10 +122,12 @@ being triggered as a default class is used instead of your actual class. To
 correctly load plugin table classes use the following::
 
     // Plugin table
-    $articlesTable = TableRegistry::get('PluginName.Articles');
+    // Prior to 3.6 use TableRegistry::get('PluginName.Articles')
+    $articlesTable = TableRegistry::getTableLocator()->get('PluginName.Articles');
 
     // Vendor prefixed plugin table
-    $articlesTable = TableRegistry::get('VendorName/PluginName.Articles');
+    // Prior to 3.6 use TableRegistry::get('VendorName/PluginName.Articles')
+    $articlesTable = TableRegistry::getTableLocator::get('VendorName/PluginName.Articles');
 
 .. _table-callbacks:
 

--- a/tl/plugins.rst
+++ b/tl/plugins.rst
@@ -466,10 +466,8 @@ You can use ``TableRegistry`` to load your plugin tables using the familiar
 
     use Cake\ORM\TableRegistry;
 
+    // Prior to 3.6 use TableRegistry::get('ContactManager.Contacts')
     $contacts = TableRegistry::getTableLocator()->get('ContactManager.Contacts');
-
-    // Prior to 3.6.0
-    $contacts = TableRegistry::get('ContactManager.Contacts');
 
 Alternatively, from a controller context, you can use::
 

--- a/zh/intro.rst
+++ b/zh/intro.rst
@@ -29,9 +29,7 @@ CakePHP提供的基本构造包括class名，文件名，数据库table名。尽
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $query = $users->find();
     foreach ($query as $row) {
@@ -45,9 +43,7 @@ CakePHP提供的基本构造包括class名，文件名，数据库table名。尽
 
     use Cake\ORM\TableRegistry;
 
-    // Prior to 3.6.0
-    $users = TableRegistry::get('Users');
-
+    // Prior to 3.6 use TableRegistry::get('Users')
     $users = TableRegistry::getTableLocator()->get('Users');
     $user = $users->newEntity(['email' => 'mark@example.com']);
     $users->save($user);


### PR DESCRIPTION
Follows en from https://github.com/cakephp/docs/pull/6224.

I split this up since it's very tedious to change all these examples multiple times if there was a review issue.  I caught a few places where the deprecated method was still used.

If there was an official translation of 'Prior to <version> use' I would have used that in each translation. 