### PR TITLE
Updated nginx config to use /2/ instead of /2.0/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -38,4 +38,4 @@ COPY --from=builder /data/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Move built site into place
 RUN mkdir -p /usr/share/nginx/html/ \
- && mv /data/website /usr/share/nginx/html/2.0
+ && mv /data/website /usr/share/nginx/html/2

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,4 +10,8 @@ server {
     gzip_proxied any;
     gzip_types text/plain text/xml text/css application/x-javascript;
     gzip_vary on;
+
+    location ~ ^/2\.[0x]/ {
+        rewrite ^/2\.[0x]/(.*)$ /2/$1 permanent;
+    }
 }


### PR DESCRIPTION
https://github.com/cakephp/docs/issues/5891

I'm not sure what the nginx setup is for routing to the version-specific books, but this will handle any `/2.0/*` and `/2.x/*` requests.  I assume the top-level router is redirecting to `/2.0/en/` and don't try to handle any special cases.

I disabled elasti-search and and ran the full container locally.