### PR TITLE
Updated nginx config to use /3/ instead of /3.0/

### DIFF
--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -38,4 +38,4 @@ COPY --from=builder /data/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Move built site into place
 RUN mkdir -p /usr/share/nginx/html/ \
- && mv /data/website /usr/share/nginx/html/3.0
+ && mv /data/website /usr/share/nginx/html/3

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,35 +11,8 @@ server {
     gzip_types text/plain text/xml text/css application/x-javascript;
     gzip_vary on;
 
-    # Error handling
-    error_page 404 @error_page;
-    location @error_page {
-        root /usr/share/nginx/html;
-        set $error404 /3.0/en/404.html;
-        if ($request_filename ~ "/3.0/es") {
-            set $error404 /3.0/es/404.html;
-        }
-        if ($request_filename ~ "/3.0/fr") {
-            set $error404 /3.0/fr/404.html;
-        }
-        if ($request_filename ~ "/3.0/ja") {
-            set $error404 /3.0/ja/404.html;
-        }
-        if ($request_filename ~ "/3.0/kr") {
-            set $error404 /3.0/kr/404.html;
-        }
-        if ($request_filename ~ "/3.0/pt") {
-            set $error404 /3.0/pt/404.html;
-        }
-        if ($request_filename ~ "/3.0/tr") {
-            set $error404 /3.0/tr/404.html;
-        }
-        if ($request_filename ~ "/3.0/zh") {
-            set $error404 /3.0/zh/404.html;
-        }
-        if ($request_filename ~ "/3.0/ru") {
-            set $error404 /3.0/ru/404.html;
-        }
-        rewrite ^(.*)$ $error404 break;
+    location ~ ^/3\.[0x]/ {
+        rewrite ^/3\.[0x]/(.*)$ /3/$1 permanent;
     }
 }
+


### PR DESCRIPTION
#5891
https://github.com/cakephp/docs/issues/4832

I'm not sure what the nginx setup is for routing to the version-specific books, but this will handle any /3.0/* and /3.x/* requests. I assume the top-level router is redirecting to /3.0/en/ and don't try to handle any special cases.

Disabled special 404 page as they have not rendered properly in a long time.  Use default 404 page just like CakePHP 2 docs.

I disabled elasti-search and and ran the full container locally.