### PR TITLE
Clarify event propagation abort in Table scope.

### DIFF
--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -182,7 +182,7 @@ The above code shows a few interesting features of behaviors:
 - Behaviors can define a default configuration property. This property is merged
   with the overrides when a behavior is attached to the table.
 
-To prevent the saving from continuing simply stop event propagation in your callback::
+To prevent the save from continuing, simply stop event propagation in your callback::
 
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {

--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -76,7 +76,6 @@ friendly URLs::
 
     class ArticlesTable extends Table
     {
-
         public function initialize(array $config)
         {
             $this->addBehavior('Sluggable');
@@ -162,7 +161,7 @@ behavior should now look like::
             'replacement' => '-',
         ];
 
-        public function slug(Entity $entity)
+        public function slug(EntityInterface $entity)
         {
             $config = $this->config();
             $value = $entity->get($config['field']);
@@ -189,10 +188,13 @@ To prevent the saving from continuing simply stop event propagation in your call
     {
         if (...) {
             $event->stopPropagation();
+            $event->setResult(false);
             return;
         }
         $this->slug($entity);
     }
+
+Alternatively, you can return false from the callback. This has the same effect as stopping event propagation.
 
 Defining Finders
 ----------------

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -326,7 +326,7 @@ The event is not triggered if a transaction is started before calling delete.
 
 Stopping Table Events
 ---------------------
-To prevent the saving from continuing simply stop event propagation in your callback::
+To prevent the save from continuing, simply stop event propagation in your callback::
 
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -191,6 +191,7 @@ which implements ``EventListenerInterface``::
                 'Model.initialize' => 'initializeEvent',
             );
         }
+
         public function initializeEvent($event)
         {
             $table = $event->getSubject();
@@ -277,7 +278,6 @@ beforeSave
 The ``Model.beforeSave`` event is fired before each entity is saved. Stopping
 this event will abort the save operation. When the event is stopped the result
 of the event will be returned.
-How to stop an event is documented :ref:`here <stopping-events>`.
 
 afterSave
 ---------
@@ -305,7 +305,6 @@ beforeDelete
 The ``Model.beforeDelete`` event is fired before an entity is deleted. By
 stopping this event you will abort the delete operation. When the event is stopped the result
 of the event will be returned.
-How to stop an event is documented :ref:`here <stopping-events>`.
 
 afterDelete
 -----------
@@ -324,6 +323,22 @@ delete operation is wrapped has been is committed. It's also triggered for non
 atomic deletes where database operations are implicitly committed. The event is
 triggered only for the primary table on which ``delete()`` is directly called.
 The event is not triggered if a transaction is started before calling delete.
+
+Stopping Table Events
+---------------------
+To prevent the saving from continuing simply stop event propagation in your callback::
+
+    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    {
+        if (...) {
+            $event->stopPropagation();
+            $event->setResult(false);
+            return;
+        }
+        ...
+    }
+
+Alternatively, you can return false from the callback. This has the same effect as stopping event propagation.
 
 Callback priorities
 -------------------


### PR DESCRIPTION
Resolves https://github.com/cakephp/docs/issues/6242

The normal stop of event propagation is not completely true for Table scope, where also the false value must be returned in order to properly stop the following action.