### PR TITLE
Copy deprecation warning

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -535,6 +535,11 @@ following::
         }
     }
 
+.. deprecated:: 3.4.0
+    Use ``viewBuilder()->setTemplate()`` instead of ``template()``. Use
+    ``viewBuilder()->setLayout()`` instead of the layout argument of
+    ``template()``. Use ``viewBuilder()->setTheme()`` instead of ``theme()``.
+
 In our example we have created two methods, one for sending a welcome email, and
 another for sending a password reset email. Each of these methods expect a user
 ``Entity`` and utilizes its properties for configuring each email.


### PR DESCRIPTION
"Creating Reusable Emails" section relies on templates, but uses code that'll soon be deprecated. Copied the deprecation warning from the "Sending Templated Emails" section for those who didn't read it and quickly jumped to "Creating Reusable Emails"