### PR TITLE
Fixing commands for rector

### DIFF
--- a/en/appendices/4-0-upgrade-guide.rst
+++ b/en/appendices/4-0-upgrade-guide.rst
@@ -50,8 +50,8 @@ Next use the ``rector`` command to automatically fix many deprecated CakePHP and
 PHPUnit method calls. It is important to apply rector **before** you upgrade
 your dependencies::
 
-    bin/cake rector --rules phpunit80 <path/to/app>
-    bin/cake rector --rules cakephp40 <path/to/app>
+    bin/cake upgrade rector --rules phpunit80 <path/to/app>
+    bin/cake upgrade rector --rules cakephp40 <path/to/app>
 
 Update CakePHP Dependency
 =========================


### PR DESCRIPTION
The commands for rector are incorrect and need to be `bin/cake upgrade rector` instead of `bin/cake rector`

Also during upgrade it maybe better to use the /src path or /tests path as just using the app results in rector running from the whole project and trying to correct packages in the /vendor dir.