### PR TITLE
3.9 - Added migration notes for Text::uuid() random_int() in PHP 5.6

### DIFF
--- a/en/appendices/3-9-migration-guide.rst
+++ b/en/appendices/3-9-migration-guide.rst
@@ -67,6 +67,8 @@ Utility
 -------
 
 * ``Hash::sort()`` now accepts the ``SORT_ASC`` and ``SORT_DESC`` constants in the direction parameter.
+* ``Text::uuid`` now uses ``random_int()`` with PHP 5.6 insted of ``mt_rand()``.
+  This adds a dependency on paragonie/random_compat which implements it for PHP 5.6.
 
 Validation
 ----------


### PR DESCRIPTION
Added migration notes for https://github.com/cakephp/cakephp/pull/13958.