### PR TITLE
Upgrade Docs 4.x Removing duplicate cd command.

### DIFF
--- a/en/appendices/4-0-upgrade-guide.rst
+++ b/en/appendices/4-0-upgrade-guide.rst
@@ -32,8 +32,6 @@ plugin:
 
 .. code-block:: bash
 
-    cd ~/code/upgrade
-
     # Rename locale files
     bin/cake upgrade file_rename locales <path/to/app>
 


### PR DESCRIPTION
As a discussion in slack/irc came up It was determined that the `cd ~/code/upgrade` is very specific and not where the user would have done the initial clone. Plus when following the directions and running `composer install --no-dev` the user is already in the directory needed to run the commands later in the docs.

cc @niel 