### PR TITLE
fatal: ../src/Locale is outside repository

### DIFF
--- a/en/appendices/4-0-upgrade-guide.rst
+++ b/en/appendices/4-0-upgrade-guide.rst
@@ -39,6 +39,7 @@ To help expedite fixing these tedious changes there is an upgrade CLI tool:
     cd upgrade
     git checkout 4.x
     composer install --no-dev
+    cd ..
 
 With the upgrade tool installed you can now run it on your application or
 plugin:
@@ -46,10 +47,10 @@ plugin:
 .. code-block:: bash
 
     # Rename locale files
-    bin/cake upgrade file_rename locales <path/to/app>
+    upgrade/bin/cake upgrade file_rename locales <path/to/app>
 
     # Rename template files
-    bin/cake upgrade file_rename templates <path/to/app>
+    upgrade/bin/cake upgrade file_rename templates <path/to/app>
 
 Once you've renamed your template and locale files, make sure you update
 ``App.paths.locales`` and ``App.paths.templates`` paths to be correct.


### PR DESCRIPTION
The [documentation](https://book.cakephp.org/4/en/appendices/4-0-upgrade-guide.html#use-the-upgrade-tool) directs the user to checkout the upgrade tool and then cd into the upgrade-folder and run the scripts from there. If the app is in a different repository the user will get the fatal error `../src/Locale is outside repository`.
The reason seems to be that the FileRenameCommand wants to use `git mv` if available, but it is not possible to do that to an outside folder.
So I propose to recommend the user to leave the upgrade folder again before attempting to run the tool.