### PR TITLE
Add ::class to ShadowTableStrategy reference

### DIFF
--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -116,7 +116,7 @@ as::
         public function initialize(array $config): void
         {
             $this->addBehavior('Translate', [
-                'strategyClass' => \Cake\ORM\Behavior\Translate\ShadowTableStrategy,
+                'strategyClass' => \Cake\ORM\Behavior\Translate\ShadowTableStrategy::class,
             ]);
         }
     }


### PR DESCRIPTION
Without the ::class it will give an invalid constant error.