### PR TITLE
Explain uncommenting lines before using .env

### DIFF
--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -71,6 +71,9 @@ instead use the ``config/.env.example`` as a template with placeholder values so
 everyone on your team knows what environment variables are in use and what
 should go in each one.
 
+Before being able to use the ``env()`` syntax, you will need to uncomment 
+the code block on line 59-65 in ``config/bootstrap.php``.
+
 Once your environment variables have been set, you can use ``env()`` to read
 data from the environment::
 

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -72,7 +72,7 @@ everyone on your team knows what environment variables are in use and what
 should go in each one.
 
 Before being able to use the ``env()`` syntax, you will need to uncomment 
-the code block on line 59-65 in ``config/bootstrap.php``.
+related code block in ``config/bootstrap.php``.
 
 Once your environment variables have been set, you can use ``env()`` to read
 data from the environment::


### PR DESCRIPTION
Currently it is not clear that you need to uncomment certain lines in bootstrap.php in order to make use of the .env syntax.