### PR TITLE
Delete duplicated explanation about RequestHandlerComponent in 4.0 migration guide

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -110,10 +110,6 @@ Console
 Component
 ---------
 
-* The input data parsing feature of ``RequestHandlerComponent`` which for e.g.
-  allowed parsing JSON/XML input into request data array has been removed. You should
-  instead use the ``Cake\Http\Middleware\BodyParserMiddleware`` in your application
-  if you need input data parsing.
 * ``Cake\Controller\Component\RequestHandlerComponent`` now sets ``isAjax`` as a
   request attribute instead of request param. Hence you should now use
   ``$request->getAttribute('isAjax')`` instead of ``$request->getParam('isAjax')``.


### PR DESCRIPTION
At 4.0 Migration guide, there are two explanations about RequestHandlerComponent in Component section.

1st one is ...

https://github.com/cakephp/docs/pull/6382/files#diff-2571a7d175dfd78b02353be306cdbfd8L113
(deleted line in this PR)

2nd one is ...

> * The request body parsing features of ``RequestHandlerComponent`` have been
  removed and now emit a deprecation warning. You should use the
  :ref:`body-parser-middleware` instead.

https://github.com/cakephp/docs/pull/6382/files#diff-2571a7d175dfd78b02353be306cdbfd8R116

I think the 2nd one is better because it contains the link to body-parser-middleware. That's why this PR deletes 1st line.

ref: https://book.cakephp.org/4/en/appendices/4-0-migration-guide.html