### PR TITLE
Update database.rst on 4.x CMS tutorial

### DIFF
--- a/en/tutorials-and-examples/cms/database.rst
+++ b/en/tutorials-and-examples/cms/database.rst
@@ -98,8 +98,8 @@ able to connect to the database' section have a green chef hat.
 
 .. note::
 
-	If you have **config/app_local.php** in your app folder,
-	it overrides app.php configuration.
+    If you have **config/app_local.php** in your app folder,
+    it overrides app.php configuration.
 
 Creating our First Model
 ========================

--- a/en/tutorials-and-examples/cms/database.rst
+++ b/en/tutorials-and-examples/cms/database.rst
@@ -98,8 +98,8 @@ able to connect to the database' section have a green chef hat.
 
 .. note::
 
-    A copy of CakePHP's default configuration file is found in
-    **config/app.default.php**.
+	If you have **config/app_local.php** in your app folder,
+	it overrides app.php configuration.
 
 Creating our First Model
 ========================


### PR DESCRIPTION
Update notes of the database setting of 4.x CMS tutorial :
https://book.cakephp.org/4/en/tutorials-and-examples/cms/database.html#database-configuration

## database.rst
* I think it's kind to have note of app_local.php. Since it exists by default, it overrides the app.php configuration even if we modified app.php Datasources section following your guidline.
* Delete the note of app.default.php because it seems it's no longer exists by default.