### PR TITLE
Add migration notes for alias truncation exception

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -256,6 +256,9 @@ ORM
 * Stopping the ``Model.beforeSave`` event with a non-false, non-entity result
   will now raise an exception. This change ensures that ``Table::save()`` always
   returns an entity or false.
+* Table will now throw an exception when aliases generated for the table name and column
+  would be truncated by the database. This warns the user before hidden errors occur when
+  cakephp cannot match the alias in the result.
 
 Router
 ------

--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -258,7 +258,7 @@ ORM
   returns an entity or false.
 * Table will now throw an exception when aliases generated for the table name and column
   would be truncated by the database. This warns the user before hidden errors occur when
-  cakephp cannot match the alias in the result.
+  CakePHP cannot match the alias in the result.
 
 Router
 ------


### PR DESCRIPTION
We might as well add migration notes for this since the user won't know the behavior was always wrong.

https://github.com/cakephp/cakephp/pull/14086