### PR TITLE
Ensure Windows compatibility in project creation command.

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -82,7 +82,7 @@ command:
 
 .. code-block:: bash
 
-    composer create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    composer create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Once Composer finishes downloading the application skeleton and the core CakePHP
 library, you should have a functioning CakePHP application installed via

--- a/en/tutorials-and-examples/blog/blog.rst
+++ b/en/tutorials-and-examples/blog/blog.rst
@@ -39,11 +39,11 @@ installation directory to install the CakePHP application skeleton
 in the directory that you wish to use it with. For this example we will be using
 "blog" but feel free to change it to something else.::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 blog
+    php composer.phar create-project --prefer-dist cakephp/app:4.* blog
 
 In case you've already got composer installed globally, you may instead type::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 blog
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* blog
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -44,14 +44,14 @@ Then simply type the following line in your terminal from your
 installation directory to install the CakePHP application skeleton
 in the **bookmarker** directory::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
 your terminal from your installation directory (ie.
 C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* bookmarker
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/cms/installation.rst
+++ b/en/tutorials-and-examples/cms/installation.rst
@@ -46,7 +46,7 @@ in the **cms** directory of the current working directory:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 cms
+    php composer.phar create-project --prefer-dist cakephp/app:4.* cms
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
@@ -55,7 +55,7 @@ C:\\wamp\\www\\dev):
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* cms
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/es/installation.rst
+++ b/es/installation.rst
@@ -63,11 +63,11 @@ instrucciones acerca de esto, puedes leer el README del instalador de Windows
 Ya que has descargado e instalado Composer puedes generar una aplicación
 CakePHP ejecutando::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 [app_name]
+    php composer.phar create-project --prefer-dist cakephp/app:4.* [app_name]
 
 O si tienes Composer definido globalmente::
 
-    composer create-project --prefer-dist cakephp/app:^4.0 [app_name]
+    composer create-project --prefer-dist cakephp/app:4.* [app_name]
 
 Una vez que Composer termine de descargar el esqueleto y la librería core
 de CakePHP, deberías tener una aplicación funcional de CakePHP instalada

--- a/es/tutorials-and-examples/blog/blog.rst
+++ b/es/tutorials-and-examples/blog/blog.rst
@@ -46,11 +46,11 @@ Luego, simplemente escribe la siguiente línea en tu terminal desde tu directori
 de instalación para instalar el esqueleto de la aplicación de CakePHP en el
 directorio [nombre_app]. ::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 [nombre_app]
+    php composer.phar create-project --prefer-dist cakephp/app:4.* [nombre_app]
 
 O si tienes Composer instalado globalmente::
 
-    composer create-project --prefer-dist cakephp/app:^4.0 [nombre_app]
+    composer create-project --prefer-dist cakephp/app:4.* [nombre_app]
 
 La ventaja de utilizar Composer es que automáticamente completará algunas tareas
 de inicialización, como aplicar permisos a ficheros y crear tu fichero

--- a/es/tutorials-and-examples/bookmarks/intro.rst
+++ b/es/tutorials-and-examples/bookmarks/intro.rst
@@ -33,11 +33,11 @@ O puedes descargar ``composer.phar`` desde la `Página web de Composer <https://
 
 Después sencillamente escribe la siguiente línea en tu terminal desde tu directorio de instalación para instalar el esqueleto de la aplicación CakePHP en el directorio **bookmarker**::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 Si descargaste y ejecutaste el `Instalador Windows de Composer <https://getcomposer.org/Composer-Setup.exe>`_, entonces escribe la siguiente línea en tu terminal desde tu directorio de instalación (ie. C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* bookmarker
 
 La ventaja de utilizar Composer es que automáticamente realizará algunas tareas importantes como configurar correctamente el archivo de permisos y crear tu archivo **config/app.php**.
 

--- a/es/tutorials-and-examples/cms/installation.rst
+++ b/es/tutorials-and-examples/cms/installation.rst
@@ -45,14 +45,14 @@ directorio "cms" del directorio de trabajo actual:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 cms
+    php composer.phar create-project --prefer-dist cakephp/app:4.* cms
 
 Si descargaste y ejecutaste el instalador de Windows de "Composer", escribí la
 siguiente linea en tu terminal desde el directorio de instalación.
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* cms
 
 La ventaja de usar "Composer" es que completará automáticamente algunas tareas
 de configuración importantes, como configurar los permisos de archivo correctos

--- a/fr/installation.rst
+++ b/fr/installation.rst
@@ -91,13 +91,13 @@ Pour ceci vous pouvez lancer la commande suivante:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    php composer.phar create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Ou si Composer est installé globalement:
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Une fois que Composer finit le téléchargement du squelette de l'application et
 du cœur de la librairie de CakePHP, vous devriez avoir une application CakePHP

--- a/fr/tutorials-and-examples/blog/blog.rst
+++ b/fr/tutorials-and-examples/blog/blog.rst
@@ -42,12 +42,12 @@ répertoire d'installation pour installer le squelette d'application de CakePHP
 dans le répertoire que vous souhaitez utiliser. Pour l'exemple nous utiliserons
 "blog", mais vous pouvez utiliser le nom que vous souhaitez::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 blog
+    php composer.phar create-project --prefer-dist cakephp/app:4.* blog
 
 Dans le cas où vous avez déjà composer installé globalement, vous devrez plutôt
 taper::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 blog
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* blog
 
 L'avantage d'utiliser Composer est qu'il va automatiquement réaliser certaines
 tâches de configurations importantes, comme configurer les bonnes permissions

--- a/fr/tutorials-and-examples/bookmarks/intro.rst
+++ b/fr/tutorials-and-examples/bookmarks/intro.rst
@@ -46,14 +46,14 @@ Ensuite tapez simplement la ligne suivante dans votre terminal à partir
 du répertoire d'installation pour installer le squelette d'application
 CakePHP dans le répertoire **bookmarker**::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 Si vous avez téléchargé et exécuté l'`installeur Windows de Composer
 <https://getcomposer.org/Composer-Setup.exe>`_, tapez la ligne suivante dans
 votre terminal à partir de votre répertoire d'installation. (par exemple
 C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* bookmarker
 
 L'avantage d'utiliser Composer est qu'il va automatiquement faire des tâches
 de configuration importantes, comme de définir les bonnes permissions de

--- a/fr/tutorials-and-examples/cms/installation.rst
+++ b/fr/tutorials-and-examples/cms/installation.rst
@@ -45,7 +45,7 @@ d'application CakePHP dans le dossier **cms** du dossier courant:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 cms
+    php composer.phar create-project --prefer-dist cakephp/app:4.* cms
 
 Si vous avez téléchargé et utilisé `l'Installer de Composer pour Windows
 <https://getcomposer.org/Composer-Setup.exe>`_, tapez la commande suivante dans
@@ -53,7 +53,7 @@ votre terminal depuis le dossier d'installation (par exemple C:\\wamp\\www\\dev\
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* cms
 
 Utiliser Composer a l'avantage d'exécuter automatiquement certaines tâches
 importantes d'installation, comme définir les bonnes permissions sur les dossiers

--- a/ja/installation.rst
+++ b/ja/installation.rst
@@ -85,13 +85,13 @@ CakePHP の新しいアプリケーションを作成してください。下記
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    php composer.phar create-project --prefer-dist cakephp/app:4.* my_app_name
 
 または Composer にパスが通っているのであれば下記のコマンドも使えます。
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* my_app_name
 
 一度 Composer がアプリケーションの雛形とコアライブラリーをダウンロードしたら、
 インストールした CakePHP アプリケーションを Composer から操作できるように

--- a/ja/tutorials-and-examples/blog/blog.rst
+++ b/ja/tutorials-and-examples/blog/blog.rst
@@ -37,11 +37,11 @@ cURL がインストールされていたら、以下のように実行するの
 インストールディレクトリーからターミナルに以下の行をシンプルにタイプしてください。
 この例では、"blog" を使用しますが、他のものに自由に変更できます。 ::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 blog
+    php composer.phar create-project --prefer-dist cakephp/app:4.* blog
 
 Composer をグローバルにすでに設定している場合は、以下のようにタイプすることもできます。 ::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 blog
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* blog
 
 Composer を使うメリットは、 正しいファイルパーミッションの設定や、 **config/app.php**
 ファイルの作成などのような、重要なセットアップを自動的に完全にしてくれることです。

--- a/ja/tutorials-and-examples/bookmarks/intro.rst
+++ b/ja/tutorials-and-examples/bookmarks/intro.rst
@@ -41,13 +41,13 @@ cURL がインストールされていたら、以下のように実行するの
 そして、CakePHP アプリケーションのスケルトンを **bookmarker** ディレクトリーにインストールするために、
 インストールディレクトリーからターミナルに以下の行をシンプルにタイプしてください。 ::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 `Composer Windows Installer <https://getcomposer.org/Composer-Setup.exe>`_
 をダウンロードして実行した場合、インストールディレクトリー (例えば、 C:\\wamp\\www\\dev\\cakephp3)
 からターミナルに以下の行をタイプしてください。 ::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* bookmarker
 
 Composer を使うメリットは、 正しいファイルパーミッションの設定や、 **config/app.php**
 ファイルの作成などのように、自動的に完全なセットアップをしてくれることです。

--- a/ja/tutorials-and-examples/cms/installation.rst
+++ b/ja/tutorials-and-examples/cms/installation.rst
@@ -42,7 +42,7 @@ cURL がインストールされていたら、次のように実行するのが
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 cms
+    php composer.phar create-project --prefer-dist cakephp/app:4.* cms
 
 `Composer Windows Installer <https://getcomposer.org/Composer-Setup.exe>`_
 をダウンロードして実行した場合、インストールディレクトリー (例えば、 C:\\wamp\\www\\dev\\cakephp3)
@@ -50,7 +50,7 @@ cURL がインストールされていたら、次のように実行するのが
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* cms
 
 Composer を使うメリットは、 正しいファイルパーミッションの設定や、 **config/app.php**
 ファイルの作成などのように、自動的に完全なセットアップをしてくれることです。

--- a/pt/installation.rst
+++ b/pt/installation.rst
@@ -71,11 +71,11 @@ do LEIA-ME `aqui <https://github.com/composer/windows-setup>`_.
 Agora que você baixou e instalou o Composer, você pode receber uma nova
 aplicação CakePHP executando::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 [app_name]
+    php composer.phar create-project --prefer-dist cakephp/app:4.* [app_name]
 
 Ou se o Composer estiver instalado globalmente::
 
-    composer create-project --prefer-dist cakephp/app:^4.0 [app_name]
+    composer create-project --prefer-dist cakephp/app:4.* [app_name]
 
 Uma vez que o Composer terminar de baixar o esqueleto da aplicação e o núcleo
 da biblioteca CakePHP, você deve ter uma aplicação funcional

--- a/pt/tutorials-and-examples/blog/blog.rst
+++ b/pt/tutorials-and-examples/blog/blog.rst
@@ -44,7 +44,7 @@ Em seguida, basta digitar a seguinte linha de comando no seu terminal a partir
 do diretório onde se localiza o arquivo ``composer.phar`` para instalar o
 esqueleto da aplicação do CakePHP no diretório [nome_do_app]. ::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 [nome_do_app]
+    php composer.phar create-project --prefer-dist cakephp/app:4.* [nome_do_app]
 
 A vantagem de usar o Composer é que ele irá completar automaticamente um conjunto
 importante de tarefas, como configurar corretamente as permissões de pastas

--- a/pt/tutorials-and-examples/bookmarks/intro.rst
+++ b/pt/tutorials-and-examples/bookmarks/intro.rst
@@ -36,7 +36,7 @@ Em seguida, basta digitar a seguinte linha no seu terminal a partir do diretóri
 onde se localiza o arquivo ``composer.phar`` para instalar o esqueleto de
 aplicações do CakePHP no diretório ``bookmarker``. ::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 A vantagem de usar Composer é que ele irá completar automaticamente um conjunto
 importante de tarefas, como configurar as permissões de arquivo e criar a sua

--- a/ru/installation.rst
+++ b/ru/installation.rst
@@ -87,13 +87,13 @@ CakePHP использует мендежер зависимостей PHP `Comp
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    php composer.phar create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Или если Composer установлен глобально:
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Как только Composer закончит скачивание каркаса приложения и библиотеки ядра
 CakePHP, у вас должно появиться полностью работоспособное приложение CakePHP.

--- a/ru/tutorials-and-examples/blog/blog.rst
+++ b/ru/tutorials-and-examples/blog/blog.rst
@@ -41,11 +41,11 @@ Composer Вы с легкостью установите фреймворк че
 примера мы будем использовать папку "blog", но Вы можете назвать ее так,
 как Вам будет удобно.::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 blog
+    php composer.phar create-project --prefer-dist cakephp/app:4.* blog
 
 В том случае, если Composer установлен глобально, можно ввести следующее::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 blog
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* blog
 
 Преимущество при использовании Composer заключается в том, что он
 автоматически произведет все необходимые настройки по правам доступа и создаст

--- a/ru/tutorials-and-examples/bookmarks/intro.rst
+++ b/ru/tutorials-and-examples/bookmarks/intro.rst
@@ -44,7 +44,7 @@ Composer Вы с легкостью установите фреймворк че
 установочной папки, чтобы развернуть базовую структуру приложения CakePHP
 в папку **bookmarker**::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 Преимущество при использовании Composer заключается в том, что он
 автоматически произведет все необходимые настройки по правам доступа и создаст

--- a/tl/installation.rst
+++ b/tl/installation.rst
@@ -89,13 +89,13 @@ following composer command:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    php composer.phar create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Or if Composer is installed globally:
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 my_app_name
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* my_app_name
 
 Once Composer finishes downloading the application skeleton and the core CakePHP
 library, you should have a functioning CakePHP application installed via

--- a/tl/tutorials-and-examples/blog/blog.rst
+++ b/tl/tutorials-and-examples/blog/blog.rst
@@ -39,11 +39,11 @@ installation directory to install the CakePHP application skeleton
 in the directory that you wish to use it with. For this example we will be using
 "blog" but feel free to change it to something else.::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 blog
+    php composer.phar create-project --prefer-dist cakephp/app:4.* blog
 
 In case you've already got composer installed globally, you may instead type::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 blog
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* blog
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/tl/tutorials-and-examples/bookmarks/intro.rst
+++ b/tl/tutorials-and-examples/bookmarks/intro.rst
@@ -44,14 +44,14 @@ Then simply type the following line in your terminal from your
 installation directory to install the CakePHP application skeleton
 in the **bookmarker** directory::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
 your terminal from your installation directory (ie.
 C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* bookmarker
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/tl/tutorials-and-examples/cms/installation.rst
+++ b/tl/tutorials-and-examples/cms/installation.rst
@@ -46,7 +46,7 @@ in the **cms** directory of the current working directory:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 cms
+    php composer.phar create-project --prefer-dist cakephp/app:4.* cms
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
@@ -55,7 +55,7 @@ C:\\wamp\\www\\dev\\cakephp3):
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* cms
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/tr/installation.rst
+++ b/tr/installation.rst
@@ -53,11 +53,11 @@ talimatlerı bulabilirsiniz.
 Şimdi Composer'i indirip kurduğunuza göre, taze bir CakePHP uygulamasını şu
 komutları çalıştırarak elde edebilirsiniz::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 [app_name]
+    php composer.phar create-project --prefer-dist cakephp/app:4.* [app_name]
 
 Eğer composer tüm sistemde yüklü ise::
 
-    composer create-project --prefer-dist cakephp/app:^4.0 [app_name]
+    composer create-project --prefer-dist cakephp/app:4.* [app_name]
 
 Composer uygulama iskeletini ve çekirdek CakePHP kütüphanesini indirdiğinde,
 elinizde Composer ile yüklenmiş çalışan bir CakePHP uygulaması olacaktır.

--- a/tr/tutorials-and-examples/bookmarks/intro.rst
+++ b/tr/tutorials-and-examples/bookmarks/intro.rst
@@ -42,13 +42,13 @@ indirebilirsiniz.
 CakePHP iskeleti basitçe oluşturup kurmak için terminalizine **bookmarker**
 komut satırını çalıştırınız::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app:4.* bookmarker
 
 Eğer `Composer Windows Installer <https://getcomposer.org/Composer-Setup.exe>`_
 'i indirip kurduysanız, o zaman kurulum klasöründe belirtilen komudu yazarak
 devam edebilirsiniz. (Örnek kurulum klasörü C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* bookmarker
 
 Composer'i kullanmanın avantajı bir takım işlemleri sizin için otomatik yapıyor
 olmasıdır. Mesela dosya yetki izinleri ve **config/app.php** dosyasını sizin

--- a/zh/tutorials-and-examples/cms/installation.rst
+++ b/zh/tutorials-and-examples/cms/installation.rst
@@ -36,7 +36,7 @@
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^4.0 cms
+    php composer.phar create-project --prefer-dist cakephp/app:4.* cms
 
 
 如果你是下载使用的 `Composer Windows Installer
@@ -44,7 +44,7 @@
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^4.0 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app:4.* cms
 
 使用 Composer 的优势是它会自动完成一些重要的设置任务，比如建立合适的文件权限以及建立配置文件
  **config/app.php**。


### PR DESCRIPTION
On the Windows command line the caret is an escape character, thus
composer would not receive the literal character and always install
version 4.0.0