### PR TITLE
Remove note about RequestHandlerComponent triggering deprecation warning

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -112,8 +112,7 @@ Component
   request attribute instead of request param. Hence you should now use
   ``$request->getAttribute('isAjax')`` instead of ``$request->getParam('isAjax')``.
 * The request body parsing features of ``RequestHandlerComponent`` have been
-  removed and now emit a deprecation warning. You should use the
-  :ref:`body-parser-middleware` instead.
+  removed. You should use the :ref:`body-parser-middleware` instead.
 * ``Cake\Controller\Component\PaginatorComponent`` now sets paging params info as
   request attribute instead of request param. Hence you should now use
   ``$request->getAttribute('paging')`` instead of ``$request->getParam('paging')``.

--- a/ja/appendices/4-0-migration-guide.rst
+++ b/ja/appendices/4-0-migration-guide.rst
@@ -103,7 +103,7 @@ Component
 * ``Cake\Controller\Component\RequestHandlerComponent`` は、リクエストパラメーターではなくリクエスト属性として、
   ``isAjax`` を設定するようになりました。したがって、 ``$request->getParam('isAjax')`` の代わりに
   ``$request->getAttribute('isAjax')`` を使用する必要があります。
-* ``RequestHandlerComponent`` の入力データ解析機能は削除され、非推奨の警告を発します。
+* ``RequestHandlerComponent`` の入力データ解析機能は削除され。
   代わりに、 :ref:`body-parser-middleware` を使用する必要があります。
 * ``Cake\Controller\Component\PaginatorComponent`` は、リクエストパラメーターではなくリクエスト属性として、
   ページングパラメーター情報を設定するようになりました。したがって、 ``$request->getParam('paging')`` の代わりに、


### PR DESCRIPTION
The deprecation warning is not being triggered anymore.

refs cakephp/cakephp#14093