### PR TITLE
Cmposer dump autoload warning.

### DIFF
--- a/en/deployment.rst
+++ b/en/deployment.rst
@@ -96,7 +96,12 @@ Class loading can take a big share of your application's processing time.
 In order to avoid this problem, it is recommended that you run this command in
 your production server once the application is deployed::
 
-    php composer.phar dumpautoload -o
+    php composer.phar dump-autoload -o
+
+.. warning::
+
+    Do not combine this with ``-a``/``--classmap-authoritative``, as this breaks class aliases. Instead, you can use the `mentioned
+option 2b <https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-b-apcu-cache>`_. instead using ``--apcu`` as additional optimization if APCu is installed.
 
 Since handling static assets, such as images, JavaScript and CSS files of
 plugins, through the ``Dispatcher`` is incredibly inefficient, it is strongly

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -83,7 +83,7 @@ will be used if no environment variable exists for the given key.
 
 .. versionchanged:: 3.5.0
     dotenv library support was added to the application skeleton.
-    
+
 .. versionchanged:: 3.5.1
     dotenv library support is now opt in. You must uncomment the appropriate block of code in ``config/bootstrap.php``
 
@@ -104,7 +104,7 @@ App.namespace
         When changing the namespace in your configuration, you will also
         need to update your **composer.json** file to use this namespace
         as well. Additionally, create a new autoloader by running
-        ``php composer.phar dumpautoload``.
+        ``php composer.phar dump-autoload``.
 
 .. _core-configuration-baseurl:
 
@@ -182,7 +182,7 @@ there is a specific use case when using plugin based assets: plugins will not
 use the plugin's prefix when absolute ``...BaseUrl`` URI is used, for example By
 default:
 
-* ``$this->Helper->assetUrl('TestPlugin.logo.png')`` resolves to ``test_plugin/logo.png`` 
+* ``$this->Helper->assetUrl('TestPlugin.logo.png')`` resolves to ``test_plugin/logo.png``
 
 If you set ``App.imageBaseUrl`` to ``https://mycdn.example.com/``:
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -678,12 +678,12 @@ you define the ``$fixtures`` property in your model::
 .. note::
     You can also override ``TestCase::getFixtures()`` instead of defining
     the ``$fixtures`` property::
-    
-        public function getFixtures() 
-        { 
+
+        public function getFixtures()
+        {
             return ['app.Articles', 'app.Comments'];
         }
-        
+
 The above will load the Article and Comment fixtures from the application's
 Fixture directory. You can also load fixtures from CakePHP core, or plugins::
 
@@ -1776,7 +1776,7 @@ following is present in your **composer.json** file::
 
 .. note::
 
-    Remember to run ``composer.phar dumpautoload`` when adding new autoload
+    Remember to run ``composer.phar dump-autoload`` when adding new autoload
     mappings.
 
 Generating Tests with Bake


### PR DESCRIPTION
Without this the whole Network >  Http class aliasing breaks.

Also unified the command to the one used predominantly already (dashed version).