### PR TITLE
Update 4-0-upgrade-guide.rst

### DIFF
--- a/en/appendices/4-0-upgrade-guide.rst
+++ b/en/appendices/4-0-upgrade-guide.rst
@@ -6,7 +6,7 @@ enable deprecation warnings::
 
     // in config/app.php
     'Error' => [
-        'errorLevel' => E_ALL ^ E_USER_DEPRECATED,
+        'errorLevel' => E_ALL,
     ]
 
 Then, incrementally fix the deprecation warnings your application and its


### PR DESCRIPTION
The example provided actually disables deprecation errors. 

`^` is bitwise xor, per https://book.cakephp.org/3/en/development/errors.html we want `E_ALL` which includes `E_USER_DEPRECATED`.  `E_ALL ^ E_USER_DEPRECATED` will exclude `E_USER_DEPRECATED` errors.