### PR TITLE
Add info about loading the plugin

### DIFF
--- a/en/tutorials-and-examples/cms/authorization.rst
+++ b/en/tutorials-and-examples/cms/authorization.rst
@@ -78,7 +78,15 @@ The Authorization plugin models authorization and permissions as Policy classes.
 These classes implement the logic to check whether or not a **identity** is
 allowed to **perform an action** on a given **resource**. Our **identity** is
 going to be our logged in user, and our **resources** are our ORM entities and
-queries. Lets use bake to generate a basic policy:
+queries. Lets use bake to generate a basic policy. In **src/Application.php** 
+add the following in the ``bootstrap()`` method::
+
+.. code-block:: bash
+
+    // Add this after you load the **Authentication** plugin
+    $this->addPlugin('Authorization');
+
+Now we can run this shell command::
 
 .. code-block:: bash
 

--- a/en/tutorials-and-examples/cms/authorization.rst
+++ b/en/tutorials-and-examples/cms/authorization.rst
@@ -14,6 +14,10 @@ Use composer to install the Auhorization Plugin:
 
     composer require cakephp/authorization:^2.0
 
+Load the plugin by adding the following statement to the ``bootstrap()`` method in **src/Application.php**::
+
+    $this->addPlugin('Authorization');
+
 Enabling the Authorization Plugin
 =================================
 
@@ -78,15 +82,7 @@ The Authorization plugin models authorization and permissions as Policy classes.
 These classes implement the logic to check whether or not a **identity** is
 allowed to **perform an action** on a given **resource**. Our **identity** is
 going to be our logged in user, and our **resources** are our ORM entities and
-queries. Lets use bake to generate a basic policy. In **src/Application.php** 
-add the following in the ``bootstrap()`` method::
-
-.. code-block:: bash
-
-    // Add this after you load the **Authentication** plugin
-    $this->addPlugin('Authorization');
-
-Now we can run this shell command::
+queries. Lets use bake to generate a basic policy:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The instructions on running the policy shell command will fail if Authorization plugin is not loaded.