### PR TITLE
Cache::read() returning null on non-existing values

### DIFF
--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -251,7 +251,7 @@ no ``$config`` is specified, default will be used. ``Cache::write()``
 can store any type of object and is ideal for storing results of
 model finds::
 
-    if (($posts = Cache::read('posts')) === false) {
+    if (is_null($posts = Cache::read('posts'))) {
         $posts = $someService->getAllPosts();
         Cache::write('posts', $posts);
     }
@@ -313,15 +313,14 @@ Reading From a Cache
 ``Cache::read()`` is used to read the cached value stored under
 ``$key`` from the ``$config``. If ``$config`` is null the default
 config will be used. ``Cache::read()`` will return the cached value
-if it is a valid cache or ``false`` if the cache has expired or
-doesn't exist. The contents of the cache might evaluate false, so
-make sure you use the strict comparison operators: ``===`` or
-``!==``.
+if it is a valid cache or ``null`` if the cache has expired or
+doesn't exist. Use php functions ``is_null()`` or ``isset()``
+to check if ``Cache::read()`` was successful.
 
 For example::
 
     $cloud = Cache::read('cloud');
-    if ($cloud !== false) {
+    if (isset($cloud)) {
         return $cloud;
     }
 
@@ -338,15 +337,13 @@ specify it in ``Cache::read()`` and ``Cache::write()`` calls as below::
 
     // Read key "cloud", but from short configuration instead of default
     $cloud = Cache::read('cloud', 'short');
-    if ($cloud !== false) {
-        return $cloud;
+    if (is_null($cloud)) {
+        // Generate cloud data
+        // Assign data to $cloud variable
+
+        // Store data in cache, using short cache configuration instead of default
+        Cache::write('cloud', $cloud, 'short');
     }
-
-    // Generate cloud data
-    // ...
-
-    // Store data in cache, using short cache configuration instead of default
-    Cache::write('cloud', $cloud, 'short');
 
     return $cloud;
 
@@ -571,9 +568,9 @@ The required API for a CacheEngine is
 
 .. php:method:: read($key)
 
-    :return: The cached value or ``false`` for failure.
+    :return: The cached value or ``null`` for failure.
 
-    Read a key from the cache. Return ``false`` to indicate
+    Read a key from the cache. Return ``null`` to indicate
     the entry has expired or does not exist.
 
 .. php:method:: delete($key)

--- a/en/core-libraries/caching.rst
+++ b/en/core-libraries/caching.rst
@@ -251,7 +251,8 @@ no ``$config`` is specified, default will be used. ``Cache::write()``
 can store any type of object and is ideal for storing results of
 model finds::
 
-    if (is_null($posts = Cache::read('posts'))) {
+    $posts = Cache::read('posts');
+    if ($posts === null) {
         $posts = $someService->getAllPosts();
         Cache::write('posts', $posts);
     }
@@ -314,13 +315,13 @@ Reading From a Cache
 ``$key`` from the ``$config``. If ``$config`` is null the default
 config will be used. ``Cache::read()`` will return the cached value
 if it is a valid cache or ``null`` if the cache has expired or
-doesn't exist. Use php functions ``is_null()`` or ``isset()``
-to check if ``Cache::read()`` was successful.
+doesn't exist. Use strict comparison operators ``===`` or ``!==``
+to check the success of the ``Cache::read()`` operation.
 
 For example::
 
     $cloud = Cache::read('cloud');
-    if (isset($cloud)) {
+    if ($cloud !== null) {
         return $cloud;
     }
 
@@ -337,9 +338,9 @@ specify it in ``Cache::read()`` and ``Cache::write()`` calls as below::
 
     // Read key "cloud", but from short configuration instead of default
     $cloud = Cache::read('cloud', 'short');
-    if (is_null($cloud)) {
+    if ($cloud === null) {
         // Generate cloud data
-        // Assign data to $cloud variable
+        // ...
 
         // Store data in cache, using short cache configuration instead of default
         Cache::write('cloud', $cloud, 'short');


### PR DESCRIPTION
Updated sections involving Cache::read to use isset() and is_null() instead of strict boolean comparison, reflecting the change from returning null instead of false when failing to read value.