### PR TITLE
Update 4-0-migration-guide.rst

### DIFF
--- a/en/appendices/4-0-migration-guide.rst
+++ b/en/appendices/4-0-migration-guide.rst
@@ -414,8 +414,8 @@ Database
   the ``cakephp/log`` package for logging.
 * ``Cake\Database\Connection`` now allows using any PSR-16 cacher. As a result
   those using the standalone database package are no longer forced to use
-  the ``cakephp/cache`` package for caching. New methods ``Cake\Database\Connection::setCache()``
-  and ``Cake\Database\Connection::getCache()`` have been added.
+  the ``cakephp/cache`` package for caching. New methods ``Cake\Database\Connection::setCacher()``
+  and ``Cake\Database\Connection::getCacher()`` have been added.
 * ``Cake\Database\ConstraintsInterface`` was extracted from
   ``Cake\Datasource\FixtureInterface``. This interface should be
   implemented by fixture implementations that support constraints, which from


### PR DESCRIPTION
It seems there are minor typos in `New Features`, under `Database` section.

The two new methods: `Cake\Database\Connection::setCache()` and `Cake\Database\Connection::getCache()` do not exist in `Cake\Database\Connection`.

Got to be referring to the `Cake\Database\Connection::setCacher()` and `Cake\Database\Connection::getCacher()` respectively.
* [Cake\Database\Connection::setCacher()](https://github.com/cakephp/cakephp/blob/4.0.0/src/Database/Connection.php#L813-L821)
* [Cake\Database\Connection::getCacher()](https://github.com/cakephp/cakephp/blob/4.0.0/src/Database/Connection.php#L823-L845)

Noticed it when I was doing investigation on CakePHP 4. Thank you.