### PR TITLE
Prepare indexing script for elasticsearch upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ server-%:
 	cd build/html/$* && python3 -m SimpleHTTPServer
 
 populate-index-%:
-	php scripts/populate_search_index.php $* $(ES_HOST)
+	php scripts/populate_search_index.php --compat --lang="$*" --host="$(ES_HOST)"
 
 rebuild-index-%:
 	curl -XDELETE $(ES_HOST)/documentation/4-0-$*

--- a/scripts/populate_search_index.php
+++ b/scripts/populate_search_index.php
@@ -8,7 +8,9 @@
 
 // Elastic search config
 define('ES_DEFAULT_HOST', 'https://ci.cakephp.org:9200');
-define('ES_INDEX', 'documentation');
+define('ES_INDEX', 'cake-docs-40');
+
+// For old index
 define('CAKEPHP_VERSION', '4-0');
 
 // file exclusion patterns
@@ -24,23 +26,31 @@ const FILE_EXCLUSIONS = [
  * @param array $argv The array of CLI arguments, 1: language, 2. Elastic search host.
  * @return void
  */
-function main($argv)
+function main()
 {
-    if (empty($argv[1])) {
+    $options = getopt('', ['host::', 'lang:', 'compat']);
+    if (empty($options['lang'])) {
         echo "A language to scan is required.\n";
         exit(1);
     }
+    $lang = $options['lang'];
 
-    $lang = $argv[1];
-    if (!empty($argv[2])) {
-        define('ES_HOST', $argv[2]);
+    if (!empty($options['host'])) {
+        define('ES_HOST', $options['host']);
     } else {
         define('ES_HOST', ES_DEFAULT_HOST);
+    }
+    if (isset($options['compat'])) {
+        define('OLD_INDEX', true);
     }
 
     $directory = new RecursiveDirectoryIterator($lang);
     $recurser = new RecursiveIteratorIterator($directory);
     $matcher = new RegexIterator($recurser, '/\.rst/');
+
+    if (!defined('OLD_INDEX')) {
+        setMapping($lang);
+    }
 
     foreach ($matcher as $file) {
         $skip = false;
@@ -58,6 +68,28 @@ function main($argv)
     }
 
     echo "\nIndex update complete\n";
+}
+
+function setMapping($lang)
+{
+    echo "Creating index.\n";
+    $url = implode('/', array(ES_HOST, ES_INDEX . '-' . $lang));
+    doRequest($url, CURLOPT_PUT);
+
+    $mapping = [
+      "properties" => [
+        "contents" => ["type" => "text"],
+        "title" => ["type" => "keyword"],
+        "url" => [
+            "type" => "keyword",
+            "index" => false,
+        ],
+      ],
+    ];
+    $data = json_encode(['mappings' => ['_doc' => $mapping]]);
+    echo "Updating mapping.\n";
+    $url = implode('/', array(ES_HOST, ES_INDEX . '-' . $lang, '_mapping', '_doc'));
+    doRequest($url, CURLOPT_PUT, $data);
 }
 
 /**
@@ -78,40 +110,19 @@ function updateIndex($lang, $file)
     $id = str_replace('/', '-', $id);
     $id = trim($id, '-');
 
-    $url = implode('/', array(ES_HOST, ES_INDEX, CAKEPHP_VERSION . '-' . $lang, $id));
+    if (defined('OLD_INDEX')) {
+        $url = implode('/', array(ES_HOST, 'documentation', CAKEPHP_VERSION . '-' . $lang, $id));
+    } else {
+        $url = implode('/', array(ES_HOST, ES_INDEX . '-' . $lang, '_doc', $id));
+    }
 
-    $data = array(
+    $data = json_encode([
         'contents' => $fileData['contents'],
         'title' => $fileData['title'],
         'url' => $path,
-    );
-
-    $data = json_encode($data);
-    $size = strlen($data);
-
-    $fh = fopen('php://memory', 'rw');
-    fwrite($fh, $data);
-    rewind($fh);
-
+    ]);
     echo "Sending request:\n\tfile: $file\n\turl: $url\n";
-
-    $ch = curl_init($url);
-    curl_setopt($ch, CURLOPT_PUT, true);
-    curl_setopt($ch, CURLOPT_INFILE, $fh);
-    curl_setopt($ch, CURLOPT_INFILESIZE, $size);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-    $response = curl_exec($ch);
-    $metadata = curl_getinfo($ch);
-
-    if ($metadata['http_code'] > 400 || !$metadata['http_code']) {
-        echo "[ERROR] Failed to complete request.\n";
-        var_dump($response);
-        exit(2);
-    }
-
-    curl_close($ch);
-    fclose($fh);
+    doRequest($url, CURLOPT_PUT, $data);
 
     echo "Sent $file\n";
 }
@@ -140,4 +151,46 @@ function readFileData($file)
     return compact('contents', 'title');
 }
 
-main($argv);
+/**
+ * Send a request with curl. If the request fails the process will die.
+ *
+ * @param string $url
+ * @param int $method curl opt value for the method.
+ * @param string | null $body The body to send if necessary.
+ */
+function doRequest($url, $method, $body = null)
+{
+    $ch = curl_init($url);
+    curl_setopt($ch, $method, true);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+    ]);
+
+    $fh = null;
+    if ($body) {
+        $size = strlen($body);
+
+        $fh = fopen('php://memory', 'rw');
+        fwrite($fh, $body);
+        rewind($fh);
+
+        curl_setopt($ch, CURLOPT_INFILE, $fh);
+        curl_setopt($ch, CURLOPT_INFILESIZE, $size);
+    }
+
+    $response = curl_exec($ch);
+    $metadata = curl_getinfo($ch);
+
+    if ($metadata['http_code'] > 400 || !$metadata['http_code']) {
+        echo "[ERROR] Failed to complete request.\n";
+        var_dump($response);
+        exit(2);
+    }
+    curl_close($ch);
+    if ($fh !== null) {
+        fclose($fh);
+    }
+}
+
+main();


### PR DESCRIPTION
I'm planning on upgrading elasticsearch for the book and plugin sites. That will require a different index structure as es6 only allows one type per index and recommends that the mapping be called _doc. This updates the indexing script to allow both an es6 mode and the `--compat` mode will work with our current elasticsearch version.

Once I have he new elasticsearch instance working the index script will run twice.