### PR TITLE
Move Chronos to Standalone Packages

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -85,7 +85,6 @@ Contents
     Authorization <https://book.cakephp.org/authorization/2/>
     Authentication <https://book.cakephp.org/authentication/2/>
     Bake <https://book.cakephp.org/bake/2/>
-    Chronos <https://book.cakephp.org/chronos/2/>
     Debug Kit <https://book.cakephp.org/debugkit/4/>
     Migrations <https://book.cakephp.org/migrations/3/>
     Elasticsearch <https://book.cakephp.org/elasticsearch/2/en/>
@@ -103,6 +102,7 @@ Contents
 
     standalone-packages
     Phinx <https://book.cakephp.org/phinx/0/en/>
+    Chronos <https://book.cakephp.org/chronos/2/>
 
 .. todolist::
 


### PR DESCRIPTION
Chronos isn't a CakePHP plugin but a standalone library.
See
https://github.com/cakephp/chronos/blob/aca7c4fdcdbbf40513c2fdc0c2b33040721cdd21/composer.json#L3