### PR TITLE
Add example for loading another plugin

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -410,6 +410,8 @@ like::
             // Add constants, load configuration defaults.
             // By default will load `config/bootstrap.php` in the plugin.
             parent::bootstrap($app);
+            // Load another plugin through this plugin
+            $app->addPlugin(\My\Plugin::class);
         }
 
         public function routes($routes)


### PR DESCRIPTION
I just stumbled about this problem while developing a plugin. 
I couldn't find any solutions to load another CakePHP from your plugin, but it was that simple.
Note for others that might have this issue:
```php
// in src/Plugin.php
class Plugin extends BasePlugin
{
    public function bootstrap(PluginApplicationInterface $app)
    {
        parent::bootstrap($app);
        $app->addPlugin(\BootstrapUI\Plugin::class);
    }
}
```