### PR TITLE
[4.x] Use spelled out variable names in DB basics

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -291,7 +291,7 @@ existing known connection::
 
     use Cake\Datasource\ConnectionManager;
 
-    $conn = ConnectionManager::get('default');
+    $connection = ConnectionManager::get('default');
 
 Attempting to load connections that do not exist will throw an exception.
 
@@ -302,7 +302,7 @@ Using ``setConfig()`` and ``get()`` you can create new connections that are not
 defined in your configuration files at runtime::
 
     ConnectionManager::setConfig('my_connection', $config);
-    $conn = ConnectionManager::get('my_connection');
+    $connection = ConnectionManager::get('my_connection');
 
 See the :ref:`database-configuration` for more information on the configuration
 data used when creating connections.
@@ -655,7 +655,7 @@ PDO. There are a few different ways you can run queries depending on the type of
 query you need to run and what kind of results you need back. The most basic
 method is ``query()`` which allows you to run already completed SQL queries::
 
-    $stmt = $conn->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -663,7 +663,7 @@ The ``query()`` method does not allow for additional parameters. If you need
 additional parameters you should use the ``execute()`` method, which allows for
 placeholders to be used::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -672,7 +672,7 @@ Without any type hinting information, ``execute`` will assume all placeholders
 are string values. If you need to bind specific types of data, you can use their
 abstract type names when creating a query::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -685,7 +685,7 @@ them into SQL statements. The last and most flexible way of creating queries is
 to use the :doc:`/orm/query-builder`. This approach allows you to build complex and
 expressive queries without having to use platform specific SQL::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
@@ -695,7 +695,7 @@ When using the query builder, no SQL will be sent to the database server until
 the ``execute()`` method is called, or the query is iterated. Iterating a query
 will first execute it and then start iterating over the result set::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->select('*')
         ->from('articles')
         ->where(['published' => true]);
@@ -716,10 +716,10 @@ The connection objects provide you a few simple ways you do database
 transactions. The most basic way of doing transactions is through the ``begin()``,
 ``commit()`` and ``rollback()`` methods, which map to their SQL equivalents::
 
-    $conn->begin();
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
-    $conn->commit();
+    $connection->begin();
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->commit();
 
 .. php:method:: transactional(callable $callback)
 
@@ -727,9 +727,9 @@ In addition to this interface connection instances also provide the
 ``transactional()`` method which makes handling the begin/commit/rollback calls
 much simpler::
 
-    $conn->transactional(function ($conn) {
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->transactional(function ($connection) {
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
     });
 
 In addition to basic queries, you can execute more complex queries using either
@@ -760,14 +760,14 @@ You can create a statement object using ``execute()``, or ``prepare()``. The
 While ``prepare()`` returns an incomplete statement::
 
     // Statements from execute will have values bound to them already.
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Statements from prepare will be parameters for placeholders.
     // You need to bind parameters before attempting to execute it.
-    $stmt = $conn->prepare('SELECT * FROM articles WHERE published = ?');
+    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Once you've prepared a statement you can bind additional data and execute it.
 
@@ -780,7 +780,7 @@ Once you've created a prepared statement, you may need to bind additional data.
 You can bind multiple values at once using the ``bind()`` method, or bind
 individual elements using ``bindValue``::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
@@ -797,7 +797,7 @@ individual elements using ``bindValue``::
 When creating statements you can also use named array keys instead of
 positional ones::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
@@ -872,10 +872,10 @@ Query logging can be enabled when configuring your connection by setting the
 ``enableQueryLogging``::
 
     // Turn query logging on.
-    $conn->enableQueryLogging(true);
+    $connection->enableQueryLogging(true);
 
     // Turn query logging off
-    $conn->enableQueryLogging(false);
+    $connection->enableQueryLogging(false);
 
 When query logging is enabled, queries will be logged to
 :php:class:`Cake\\Log\\Log` using the 'debug' level, and the 'queriesLog' scope.
@@ -922,7 +922,7 @@ If you are using a legacy schema that requires identifier quoting you can enable
 it using the ``quoteIdentifiers`` setting in your
 :ref:`database-configuration`. You can also enable this feature at runtime::
 
-    $conn->getDriver()->enableAutoQuoting();
+    $connection->getDriver()->enableAutoQuoting();
 
 When enabled, identifier quoting will cause additional query traversal that
 converts all identifiers into ``IdentifierExpression`` objects.

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -655,7 +655,7 @@ PDO. There are a few different ways you can run queries depending on the type of
 query you need to run and what kind of results you need back. The most basic
 method is ``query()`` which allows you to run already completed SQL queries::
 
-    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $statement = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -663,7 +663,7 @@ The ``query()`` method does not allow for additional parameters. If you need
 additional parameters you should use the ``execute()`` method, which allows for
 placeholders to be used::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -672,7 +672,7 @@ Without any type hinting information, ``execute`` will assume all placeholders
 are string values. If you need to bind specific types of data, you can use their
 abstract type names when creating a query::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -689,7 +689,7 @@ expressive queries without having to use platform specific SQL::
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
-    $stmt = $query->execute();
+    $statement = $query->execute();
 
 When using the query builder, no SQL will be sent to the database server until
 the ``execute()`` method is called, or the query is iterated. Iterating a query
@@ -760,14 +760,14 @@ You can create a statement object using ``execute()``, or ``prepare()``. The
 While ``prepare()`` returns an incomplete statement::
 
     // Statements from execute will have values bound to them already.
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Statements from prepare will be parameters for placeholders.
     // You need to bind parameters before attempting to execute it.
-    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
+    $statement = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Once you've prepared a statement you can bind additional data and execute it.
 
@@ -780,36 +780,36 @@ Once you've created a prepared statement, you may need to bind additional data.
 You can bind multiple values at once using the ``bind()`` method, or bind
 individual elements using ``bindValue``::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
     // Bind multiple values
-    $stmt->bind(
+    $statement->bind(
         [true, new DateTime('2013-01-01')],
         ['boolean', 'date']
     );
 
     // Bind a single value
-    $stmt->bindValue(1, true, 'boolean');
-    $stmt->bindValue(2, new DateTime('2013-01-01'), 'date');
+    $statement->bindValue(1, true, 'boolean');
+    $statement->bindValue(2, new DateTime('2013-01-01'), 'date');
 
 When creating statements you can also use named array keys instead of
 positional ones::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
     // Bind multiple values
-    $stmt->bind(
+    $statement->bind(
         ['published' => true, 'created' => new DateTime('2013-01-01')],
         ['published' => 'boolean', 'created' => 'date']
     );
 
     // Bind a single value
-    $stmt->bindValue('published', true, 'boolean');
-    $stmt->bindValue('created', new DateTime('2013-01-01'), 'date');
+    $statement->bindValue('published', true, 'boolean');
+    $statement->bindValue('created', new DateTime('2013-01-01'), 'date');
 
 .. warning::
 
@@ -823,16 +823,16 @@ rows. Statements should be executed using the ``execute()`` method. Once
 executed, results can be fetched using ``fetch()``, ``fetchAll()`` or iterating
 the statement::
 
-    $stmt->execute();
+    $statement->execute();
 
     // Read one row.
-    $row = $stmt->fetch('assoc');
+    $row = $statement->fetch('assoc');
 
     // Read all rows.
-    $rows = $stmt->fetchAll('assoc');
+    $rows = $statement->fetchAll('assoc');
 
     // Read rows through iteration.
-    foreach ($stmt as $row) {
+    foreach ($statement as $row) {
         // Do work
     }
 
@@ -846,8 +846,8 @@ Getting Row Counts
 
 After executing a statement, you can fetch the number of affected rows::
 
-    $rowCount = count($stmt);
-    $rowCount = $stmt->rowCount();
+    $rowCount = count($statement);
+    $rowCount = $statement->rowCount();
 
 Checking Error Codes
 --------------------
@@ -856,8 +856,8 @@ If your query was not successful, you can get related error information
 using the ``errorCode()`` and ``errorInfo()`` methods. These methods work the
 same way as the ones provided by PDO::
 
-    $code = $stmt->errorCode();
-    $info = $stmt->errorInfo();
+    $code = $statement->errorCode();
+    $info = $statement->errorInfo();
 
 .. todo::
     Possibly document CallbackStatement and BufferedStatement

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -658,7 +658,7 @@ selon le type de résultats que vous souhaitez en retour. La méthode la plus
 basique est ``query()`` qui vous permet de lancer des requêtes SQL déjà
 complètes::
 
-    $stmt = $connection->query('UPDATE posts SET published = 1 WHERE id = 2');
+    $statement = $connection->query('UPDATE posts SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -666,7 +666,7 @@ La méthode ``query`` n'accepte pas de paramètres supplémentaires. Si vous
 avez besoin de paramètres supplémentaires, vous devrez utiliser la méthode
 ``execute()``, ce qui permet aux placeholders d'être utilisés::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE posts SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -676,7 +676,7 @@ placeholders sont des chaînes de valeur. Si vous avez besoin de lier des types
 spécifiques de données, vous pouvez utiliser leur nom de type abstrait lors
 de la création d'une requête::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE posts SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -694,7 +694,7 @@ avoir à utiliser une plateforme SQL spécifique::
     $query->update('posts')
         ->set(['published' => true])
         ->where(['id' => 2]);
-    $stmt = $query->execute();
+    $statement = $query->execute();
 
 Quand vous utilisez le query builder, aucun SQL ne sera envoyé au serveur
 de base de données jusqu'à ce que la méthode ``execute()`` soit appelée, ou
@@ -770,14 +770,14 @@ fournies en les liant à lui. Alors que ``prepare()`` retourne une requête
 incomplète::
 
     // Les requêtes à partir de execute auront des valeurs leur étant déjà liées.
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Les Requêtes à partir de prepare seront des paramètres pour les placeholders.
     // Vous avez besoin de lier les paramètres avant d'essayer de l'exécuter.
-    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
+    $statement = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Une fois que vous avez préparé une requête, vous pouvez lier les données
 supplémentaires et l'exécuter.
@@ -792,36 +792,36 @@ lier des données supplémentaires. Vous pouvez lier plusieurs valeurs en une
 fois en utilisant la méthode ``bind``, ou lier les éléments individuels
 en utilisant ``bindValue``::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
     // Lier plusieurs valeurs
-    $stmt->bind(
+    $statement->bind(
         [true, new DateTime('2013-01-01')],
         ['boolean', 'date']
     );
 
     // Lier une valeur unique
-    $stmt->bindValue(1, true, 'boolean');
-    $stmt->bindValue(2, new DateTime('2013-01-01'), 'date');
+    $statement->bindValue(1, true, 'boolean');
+    $statement->bindValue(2, new DateTime('2013-01-01'), 'date');
 
 Lors de la création de requêtes, vous pouvez aussi utiliser les clés nommées
 de tableau plutôt que des clés de position::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
     // Lier plusieurs valeurs
-    $stmt->bind(
+    $statement->bind(
         ['published' => true, 'created' => new DateTime('2013-01-01')],
         ['published' => 'boolean', 'created' => 'date']
     );
 
     // Lier une valeur unique
-    $stmt->bindValue('published', true, 'boolean');
-    $stmt->bindValue('created', new DateTime('2013-01-01'), 'date');
+    $statement->bindValue('published', true, 'boolean');
+    $statement->bindValue('created', new DateTime('2013-01-01'), 'date');
 
 .. warning::
 
@@ -837,16 +837,16 @@ exécutées en utilisant la méthode ``execute()``. Une fois exécutée, les
 résultats peuvent être récupérés en utilisant ``fetch()``, ``fetchAll()`` ou
 en faisant une itération de la requête::
 
-    $stmt->execute();
+    $statement->execute();
 
     // Lire une ligne.
-    $row = $stmt->fetch('assoc');
+    $row = $statement->fetch('assoc');
 
     // Lire toutes les lignes.
-    $rows = $stmt->fetchAll('assoc');
+    $rows = $statement->fetchAll('assoc');
 
     // Lire les lignes en faisant une itération.
-    foreach ($stmt as $row) {
+    foreach ($statement as $row) {
         // Faire quelque chose
     }
 
@@ -862,8 +862,8 @@ Récupérer les Compteurs de Ligne
 Après avoir exécuté une requête, vous pouvez récupérer le nombre de lignes
 affectées::
 
-    $rowCount = count($stmt);
-    $rowCount = $stmt->rowCount();
+    $rowCount = count($statement);
+    $rowCount = $statement->rowCount();
 
 Vérifier les Codes d'Erreur
 ---------------------------
@@ -872,8 +872,8 @@ Si votre requête n'est pas réussie, vous pouvez obtenir des informations liée
 à l'erreur en utilisant les méthodes ``errorCode()`` et ``errorInfo()``. Ces
 méthodes fonctionnent de la même façon que celles fournies par PDO::
 
-    $code = $stmt->errorCode();
-    $info = $stmt->errorInfo();
+    $code = $statement->errorCode();
+    $info = $statement->errorInfo();
 
 .. _database-query-logging:
 

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -308,7 +308,7 @@ avant, ou retourner la connexion connue existante::
 
     use Cake\Datasource\ConnectionManager;
 
-    $conn = ConnectionManager::get('default');
+    $connection = ConnectionManager::get('default');
 
 La tentative de chargement de connexions qui n'existent pas va lancer une
 exception.
@@ -321,7 +321,7 @@ nouvelles connexions qui ne sont pas défines dans votre fichier de
 configuration::
 
     ConnectionManager::config('my_connection', $config);
-    $conn = ConnectionManager::get('my_connection');
+    $connection = ConnectionManager::get('my_connection');
 
 Consultez le chapitre sur la :ref:`configuration <database-configuration>`
 pour plus d'informations sur les données de configuration utilisées lors de
@@ -658,7 +658,7 @@ selon le type de résultats que vous souhaitez en retour. La méthode la plus
 basique est ``query()`` qui vous permet de lancer des requêtes SQL déjà
 complètes::
 
-    $stmt = $conn->query('UPDATE posts SET published = 1 WHERE id = 2');
+    $stmt = $connection->query('UPDATE posts SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -666,7 +666,7 @@ La méthode ``query`` n'accepte pas de paramètres supplémentaires. Si vous
 avez besoin de paramètres supplémentaires, vous devrez utiliser la méthode
 ``execute()``, ce qui permet aux placeholders d'être utilisés::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE posts SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -676,7 +676,7 @@ placeholders sont des chaînes de valeur. Si vous avez besoin de lier des types
 spécifiques de données, vous pouvez utiliser leur nom de type abstrait lors
 de la création d'une requête::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE posts SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -690,7 +690,7 @@ la plus flexible de créer des requêtes est d'utiliser :doc:`/orm/query-builder
 Cette approche vous permet de construire des requêtes expressives complexes sans
 avoir à utiliser une plateforme SQL spécifique::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->update('posts')
         ->set(['published' => true])
         ->where(['id' => 2]);
@@ -701,7 +701,7 @@ de base de données jusqu'à ce que la méthode ``execute()`` soit appelée, ou
 que la requête soit itérée. Itérer une requête va d'abord l'exécuter et ensuite
 démarrer l'itération sur l'ensemble des résultats::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->select('*')
         ->from('posts')
         ->where(['published' => true]);
@@ -724,10 +724,10 @@ vous fassiez des transactions de base de données. La façon la plus basique de
 faire des transactions est avec les méthodes ``begin``, ``commit`` et
 ``rollback``, qui correspondent à leurs équivalents SQL::
 
-    $conn->begin();
-    $conn->execute('UPDATE posts SET published = ? WHERE id = ?', [true, 2]);
-    $conn->execute('UPDATE posts SET published = ? WHERE id = ?', [false, 4]);
-    $conn->commit();
+    $connection->begin();
+    $connection->execute('UPDATE posts SET published = ? WHERE id = ?', [true, 2]);
+    $connection->execute('UPDATE posts SET published = ? WHERE id = ?', [false, 4]);
+    $connection->commit();
 
 .. php:method:: transactional(callable $callback)
 
@@ -735,9 +735,9 @@ En plus de cette interface, les instances de connexion fournissent aussi la
 méthode ``transactional`` ce qui simplifie la gestion des appels
 begin/commit/rollback::
 
-    $conn->transactional(function ($conn) {
-        $conn->execute('UPDATE posts SET published = ? WHERE id = ?', [true, 2]);
-        $conn->execute('UPDATE posts SET published = ? WHERE id = ?', [false, 4]);
+    $connection->transactional(function ($connection) {
+        $connection->execute('UPDATE posts SET published = ? WHERE id = ?', [true, 2]);
+        $connection->execute('UPDATE posts SET published = ? WHERE id = ?', [false, 4]);
     });
 
 En plus des requêtes basiques, vous pouvez exécuter des requêtes plus complexes
@@ -770,14 +770,14 @@ fournies en les liant à lui. Alors que ``prepare()`` retourne une requête
 incomplète::
 
     // Les requêtes à partir de execute auront des valeurs leur étant déjà liées.
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Les Requêtes à partir de prepare seront des paramètres pour les placeholders.
     // Vous avez besoin de lier les paramètres avant d'essayer de l'exécuter.
-    $stmt = $conn->prepare('SELECT * FROM articles WHERE published = ?');
+    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Une fois que vous avez préparé une requête, vous pouvez lier les données
 supplémentaires et l'exécuter.
@@ -792,7 +792,7 @@ lier des données supplémentaires. Vous pouvez lier plusieurs valeurs en une
 fois en utilisant la méthode ``bind``, ou lier les éléments individuels
 en utilisant ``bindValue``::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
@@ -809,7 +809,7 @@ en utilisant ``bindValue``::
 Lors de la création de requêtes, vous pouvez aussi utiliser les clés nommées
 de tableau plutôt que des clés de position::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
@@ -885,10 +885,10 @@ connexion en définissant l'option ``log`` à ``true``. Vous pouvez changer le
 log de requête à la volée, en utilisant ``logQueries``::
 
     // Active les logs des requêtes.
-    $conn->logQueries(true);
+    $connection->logQueries(true);
 
     // Stoppe les logs des requêtes
-    $conn->logQueries(false);
+    $connection->logQueries(false);
 
 Quand les logs des requêtes sont activés, les requêtes sont enregistrées dans
 :php:class:`Cake\\Log\\Log` en utilisant le niveau de 'debug', et le scope
@@ -940,7 +940,7 @@ identifiers, vous pouvez l'activer en utilisant le paramètre
 ``quoteIdentifiers`` dans votre :ref:`database-configuration`. Vous pouvez
 aussi activer cette fonctionnalité à la volée::
 
-    $conn->getDriver()->enableAutoQuoting();
+    $connection->getDriver()->enableAutoQuoting();
 
 Quand elle est activée, l'identifier quoting va entrainer des requêtes
 supplémentaires traversales qui convertissent tous les identifiers en objets

--- a/ja/orm/database-basics.rst
+++ b/ja/orm/database-basics.rst
@@ -280,7 +280,7 @@ BigBoxesTable と、コントローラー BigBoxesController は、全て自動�
 
     use Cake\Datasource\ConnectionManager;
 
-    $conn = ConnectionManager::get('default');
+    $connection = ConnectionManager::get('default');
 
 存在しない接続をロードしようとしたら、例外を throw します。
 
@@ -291,7 +291,7 @@ BigBoxesTable と、コントローラー BigBoxesController は、全て自動�
 コネクションを生成することができます。 ::
 
     ConnectionManager::config('my_connection', $config);
-    $conn = ConnectionManager::get('my_connection');
+    $connection = ConnectionManager::get('my_connection');
 
 コネクション生成時の設定についての詳細は :ref:`database-configuration` を参照してください。
 
@@ -610,14 +610,14 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 いくつかあります。
 もっとも基本的な方法は、完全な SQL クエリーの実行を可能にする ``query()`` です。 ::
 
-    $stmt = $conn->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
 ``query()`` メソッドは追加パラメーターを受け付けません。もし追加パラメーターが必要なら、
 プレースホルダーを使用可能な ``execute()`` メソッドを使用します。 ::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -626,7 +626,7 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 もし特定の型にバインドする必要があるなら、クエリーを生成する時に型名を指定することが
 できます。 ::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -640,7 +640,7 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 この方法では、プラットフォーム固有の SQL を使用することなく、複雑で表現力豊かなクエリーを
 構築することができます。 ::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
@@ -650,7 +650,7 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 送信されず、メソッド呼び出し後に順次処理されます。
 最初に送信してから、順次結果セットを作成します。 ::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->select('*')
         ->from('articles')
         ->where(['published' => true]);
@@ -672,19 +672,19 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 トランザクション操作の最も基本的な方法は、SQL構文と同じような ``begin()`` ,
 ``commit()`` , ``rollback()`` を使用するものです。 ::
 
-    $conn->begin();
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
-    $conn->commit();
+    $connection->begin();
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->commit();
 
 .. php:method:: transactional(callable $callback)
 
 このコネクションインスタンスへのインターフェースに加えて、さらに begin/commit/rollback を
 簡単にハンドリングする ``transactional()`` メソッドが提供されています。 ::
 
-    $conn->transactional(function ($conn) {
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->transactional(function ($connection) {
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
     });
 
 基本的なクエリーに加えて、 :doc:`/orm/query-builder` または :doc:`/orm/table-objects` の
@@ -717,14 +717,14 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 それに対して ``prepare()`` は不完全なステートメントを返します。 ::
 
     // execute は指定された値でバインドして SQL ステートメントを実行します。
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // prepare はプレースホルダーのための準備をします。
     // 実行する前にパラメーターをバインドする必要があります。
-    $stmt = $conn->prepare('SELECT * FROM articles WHERE published = ?');
+    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 SQL 文を準備したら、あなたは追加のデータをバインドし、それを実行することができます。
 
@@ -737,7 +737,7 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 あなたは ``bind()`` メソッドを使って一度に複数の値をバインドする事も、
 ``bindValue`` を使って１項目ずつバインドする事もできます。 ::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
@@ -754,7 +754,7 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 ステートメントを作成する時には、項目の通し番号ではなく、項目名の配列をキーに
 使用することもできます。 ::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
@@ -829,10 +829,10 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 また、 ``logQueries`` を使って実行中にクエリーログを切り替えることができます。 ::
 
     // クエリーログを有効
-    $conn->logQueries(true);
+    $connection->logQueries(true);
 
     // クエリーログを停止
-    $conn->logQueries(false);
+    $connection->logQueries(false);
 
 クエリーログを有効にしていると、 'debug' レベルで 'queriesLog' スコープで
 :php:class:`Cake\\Log\\Log` にクエリーをログ出力します。
@@ -879,7 +879,7 @@ Web リクエストの時に便利です。 ::
 引用符を使うことができます。
 また、実行時にこの機能を有効にすることもできます。 ::
 
-    $conn->getDriver()->enableAutoQuoting();
+    $connection->getDriver()->enableAutoQuoting();
 
 有効にすると、引用識別子は 全ての識別子を ``IdentifierExpression`` オブジェクトに
 変換するトラバーサルが発生する原因になります。

--- a/ja/orm/database-basics.rst
+++ b/ja/orm/database-basics.rst
@@ -610,14 +610,14 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 いくつかあります。
 もっとも基本的な方法は、完全な SQL クエリーの実行を可能にする ``query()`` です。 ::
 
-    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $statement = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
 ``query()`` メソッドは追加パラメーターを受け付けません。もし追加パラメーターが必要なら、
 プレースホルダーを使用可能な ``execute()`` メソッドを使用します。 ::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -626,7 +626,7 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 もし特定の型にバインドする必要があるなら、クエリーを生成する時に型名を指定することが
 できます。 ::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -644,7 +644,7 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
-    $stmt = $query->execute();
+    $statement = $query->execute();
 
 クエリービルダーを使用する場合は、 ``execute()`` メソッドを呼ぶまではサーバーに SQL は
 送信されず、メソッド呼び出し後に順次処理されます。
@@ -717,14 +717,14 @@ CakePHP のデータベース抽象化レイヤは、PDO とネイティブド�
 それに対して ``prepare()`` は不完全なステートメントを返します。 ::
 
     // execute は指定された値でバインドして SQL ステートメントを実行します。
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // prepare はプレースホルダーのための準備をします。
     // 実行する前にパラメーターをバインドする必要があります。
-    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
+    $statement = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 SQL 文を準備したら、あなたは追加のデータをバインドし、それを実行することができます。
 
@@ -737,36 +737,36 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 あなたは ``bind()`` メソッドを使って一度に複数の値をバインドする事も、
 ``bindValue`` を使って１項目ずつバインドする事もできます。 ::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
     // 複数項目のバインド
-    $stmt->bind(
+    $statement->bind(
         [true, new DateTime('2013-01-01')],
         ['boolean', 'date']
     );
 
     // １項目ずつのバインド
-    $stmt->bindValue(1, true, 'boolean');
-    $stmt->bindValue(2, new DateTime('2013-01-01'), 'date');
+    $statement->bindValue(1, true, 'boolean');
+    $statement->bindValue(2, new DateTime('2013-01-01'), 'date');
 
 ステートメントを作成する時には、項目の通し番号ではなく、項目名の配列をキーに
 使用することもできます。 ::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
     // 複数項目のバインド
-    $stmt->bind(
+    $statement->bind(
         ['published' => true, 'created' => new DateTime('2013-01-01')],
         ['published' => 'boolean', 'created' => 'date']
     );
 
     // １項目ずつのバインド
-    $stmt->bindValue('published', true, 'boolean');
-    $stmt->bindValue('created', new DateTime('2013-01-01'), 'date');
+    $statement->bindValue('published', true, 'boolean');
+    $statement->bindValue('created', new DateTime('2013-01-01'), 'date');
 
 .. warning::
 
@@ -780,16 +780,16 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 ステートメントは ``execute()`` メソッドで実行します。
 一度実行したら、結果は ``fetch()`` か ``fetchAll()`` を使ってフェッチします。 ::
 
-    $stmt->execute();
+    $statement->execute();
 
     // １行読み込む
-    $row = $stmt->fetch('assoc');
+    $row = $statement->fetch('assoc');
 
     // 全行を読み込む
-    $rows = $stmt->fetchAll('assoc');
+    $rows = $statement->fetchAll('assoc');
 
     // 全行読み込んだ結果を順次処理する
-    foreach ($stmt as $row) {
+    foreach ($statement as $row) {
         // Do work
     }
 
@@ -803,8 +803,8 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 
 ステートメントを実行したら、下記のように対象行数を取得することができます。 ::
 
-    $rowCount = count($stmt);
-    $rowCount = $stmt->rowCount();
+    $rowCount = count($statement);
+    $rowCount = $statement->rowCount();
 
 エラーコードをチェックする
 ---------------------------
@@ -813,8 +813,8 @@ SQL 文を準備したら、あなたは追加のデータをバインドし、�
 メソッドによって取得することができます。
 このメソッドは PDO で提供されているものと同じように動作します。 ::
 
-    $code = $stmt->errorCode();
-    $info = $stmt->errorInfo();
+    $code = $statement->errorCode();
+    $info = $statement->errorInfo();
 
 .. todo::
     Possibly document CallbackStatement and BufferedStatement

--- a/pt/orm/database-basics.rst
+++ b/pt/orm/database-basics.rst
@@ -612,7 +612,7 @@ diferentes de executar consultas, dependendo do tipo de consulta que você
 precisa executar e do tipo de resultados que você precisa receber. O método
 mais básico é o ``query()`` que lhe permite executar consultas SQL já prontas::
 
-    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $statement = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -620,7 +620,7 @@ O método ``query()`` não aceita parâmetros adicionais. Se você precisa de
 parâmetros adicionais, você deve usar o método ``execute()``, que permite que
 placeholders sejam usados::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -629,7 +629,7 @@ Sem qualquer informação de indução de tipo, ``execute`` assumirá que todos 
 placeholders são valores do tipo string. Se você precisa vincular tipos específicos
 de dados, você pode usar seus nomes de tipos abstratos ao criar uma consulta::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -646,7 +646,7 @@ complexas e expressivas sem ter que usar SQL específico de plataforma::
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
-    $stmt = $query->execute();
+    $statement = $query->execute();
 
 Ao usar o construtor de consulta (*query builder*), nenhum SQL será enviado
 para o servidor do banco de dados até que o método ``execute()`` é chamado ou a
@@ -712,14 +712,14 @@ retorna uma instrução com os valores fornecidos ligados a ela. Enquanto que o 
 uma instrução incompleta::
 
     // Instruções do ``execute`` terão valores já vinculados a eles.
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Instruções do ``prepare``serão parâmetros para placeholders.
     // Você precisa vincular os parâmetros antes de executar.
-    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
+    $statement = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Uma vez que você preparou uma instrução, você pode vincular dados adicionais e executá-lo.
 
@@ -732,34 +732,34 @@ Uma vez que você criou uma instrução preparada, você talvez precise vincular
 Você pode vincular vários valores ao mesmo tempo usando o método ``bind()``, ou vincular elementos
 individuais usando ``bindValue``::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
     // Vincular vários valores
-    $stmt->bind(
+    $statement->bind(
         [true, new DateTime('2013-01-01')],
         ['boolean', 'date']
     );
 
     // Vincular único valor
-    $stmt->bindValue(1, true, 'boolean');
-    $stmt->bindValue(2, new DateTime('2013-01-01'), 'date');
+    $statement->bindValue(1, true, 'boolean');
+    $statement->bindValue(2, new DateTime('2013-01-01'), 'date');
 
 Ao criar instruções, você também pode usar chave de array nomeadas em vez de posicionais::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
     // Vincular vários valores
-    $stmt->bind(
+    $statement->bind(
         ['published' => true, 'created' => new DateTime('2013-01-01')],
         ['published' => 'boolean', 'created' => 'date']
     );
 
     // Vincular um valor único
-    $stmt->bindValue('published', true, 'boolean');
-    $stmt->bindValue('created', new DateTime('2013-01-01'), 'date');
+    $statement->bindValue('published', true, 'boolean');
+    $statement->bindValue('created', new DateTime('2013-01-01'), 'date');
 
 .. warning::
 
@@ -773,16 +773,16 @@ linhas. As instruções devem ser executadas usando o método ``execute()``. Uma
 executado, os resultados podem ser obtidos usando ``fetch()``, ``fetchAll()`` ou iterando
 a instrução::
 
-    $stmt->execute();
+    $statement->execute();
 
     // Lê uma linha.
-    $row = $stmt->fetch('assoc');
+    $row = $statement->fetch('assoc');
 
     // Lê todas as linhas.
-    $rows = $stmt->fetchAll('assoc');
+    $rows = $statement->fetchAll('assoc');
 
     // Lê linhas através de iteração.
-    foreach ($stmt as $row) {
+    foreach ($statement as $row) {
         // Do work
     }
 
@@ -796,8 +796,8 @@ Obtendo Contagens de Linha
 
 Depois de executar uma declaração, você pode buscar o número de linhas afetadas::
 
-    $rowCount = count($stmt);
-    $rowCount = $stmt->rowCount();
+    $rowCount = count($statement);
+    $rowCount = $statement->rowCount();
 
 Verificando Códigos de Erro
 ---------------------------
@@ -806,8 +806,8 @@ Se a sua consulta não foi bem sucedida, você pode obter informações de erro 
 usando os métodos ``errorCode()`` e ``errorInfo()``. Estes métodos funcionam da mesma
 maneira que os fornecidos pelo PDO::
 
-    $code = $stmt->errorCode();
-    $info = $stmt->errorInfo();
+    $code = $statement->errorCode();
+    $info = $statement->errorInfo();
 
 .. todo::
     Possibly document CallbackStatement and BufferedStatement

--- a/pt/orm/database-basics.rst
+++ b/pt/orm/database-basics.rst
@@ -281,7 +281,7 @@ conhecida existente::
 
     use Cake\Datasource\ConnectionManager;
 
-    $conn = ConnectionManager::get('default');
+    $connection = ConnectionManager::get('default');
 
 Ao tentar carregar conexões que não existem será lançado uma exceção.
 
@@ -292,7 +292,7 @@ Usando ``config()`` e ``get()`` você pode criar novas conexões que não estão
 definadas em seus arquivos de configuração em tempo de execução::
 
     ConnectionManager::config('my_connection', $config);
-    $conn = ConnectionManager::get('my_connection');
+    $connection = ConnectionManager::get('my_connection');
 
 Consulte a seção :ref:`database-configuration` para mais informações sobre os
 dados de configuração usados ao criar conexões.
@@ -612,7 +612,7 @@ diferentes de executar consultas, dependendo do tipo de consulta que você
 precisa executar e do tipo de resultados que você precisa receber. O método
 mais básico é o ``query()`` que lhe permite executar consultas SQL já prontas::
 
-    $stmt = $conn->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -620,7 +620,7 @@ O método ``query()`` não aceita parâmetros adicionais. Se você precisa de
 parâmetros adicionais, você deve usar o método ``execute()``, que permite que
 placeholders sejam usados::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -629,7 +629,7 @@ Sem qualquer informação de indução de tipo, ``execute`` assumirá que todos 
 placeholders são valores do tipo string. Se você precisa vincular tipos específicos
 de dados, você pode usar seus nomes de tipos abstratos ao criar uma consulta::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -642,7 +642,7 @@ adequadamente em instruções SQL. A última e mais flexível maneira de criar c
 é usar o :doc:`/orm/query-builder`. Essa abordagem lhe permite criar consultas
 complexas e expressivas sem ter que usar SQL específico de plataforma::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
@@ -653,7 +653,7 @@ para o servidor do banco de dados até que o método ``execute()`` é chamado ou
 consulta seja iterada. Iterar uma consulta irá primeiro executá-la e então começar a
 iterar sobre o conjunto de resultados::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->select('*')
         ->from('articles')
         ->where(['published' => true]);
@@ -672,19 +672,19 @@ Os objetos de conexão lhe fornecem algumas maneiras simples de realizar transa�
 de banco de dados. A maneira mais básica de fazer transações é através dos métodos
 ``begin()``, ``commit()`` e ``rollback()``, que mapeiam para seus equivalentes em SQL::
 
-    $conn->begin();
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
-    $conn->commit();
+    $connection->begin();
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->commit();
 
 .. php:method:: transactional(callable $callback)
 
 Além disso, essas instâncias de interface de conexão também fornecem o método
 ``transactional()`` que torna o tratamento das chamadas begin/commit/rollback muito mais simples::
 
-    $conn->transactional(function ($conn) {
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->transactional(function ($connection) {
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
     });
 
 Além de consultas básicas, você pode executar consultas mais complexas usando
@@ -712,14 +712,14 @@ retorna uma instrução com os valores fornecidos ligados a ela. Enquanto que o 
 uma instrução incompleta::
 
     // Instruções do ``execute`` terão valores já vinculados a eles.
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Instruções do ``prepare``serão parâmetros para placeholders.
     // Você precisa vincular os parâmetros antes de executar.
-    $stmt = $conn->prepare('SELECT * FROM articles WHERE published = ?');
+    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Uma vez que você preparou uma instrução, você pode vincular dados adicionais e executá-lo.
 
@@ -732,7 +732,7 @@ Uma vez que você criou uma instrução preparada, você talvez precise vincular
 Você pode vincular vários valores ao mesmo tempo usando o método ``bind()``, ou vincular elementos
 individuais usando ``bindValue``::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
     // Vincular vários valores
@@ -747,7 +747,7 @@ individuais usando ``bindValue``::
 
 Ao criar instruções, você também pode usar chave de array nomeadas em vez de posicionais::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
@@ -822,10 +822,10 @@ com o valor ``true``. Você também pode alternar o log de consulta em tempo de 
 usando o método ``logQueries``::
 
     // Habilita log de consultas.
-    $conn->logQueries(true);
+    $connection->logQueries(true);
 
     // Desabilita o log de consultas.
-    $conn->logQueries(false);
+    $connection->logQueries(false);
 
 Quando o log de consultas está habilitado, as consultas serão logadas em
 :php:class:`Cake\\Log\\Log` usando o nível 'debug', e o escopo 'queriesLog'.
@@ -874,7 +874,7 @@ Se você estiver usando um schema legado que requer citação de identificador, 
 habilitar isso usando a configuração ``quoteIdentifiers``` em seu
 :ref:`database-configuration`. Você também pode habilitar esse recurso em tempo de execução::
 
-    $conn->getDriver()->enableAutoQuoting();
+    $connection->getDriver()->enableAutoQuoting();
 
 Quando habilitado, a citação de identificador causará uma *traversal query* adicional
 que converte todos os identificadores em objetos ``IdentifierExpression``.

--- a/ru/orm/database-basics.rst
+++ b/ru/orm/database-basics.rst
@@ -611,14 +611,14 @@ json
 который необходимо выполнить и того какие результаты нужны в ответ.
 Наиболее простой метод - ``query()``, который позволяет запускать уже выполненные SQL запросы::
 
-    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $statement = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
 Метод ``query()`` не допускает применение дополнительных параметров. Если нужны дополнительные параметры,
 необходимо использовать метод ``execute()``, который дает возможность использовать шаблон для подстановки::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -627,7 +627,7 @@ json
 Если необходимо привязать определенные типы данных, можно использовать абстрактные имена типов при
 создании запроса::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -644,7 +644,7 @@ json
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
-    $stmt = $query->execute();
+    $statement = $query->execute();
 
 При использовании конструктора запросов, ни один SQL запрос не будет послан на сервер
 базы данных до вызова метода ``execute()`` или пока запрос не будет повторён.
@@ -715,14 +715,14 @@ json
 При использовании ``prepare()`` возвращается неполное выражение::
 
     // Выражения execute уже имеют связанные значения.
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Выражения из метода prepare будут параметрами полей для подстановки.
     // Необходимо привязать параметры до того как их использовать.
-    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
+    $statement = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 После того как выражение подготовлено, вы можете привязать дополнительные данные и выполнить его.
 
@@ -735,36 +735,36 @@ json
 Можно привязать множество значений сразу, используя метод ``bind()`` или привязать
 отдельные элементы, используя ``bindValue``::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
     // Привязка множества значений
-    $stmt->bind(
+    $statement->bind(
         [true, new DateTime('2013-01-01')],
         ['boolean', 'date']
     );
 
     // Привязка одного значения
-    $stmt->bindValue(1, true, 'boolean');
-    $stmt->bindValue(2, new DateTime('2013-01-01'), 'date');
+    $statement->bindValue(1, true, 'boolean');
+    $statement->bindValue(2, new DateTime('2013-01-01'), 'date');
 
 При создании выражений, можно использовать именованные ключи массива вместо
 индексных::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
     // Привязка множества значений
-    $stmt->bind(
+    $statement->bind(
         ['published' => true, 'created' => new DateTime('2013-01-01')],
         ['published' => 'boolean', 'created' => 'date']
     );
 
     // Привязка одного значения
-    $stmt->bindValue('published', true, 'boolean');
-    $stmt->bindValue('created', new DateTime('2013-01-01'), 'date');
+    $statement->bindValue('published', true, 'boolean');
+    $statement->bindValue('created', new DateTime('2013-01-01'), 'date');
 
 .. warning::
 
@@ -777,16 +777,16 @@ json
 Выражения должны быть выполнены с использованием метода ``execute()``. После выполнения, результаты
 можно получить, используя ``fetch()``, ``fetchAll()`` или проитерировать выражение::
 
-    $stmt->execute();
+    $statement->execute();
 
     // Прочитать одну строку.
-    $row = $stmt->fetch('assoc');
+    $row = $statement->fetch('assoc');
 
     // Прочитать все строки.
-    $rows = $stmt->fetchAll('assoc');
+    $rows = $statement->fetchAll('assoc');
 
     // Прочитать строки путем итерации.
-    foreach ($stmt as $row) {
+    foreach ($statement as $row) {
         // Выполнить задачу
     }
 
@@ -800,8 +800,8 @@ json
 
 После выполнения выражения, можно получить количество затронутых строк::
 
-    $rowCount = count($stmt);
-    $rowCount = $stmt->rowCount();
+    $rowCount = count($statement);
+    $rowCount = $statement->rowCount();
 
 Коды ошибок
 -----------
@@ -810,8 +810,8 @@ json
 используя методы ``errorCode()`` и ``errorInfo()``. Эти методы работают также, как те, что
 предоставляются PDO::
 
-    $code = $stmt->errorCode();
-    $info = $stmt->errorInfo();
+    $code = $statement->errorCode();
+    $info = $statement->errorInfo();
 
 .. todo::
     Possibly document CallbackStatement and BufferedStatement

--- a/ru/orm/database-basics.rst
+++ b/ru/orm/database-basics.rst
@@ -277,7 +277,7 @@ BigBoxesController, то все вместе будет работать авт�
 
     use Cake\Datasource\ConnectionManager;
 
-    $conn = ConnectionManager::get('default');
+    $connection = ConnectionManager::get('default');
 
 Попытка загрузить соединения, которые не существуют, приведет к вызову исключения.
 
@@ -288,7 +288,7 @@ BigBoxesController, то все вместе будет работать авт�
 файлах конфигурации, во время выполнения приложения::
 
     ConnectionManager::config('my_connection', $config);
-    $conn = ConnectionManager::get('my_connection');
+    $connection = ConnectionManager::get('my_connection');
 
 Смотрите раздел :ref:`database-configuration` для получения дополительной информации по конфигурационным данным,
 используемым при создании соединений.
@@ -611,14 +611,14 @@ json
 который необходимо выполнить и того какие результаты нужны в ответ.
 Наиболее простой метод - ``query()``, который позволяет запускать уже выполненные SQL запросы::
 
-    $stmt = $conn->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
 Метод ``query()`` не допускает применение дополнительных параметров. Если нужны дополнительные параметры,
 необходимо использовать метод ``execute()``, который дает возможность использовать шаблон для подстановки::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -627,7 +627,7 @@ json
 Если необходимо привязать определенные типы данных, можно использовать абстрактные имена типов при
 создании запроса::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -640,7 +640,7 @@ json
 использование :doc:`/orm/query-builder`. Данный подход позволяет сконструировать сложные
 и выразительные запросы без использования платформенно-ориентированного SQL::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
@@ -650,7 +650,7 @@ json
 базы данных до вызова метода ``execute()`` или пока запрос не будет повторён.
 При итерации запроса, сначала он выполняется, а затем его результатирующий набор данных будет проитерирован::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->select('*')
         ->from('articles')
         ->where(['published' => true]);
@@ -671,10 +671,10 @@ json
 базы данных. Наиболее простой способ выполнения - используя методы ``begin()``,
 ``commit()`` и ``rollback()``, которые преобразуются в их SQL эквиваленты::
 
-    $conn->begin();
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
-    $conn->commit();
+    $connection->begin();
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->commit();
 
 .. php:method:: transactional(callable $callback)
 
@@ -682,9 +682,9 @@ json
 метод ``transactional()``, который делает обработку вызовов begin/commit/rollback
 еще проще::
 
-    $conn->transactional(function ($conn) {
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->transactional(function ($connection) {
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
     });
 
 В дополнение к базовым запросам, вы можете выполнить более сложные запросы, используя
@@ -715,14 +715,14 @@ json
 При использовании ``prepare()`` возвращается неполное выражение::
 
     // Выражения execute уже имеют связанные значения.
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Выражения из метода prepare будут параметрами полей для подстановки.
     // Необходимо привязать параметры до того как их использовать.
-    $stmt = $conn->prepare('SELECT * FROM articles WHERE published = ?');
+    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 После того как выражение подготовлено, вы можете привязать дополнительные данные и выполнить его.
 
@@ -735,7 +735,7 @@ json
 Можно привязать множество значений сразу, используя метод ``bind()`` или привязать
 отдельные элементы, используя ``bindValue``::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
@@ -752,7 +752,7 @@ json
 При создании выражений, можно использовать именованные ключи массива вместо
 индексных::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
@@ -827,10 +827,10 @@ json
 
     // До 3.7.0 используйте logQueries()
     // Включить логирование.
-    $conn->enableQueryLogging(true);
+    $connection->enableQueryLogging(true);
 
     // Отключить логирование
-    $conn->enableQueryLogging(false);
+    $connection->enableQueryLogging(false);
 
 Когда логирование запросов включено, запросы логируются в :php:class:`Cake\\Log\\Log`,
 используя уровень 'debug' и область действия 'queriesLog'.
@@ -876,7 +876,7 @@ files/syslog может быть полезно при работе с веб-з
 Для унаследованной схемы, в которой требуются кавычки в идентификаторах, можно включить настройку ``quoteIdentifiers``
 в :ref:`database-configuration`. Эта функция включается в том числе и при выполении::
 
-    $conn->getDriver()->enableAutoQuoting();
+    $connection->getDriver()->enableAutoQuoting();
 
 При включенном режиме, использование кавычек в идентификаторах
 

--- a/tl/orm/database-basics.rst
+++ b/tl/orm/database-basics.rst
@@ -281,7 +281,7 @@ existing known connection::
 
     use Cake\Datasource\ConnectionManager;
 
-    $conn = ConnectionManager::get('default');
+    $connection = ConnectionManager::get('default');
 
 Attempting to load connections that do not exist will throw an exception.
 
@@ -292,7 +292,7 @@ Using ``config()`` and ``get()`` you can create new connections that are not
 defined in your configuration files at runtime::
 
     ConnectionManager::config('my_connection', $config);
-    $conn = ConnectionManager::get('my_connection');
+    $connection = ConnectionManager::get('my_connection');
 
 See the :ref:`database-configuration` for more information on the configuration
 data used when creating connections.
@@ -617,7 +617,7 @@ PDO. There are a few different ways you can run queries depending on the type of
 query you need to run and what kind of results you need back. The most basic
 method is ``query()`` which allows you to run already completed SQL queries::
 
-    $stmt = $conn->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -625,7 +625,7 @@ The ``query()`` method does not allow for additional parameters. If you need
 additional parameters you should use the ``execute()`` method, which allows for
 placeholders to be used::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -634,7 +634,7 @@ Without any type hinting information, ``execute`` will assume all placeholders
 are string values. If you need to bind specific types of data, you can use their
 abstract type names when creating a query::
 
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -647,7 +647,7 @@ them into SQL statements. The last and most flexible way of creating queries is
 to use the :doc:`/orm/query-builder`. This approach allows you to build complex and
 expressive queries without having to use platform specific SQL::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
@@ -657,7 +657,7 @@ When using the query builder, no SQL will be sent to the database server until
 the ``execute()`` method is called, or the query is iterated. Iterating a query
 will first execute it and then start iterating over the result set::
 
-    $query = $conn->newQuery();
+    $query = $connection->newQuery();
     $query->select('*')
         ->from('articles')
         ->where(['published' => true]);
@@ -678,10 +678,10 @@ The connection objects provide you a few simple ways you do database
 transactions. The most basic way of doing transactions is through the ``begin()``,
 ``commit()`` and ``rollback()`` methods, which map to their SQL equivalents::
 
-    $conn->begin();
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-    $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
-    $conn->commit();
+    $connection->begin();
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+    $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->commit();
 
 .. php:method:: transactional(callable $callback)
 
@@ -689,9 +689,9 @@ In addition to this interface connection instances also provide the
 ``transactional()`` method which makes handling the begin/commit/rollback calls
 much simpler::
 
-    $conn->transactional(function ($conn) {
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
-        $conn->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
+    $connection->transactional(function ($connection) {
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [true, 2]);
+        $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4]);
     });
 
 In addition to basic queries, you can execute more complex queries using either
@@ -722,14 +722,14 @@ You can create a statement object using ``execute()``, or ``prepare()``. The
 While ``prepare()`` returns an incomplete statement::
 
     // Statements from execute will have values bound to them already.
-    $stmt = $conn->execute(
+    $stmt = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Statements from prepare will be parameters for placeholders.
     // You need to bind parameters before attempting to execute it.
-    $stmt = $conn->prepare('SELECT * FROM articles WHERE published = ?');
+    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Once you've prepared a statement you can bind additional data and execute it.
 
@@ -742,7 +742,7 @@ Once you've created a prepared statement, you may need to bind additional data.
 You can bind multiple values at once using the ``bind()`` method, or bind
 individual elements using ``bindValue``::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
@@ -759,7 +759,7 @@ individual elements using ``bindValue``::
 When creating statements you can also use named array keys instead of
 positional ones::
 
-    $stmt = $conn->prepare(
+    $stmt = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
@@ -834,10 +834,10 @@ Query logging can be enabled when configuring your connection by setting the
 ``logQueries``::
 
     // Turn query logging on.
-    $conn->logQueries(true);
+    $connection->logQueries(true);
 
     // Turn query logging off
-    $conn->logQueries(false);
+    $connection->logQueries(false);
 
 When query logging is enabled, queries will be logged to
 :php:class:`Cake\\Log\\Log` using the 'debug' level, and the 'queriesLog' scope.
@@ -884,7 +884,7 @@ If you are using a legacy schema that requires identifier quoting you can enable
 it using the ``quoteIdentifiers`` setting in your
 :ref:`database-configuration`. You can also enable this feature at runtime::
 
-    $conn->getDriver()->enableAutoQuoting();
+    $connection->getDriver()->enableAutoQuoting();
 
 When enabled, identifier quoting will cause additional query traversal that
 converts all identifiers into ``IdentifierExpression`` objects.

--- a/tl/orm/database-basics.rst
+++ b/tl/orm/database-basics.rst
@@ -617,7 +617,7 @@ PDO. There are a few different ways you can run queries depending on the type of
 query you need to run and what kind of results you need back. The most basic
 method is ``query()`` which allows you to run already completed SQL queries::
 
-    $stmt = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
+    $statement = $connection->query('UPDATE articles SET published = 1 WHERE id = 2');
 
 .. php:method:: execute($sql, $params, $types)
 
@@ -625,7 +625,7 @@ The ``query()`` method does not allow for additional parameters. If you need
 additional parameters you should use the ``execute()`` method, which allows for
 placeholders to be used::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published = ? WHERE id = ?',
         [1, 2]
     );
@@ -634,7 +634,7 @@ Without any type hinting information, ``execute`` will assume all placeholders
 are string values. If you need to bind specific types of data, you can use their
 abstract type names when creating a query::
 
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'UPDATE articles SET published_date = ? WHERE id = ?',
         [new DateTime('now'), 2],
         ['date', 'integer']
@@ -651,7 +651,7 @@ expressive queries without having to use platform specific SQL::
     $query->update('articles')
         ->set(['published' => true])
         ->where(['id' => 2]);
-    $stmt = $query->execute();
+    $statement = $query->execute();
 
 When using the query builder, no SQL will be sent to the database server until
 the ``execute()`` method is called, or the query is iterated. Iterating a query
@@ -722,14 +722,14 @@ You can create a statement object using ``execute()``, or ``prepare()``. The
 While ``prepare()`` returns an incomplete statement::
 
     // Statements from execute will have values bound to them already.
-    $stmt = $connection->execute(
+    $statement = $connection->execute(
         'SELECT * FROM articles WHERE published = ?',
         [true]
     );
 
     // Statements from prepare will be parameters for placeholders.
     // You need to bind parameters before attempting to execute it.
-    $stmt = $connection->prepare('SELECT * FROM articles WHERE published = ?');
+    $statement = $connection->prepare('SELECT * FROM articles WHERE published = ?');
 
 Once you've prepared a statement you can bind additional data and execute it.
 
@@ -742,36 +742,36 @@ Once you've created a prepared statement, you may need to bind additional data.
 You can bind multiple values at once using the ``bind()`` method, or bind
 individual elements using ``bindValue``::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = ? AND created > ?'
     );
 
     // Bind multiple values
-    $stmt->bind(
+    $statement->bind(
         [true, new DateTime('2013-01-01')],
         ['boolean', 'date']
     );
 
     // Bind a single value
-    $stmt->bindValue(1, true, 'boolean');
-    $stmt->bindValue(2, new DateTime('2013-01-01'), 'date');
+    $statement->bindValue(1, true, 'boolean');
+    $statement->bindValue(2, new DateTime('2013-01-01'), 'date');
 
 When creating statements you can also use named array keys instead of
 positional ones::
 
-    $stmt = $connection->prepare(
+    $statement = $connection->prepare(
         'SELECT * FROM articles WHERE published = :published AND created > :created'
     );
 
     // Bind multiple values
-    $stmt->bind(
+    $statement->bind(
         ['published' => true, 'created' => new DateTime('2013-01-01')],
         ['published' => 'boolean', 'created' => 'date']
     );
 
     // Bind a single value
-    $stmt->bindValue('published', true, 'boolean');
-    $stmt->bindValue('created', new DateTime('2013-01-01'), 'date');
+    $statement->bindValue('published', true, 'boolean');
+    $statement->bindValue('created', new DateTime('2013-01-01'), 'date');
 
 .. warning::
 
@@ -785,16 +785,16 @@ rows. Statements should be executed using the ``execute()`` method. Once
 executed, results can be fetched using ``fetch()``, ``fetchAll()`` or iterating
 the statement::
 
-    $stmt->execute();
+    $statement->execute();
 
     // Read one row.
-    $row = $stmt->fetch('assoc');
+    $row = $statement->fetch('assoc');
 
     // Read all rows.
-    $rows = $stmt->fetchAll('assoc');
+    $rows = $statement->fetchAll('assoc');
 
     // Read rows through iteration.
-    foreach ($stmt as $row) {
+    foreach ($statement as $row) {
         // Do work
     }
 
@@ -808,8 +808,8 @@ Getting Row Counts
 
 After executing a statement, you can fetch the number of affected rows::
 
-    $rowCount = count($stmt);
-    $rowCount = $stmt->rowCount();
+    $rowCount = count($statement);
+    $rowCount = $statement->rowCount();
 
 Checking Error Codes
 --------------------
@@ -818,8 +818,8 @@ If your query was not successful, you can get related error information
 using the ``errorCode()`` and ``errorInfo()`` methods. These methods work the
 same way as the ones provided by PDO::
 
-    $code = $stmt->errorCode();
-    $info = $stmt->errorInfo();
+    $code = $statement->errorCode();
+    $info = $statement->errorInfo();
 
 .. todo::
     Possibly document CallbackStatement and BufferedStatement


### PR DESCRIPTION
Improves clarity.