### PR TITLE
fix: Zend -> Laminas

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -132,11 +132,6 @@ be accessed like this::
     $attachment = $this->request->getData('attachment');
 
 By default file uploads are represented in the request data as objects that implement
-`\\Psr\\Http\\Message\\UploadedFileInterface <https://www.php-fig.org/psr/psr-7/#16-uploaded-files>`__.
-In the above example, ``$attachment`` would hold an object, in the current implementation it would by default be an
-instance of ``\Zend\Diactoros\UploadedFile``.
-
-By default file uploads are represented in the request data as objects that implement
 `\\Psr\\Http\\Message\\UploadedFileInterface <https://www.php-fig.org/psr/psr-7/#16-uploaded-files>`__. In the current
 implementation, the ``$attachment`` variable in the above example would by default hold an instance of
 ``\Laminas\Diactoros\UploadedFile``.
@@ -210,7 +205,7 @@ Returns all uploaded files in a normalized array structure. For the above exampl
 ``attachment``, the structure would look like::
 
     [
-          'attachment' => object(Zend\Diactoros\UploadedFile) {
+          'attachment' => object(Laminas\Diactoros\UploadedFile) {
               // ...
           }
     ]


### PR DESCRIPTION
I noticed during Japanese translation.
https://github.com/cakephp/docs/pull/6554

I actually tried file upload and confirmed it.
```
object(Laminas\Diactoros\UploadedFile) {
	[private] clientFilename => 'test.csv'
	[private] clientMediaType => 'application/vnd.ms-excel'
	[private] error => (int) 0
	[private] file => '/tmp/php9mTDKH'
	[private] moved => false
	[private] size => (int) 14112
	[private] stream => null
}
```