### PR TITLE
corrected namespace

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -413,7 +413,7 @@ model fields, depending on a country, ie::
         public function validationDefault(Validator $validator)
         {
             // add the provider to the validator
-            $validator->setProvider('fr', 'Localized\Validation\FrValidation');
+            $validator->setProvider('fr', 'Cake\Localized\Validation\FrValidation');
             // use the provider in a field validation rule
             $validator->add('phoneField', 'myCustomRuleNameForPhone', [
                 'rule' => 'phone',


### PR DESCRIPTION
Corrected namespace for localized class
With `Localized\Validation\FrValidation` `ValidationRule` class return error 'Unable to call method "%s" in "%s" provider for field "%s"'
That classes located under the `Cake\Localized\Validation` namespace