### PR TITLE
Update installation.rst

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -14,7 +14,7 @@ CakePHP has a few system requirements:
 .. note::
 
     In XAMPP, intl extension is included but you have to uncomment
-    ``extension=php_intl.dll`` (or extension=intl) in **php.ini** and restart the server through
+    ``extension=php_intl.dll`` (or ``extension=intl``) in **php.ini** and restart the server through
     the XAMPP Control Panel.
 
     In WAMP, the intl extension is "activated" by default but not working.

--- a/en/installation.rst
+++ b/en/installation.rst
@@ -14,7 +14,7 @@ CakePHP has a few system requirements:
 .. note::
 
     In XAMPP, intl extension is included but you have to uncomment
-    ``extension=php_intl.dll`` in **php.ini** and restart the server through
+    ``extension=php_intl.dll`` (or extension=intl) in **php.ini** and restart the server through
     the XAMPP Control Panel.
 
     In WAMP, the intl extension is "activated" by default but not working.


### PR DESCRIPTION
from the xampp php.ini:

; Note : The syntax used in previous PHP versions ('extension=<ext>.so' and
; 'extension='php_<ext>.dll') is supported for legacy reasons and may be
; deprecated in a future PHP major version. So, when it is possible, please
; move to the new ('extension=<ext>) syntax.
;