### PR TITLE
Fix __d() domain docs.

### DIFF
--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -41,7 +41,11 @@ translating content.
     Allows you to override the current domain for a single message lookup.
 
     Useful when internationalizing a plugin:
-    ``echo __d('PluginName', 'This is my plugin');``
+    ``echo __d('plugin_name', 'This is my plugin');``
+
+    .. note::
+
+        Make sure to use the underscored version of the plugin name here as domain.
 
 .. php:function:: __dn(string $domain, string $singular, string $plural, integer $count, mixed $args = null)
 


### PR DESCRIPTION
I had to use

    __d('plugin_name', 'A simple string.'))

here

Refs https://book.cakephp.org/4/en/core-libraries/internationalization-and-localization.html#language-files

What I don't know yet, is now plugins with namespacing work:
-  `ADmad/SocialAuth` etc