### PR TITLE
invalid header value type

### DIFF
--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -520,7 +520,7 @@ use the ``HttpsEnforcerMiddleware``::
 
     // Send additional headers in the redirect response.
     $https = new HttpsEnforcerMiddleware([
-        'headers' => ['X-Https-Upgrade' => true],
+        'headers' => ['X-Https-Upgrade' => 1],
     ]);
 
     // Disable HTTPs enforcement when ``debug`` is on.


### PR DESCRIPTION
With the boolean value, Laminas\Diactoros fires an exception. It has to be of type string or numeric.