### PR TITLE
Wrong file was referenced

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -24,7 +24,7 @@ Logging Configuration
 =====================
 
 Configuring ``Log`` should be done during your application's bootstrap phase.
-The **config/app.php** file is intended for just this.  You can define
+The **config/boostrap.php** file is intended for just this.  You can define
 as many or as few loggers as your application needs.  Loggers should be
 configured using :php:class:`Cake\\Log\\Log`. An example would be::
 


### PR DESCRIPTION
As far as I can tell for 4.x logging should be configured in `bootstrap.php` not in `app.php`