### PR TITLE
Update articles-controller.rst

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -446,11 +446,11 @@ using :ref:`a validator <validating-request-data>`::
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->allowEmptyString('title', false)
+            ->notEmptyString('title')
             ->minLength('title', 10)
             ->maxLength('title', 255)
 
-            ->allowEmptyString('body', false)
+            ->notEmptyString('body')
             ->minLength('body', 10);
 
         return $validator;


### PR DESCRIPTION
Docs stating "that both the title, and body fields must not be empty".
Incorrect validator function used (allowEmptyString), should use notEmptyString if you ask me