### PR TITLE
Note virus-scanner can disrupt sending mail

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -508,6 +508,9 @@ in your configuration::
 
 .. note::
     `Gmail SMTP settings <https://support.google.com/a/answer/176600?hl=en>`__.
+        
+.. note::
+    Virus-scanners can disrupt sending mails through Gmail (for instance, you have to disable scanning outbound mail in 'AntiVirus free' (Windows10) in order to get this to work).    
 
 .. note::
     To use SSL + SMTP, you will need to have the SSL configured in your PHP


### PR DESCRIPTION
https://discourse.cakephp.org/t/cant-send-mails-using-gmail-with-emailtransport-configured-as-described-in-cookbook-4/7786/9

Don't know how specific this is, only gmail, only Anti Virus Free (windows 10)? Seems to be php/tls issue?

Whatever the cause/combo's, at the moment it seems that you have take this in account when trying to get sending mail to work with gmail. Think it has to be mentioned.