### PR TITLE
Fix inline usages of removed `templates()` method.

### DIFF
--- a/en/views/helpers/breadcrumbs.rst
+++ b/en/views/helpers/breadcrumbs.rst
@@ -122,7 +122,7 @@ It includes four templates, with the following default declaration::
         'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
     ]
 
-You can easily customize them using the ``templates()`` method from the
+You can easily customize them using the ``setTemplates()`` method from the
 ``StringTemplateTrait``::
 
     $this->Breadcrumbs->setTemplates([

--- a/fr/views/helpers/breadcrumbs.rst
+++ b/fr/views/helpers/breadcrumbs.rst
@@ -131,7 +131,7 @@ Quatre templates sont inclus. Voici leur déclaration par défaut::
         'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
     ]
 
-Vous pouvez facilement personnaliser ces templates via la méthode ``templates()``
+Vous pouvez facilement personnaliser ces templates via la méthode ``setTemplates()``
 du ``StringTemplateTrait``::
 
     $this->Breadcrumbs->setTemplates([

--- a/ja/views/helpers/breadcrumbs.rst
+++ b/ja/views/helpers/breadcrumbs.rst
@@ -117,7 +117,7 @@ BreadcrumbsHelper は内部で ``StringTemplateTrait`` を使用しています�
         'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
     ]
 
-``StringTemplateTrait`` の ``template()`` メソッドを使用すると簡単にカスタマイズすることができます。 ::
+``StringTemplateTrait`` の ``setTemplates()`` メソッドを使用すると簡単にカスタマイズすることができます。 ::
 
     $this->Breadcrumbs->setTemplates([
         'wrapper' => '<nav class="breadcrumbs"><ul{{attrs}}>{{content}}</ul></nav>',

--- a/ru/views/helpers/breadcrumbs.rst
+++ b/ru/views/helpers/breadcrumbs.rst
@@ -127,7 +127,7 @@
         'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
     ]
 
-Вы можете с легкостью изменять их, используя метод ``templates()``, из
+Вы можете с легкостью изменять их, используя метод ``setTemplates()``, из
 ``StringTemplateTrait``::
 
     $this->Breadcrumbs->setTemplates([

--- a/tl/views/helpers/breadcrumbs.rst
+++ b/tl/views/helpers/breadcrumbs.rst
@@ -124,7 +124,7 @@ It includes four templates, with the following default declaration::
         'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
     ]
 
-You can easily customize them using the ``templates()`` method from the
+You can easily customize them using the ``setTemplates()`` method from the
 ``StringTemplateTrait``::
 
     $this->Breadcrumbs->setTemplates([


### PR DESCRIPTION
Missed the inline ones.