### PR TITLE
Update form.rst

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -156,7 +156,7 @@ Valid values:
   ``formStart`` template.
 
 * ``autoSetCustomValidity`` - Set to ``true`` to use custom required and notBlank
-  validation messages in the control's HTML5 validity message. Default is ``false``.
+  validation messages in the control's HTML5 validity message. Default is ``true``.
 
 .. tip::
 


### PR DESCRIPTION
Fixed "autoSetCustomValidity" default description to _true_, according to the latest 4.x FormHelper.php.
