### PR TITLE
Returns "none returned" error without 'return' keyword

### DIFF
--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -228,7 +228,7 @@ the view file in **templates/Recipes/search.php** will be rendered::
         public function search()
         {
             // Render the view in templates/Recipes/search.php
-            $this->render();
+            return $this->render();
         }
     // ...
     }


### PR DESCRIPTION
If we don't use return keyword with render method it throws below error:

> Return value of App\Controller\PagesController::home() must be an instance of Cake\Http\Response or null, none returned