### PR TITLE
Tutorial using deprecated validation function

### DIFF
--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -418,9 +418,9 @@ back at our Articles model and make a few adjustments::
         public function validationDefault(Validator $validator): Validator
         {
             $validator
-                ->notEmpty('title')
+                ->notEmptyString('title')
                 ->requirePresence('title')
-                ->notEmpty('body')
+                ->notEmptyString('body')
                 ->requirePresence('body');
 
             return $validator;


### PR DESCRIPTION
Blog tutorial part 2, replaced notEmpty() with notEmptyString()