### PR TITLE
Update saving-data.rst

### DIFF
--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -36,7 +36,7 @@ passing it to the ``save()`` method in the ``Table`` class::
         $id = $article->id;
     }
     
-The save method returns the successfully saved entity or false on failure.
+The ``save()`` method returns the successfully saved entity or ``false`` on failure.
 
 Updating Data
 -------------

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -35,6 +35,8 @@ passing it to the ``save()`` method in the ``Table`` class::
         // The $article entity contains the id now
         $id = $article->id;
     }
+    
+The save method returns the successfully saved entity or false on failure.
 
 Updating Data
 -------------


### PR DESCRIPTION
New users need to be told some of the basics (like return values) without having to hunt for the API link and then searching through the API documentation to find the simple facts about methods the documentation tells them to use.  Alternatively, you could hyperlink the save() method reference so that it connects directly to the save method definition in the API.