### PR TITLE
Clarify use of "setTo(), setCc(), setBcc()"

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -43,7 +43,8 @@ add more recipients to their respective field::
     // The email's To recipient is: test@example.com
 
 .. deprecated:: 3.4.0
-    Use ``setFrom()``, ``setTo()``, ``setCc()`` , ``setBcc()``  and ``setSubject()`` instead.
+    Use ``setFrom()``, ``setTo()``, ``setCc()`` , ``setBcc()``  and ``setSubject()`` instead of ``from()``, ``to()``, ``cc()``,
+``bcc()`` and ``subject()``
 
 Choosing the Sender
 -------------------


### PR DESCRIPTION
Hoping to clarify that the new "setXXX()" methods in 3.4+ are replacing the "XXX()" methods and that the "addXXX()" methods should still to be used for multiple recipients, senders etc.