### PR TITLE
Fixes incorrect example for defaultConnectionName()

### DIFF
--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -447,7 +447,7 @@ tables use which connections. This is the ``defaultConnectionName()`` method::
 
     class ArticlesTable extends Table
     {
-        public static function defaultConnectionName() {
+        public static function defaultConnectionName(): string {
             return 'replica_db';
         }
     }


### PR DESCRIPTION
Must declare return type `string`