### PR TITLE
Docs of CamelCase

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -685,7 +685,7 @@ The current prefix will be available from the controller methods through
 ``$this->request->getParam('prefix')``
 
 When using prefix routes it's important to set the ``prefix`` option, and to
-use the same camel-cased format that is used in the ``prefix()`` method. Here's
+use the same CamelCased format that is used in the ``prefix()`` method. Here's
 how to build this link using the HTML helper::
 
     // Go into a prefixed route.

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -685,7 +685,7 @@ The current prefix will be available from the controller methods through
 ``$this->request->getParam('prefix')``
 
 When using prefix routes it's important to set the ``prefix`` option, and to
-use the same camel cased format that is used in the ``prefix()`` method. Here's
+use the same camel-cased format that is used in the ``prefix()`` method. Here's
 how to build this link using the HTML helper::
 
     // Go into a prefixed route.
@@ -729,7 +729,7 @@ This would link to a controller with the namespace ``App\\Controller\\Admin\\MyP
 
 .. note::
 
-    The prefix is always camel cased here, even if the routing result is dashed.
+    The prefix is always camel-cased here, even if the routing result is dashed.
     The route itself will do the inflection if necessary.
 
 Plugin Routing

--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -729,7 +729,7 @@ This would link to a controller with the namespace ``App\\Controller\\Admin\\MyP
 
 .. note::
 
-    The prefix is always camel-cased here, even if the routing result is dashed.
+    The prefix is always CamelCased here, even if the routing result is dashed.
     The route itself will do the inflection if necessary.
 
 Plugin Routing

--- a/en/intro/conventions.rst
+++ b/en/intro/conventions.rst
@@ -189,7 +189,7 @@ by creating classes and files that you'd need to create anyway.
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Class      | ArticlesController          | ArticlesCategoriesController     |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
-| Controller | ArticlesController          | ArticlesCategoriesController     | Plural, CamelCased, end in Controller               |
+| Controller | ArticlesController          | ArticlesCategoriesController     | Plural, CamelCased, end in Controller                |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Behavior   | ArticlesBehavior.php        | ArticlesCategoriesBehavior.php   |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+

--- a/en/intro/conventions.rst
+++ b/en/intro/conventions.rst
@@ -10,14 +10,14 @@ uniform development experience, allowing other developers to jump in and help.
 Controller Conventions
 ======================
 
-Controller class names are plural, PascalCased, and end in ``Controller``.
+Controller class names are plural, CamelCased, and end in ``Controller``.
 ``UsersController`` and ``ArticleCategoriesController`` are both examples of
 conventional controller names.
 
 Public methods on Controllers are often exposed as 'actions' accessible through
-a web browser. For example the ``/users/view`` maps to the ``view()`` method
-of the ``UsersController`` out of the box. Protected or private methods
-cannot be accessed with routing.
+a web browser. They are camelBacked. For example the ``/users/view-me`` maps to the ``viewMe()`` method
+of the ``UsersController`` out of the box (if one uses default dashed inflection in routing).
+Protected or private methods cannot be accessed with routing.
 
 URL Considerations for Controller Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,9 +35,9 @@ When you create links using ``this->Html->link()``, you can use the following
 conventions for the url array::
 
     $this->Html->link('link-title', [
-        'prefix' => 'MyPrefix' // PascalCased
-        'plugin' => 'MyPlugin', // PascalCased
-        'controller' => 'ControllerName', // PascalCased
+        'prefix' => 'MyPrefix' // CamelCased
+        'plugin' => 'MyPlugin', // CamelCased
+        'controller' => 'ControllerName', // CamelCased
         'action' => 'actionName' // camelBacked
     ]
 
@@ -103,12 +103,12 @@ the ``Table::save()`` method.
 Model Conventions
 =================
 
-Table class names are plural, PascalCased and end in ``Table``. ``UsersTable``,
+Table class names are plural, CamelCased and end in ``Table``. ``UsersTable``,
 ``ArticleCategoriesTable``, and ``UserFavoritePagesTable`` are all examples of
 table class names matching the ``users``, ``article_categories`` and
 ``user_favorite_pages`` tables respectively.
 
-Entity class names are singular PascalCased and have no suffix. ``User``,
+Entity class names are singular CamelCased and have no suffix. ``User``,
 ``ArticleCategory``, and ``UserFavoritePage`` are all examples of entity names
 matching the ``users``, ``article_categories`` and ``user_favorite_pages``
 tables respectively.
@@ -182,14 +182,14 @@ by creating classes and files that you'd need to create anyway.
 | File       | ArticlesController.php      | ArticlesCategoriesController.php |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Table      | ArticlesTable.php           | ArticlesCategoriesTable.php      | Table class names are plural,                        |
-|            |                             |                                  | PascalCased and end in Table                         |
+|            |                             |                                  | CamelCased and end in Table                         |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Entity     | Articles.php                | ArticlesCategories.php           | Entity class names are singular,                     |
-|            |                             |                                  | PascalCased: Article and ArticleCategory             |
+|            |                             |                                  | CamelCased: Article and ArticleCategory             |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Class      | ArticlesController          | ArticlesCategoriesController     |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
-| Controller | ArticlesController          | ArticlesCategoriesController     | Plural, PascalCased, end in Controller               |
+| Controller | ArticlesController          | ArticlesCategoriesController     | Plural, CamelCased, end in Controller               |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Behavior   | ArticlesBehavior.php        | ArticlesCategoriesBehavior.php   |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+

--- a/en/intro/conventions.rst
+++ b/en/intro/conventions.rst
@@ -185,7 +185,7 @@ by creating classes and files that you'd need to create anyway.
 |            |                             |                                  | CamelCased and end in Table                         |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Entity     | Articles.php                | ArticlesCategories.php           | Entity class names are singular,                     |
-|            |                             |                                  | CamelCased: Article and ArticleCategory             |
+|            |                             |                                  | CamelCased: Article and ArticleCategory              |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Class      | ArticlesController          | ArticlesCategoriesController     |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+

--- a/en/intro/conventions.rst
+++ b/en/intro/conventions.rst
@@ -182,7 +182,7 @@ by creating classes and files that you'd need to create anyway.
 | File       | ArticlesController.php      | ArticlesCategoriesController.php |                                                      |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Table      | ArticlesTable.php           | ArticlesCategoriesTable.php      | Table class names are plural,                        |
-|            |                             |                                  | CamelCased and end in Table                         |
+|            |                             |                                  | CamelCased and end in Table                          |
 +------------+-----------------------------+----------------------------------+------------------------------------------------------+
 | Entity     | Articles.php                | ArticlesCategories.php           | Entity class names are singular,                     |
 |            |                             |                                  | CamelCased: Article and ArticleCategory              |


### PR DESCRIPTION
Refs https://api.cakephp.org/4.0/class-Cake.Utility.Inflector.html#camelize

We shouldnt use a word, that has no good meaning and is not in line with the current API and how people use the casings.

Most people don't know what Pascal case means or is supposed to be. CamelCase and camelBacked is an agnostic and visual way to describe it and thus a good default anyway.
It makes sense to not confuse people already used to those very good default style names.
https://en.wikipedia.org/wiki/Camel_case lists PascalCase as well, but as I said: It has less visual and thus less useful meaning.