### PR TITLE
Re-order TOC entries to create better fwd/back links

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -2,20 +2,6 @@ Contents
 ########
 
 .. toctree::
-   :hidden:
-
-   index
-   topics
-   chronos
-   debug-kit
-   elasticsearch
-   bake
-   bake/development
-   bake/usage
-   migrations
-   phinx
-
-.. toctree::
     :maxdepth: 3
     :caption: Preface
 
@@ -105,6 +91,20 @@ Contents
     Authorization <https://book.cakephp.org/authorization/2/>
     Phinx <https://book.cakephp.org/phinx/0/en/>
     Chronos <https://book.cakephp.org/chronos/2/>
+
+.. toctree::
+   :hidden:
+
+   index
+   topics
+   chronos
+   debug-kit
+   elasticsearch
+   bake
+   bake/development
+   bake/usage
+   migrations
+   phinx
 
 .. todolist::
 

--- a/es/contents.rst
+++ b/es/contents.rst
@@ -2,16 +2,6 @@ Contenidos
 ##########
 
 .. toctree::
-   :hidden:
-
-   index
-   topics
-   chronos
-   debug-kit
-   bake
-   bake/usage
-
-.. toctree::
     :maxdepth: 3
     :caption: Prólogo
 
@@ -89,6 +79,16 @@ Contenidos
 
     core-libraries/global-constants-and-functions
     appendices
+
+.. toctree::
+   :hidden:
+
+   index
+   topics
+   chronos
+   debug-kit
+   bake
+   bake/usage
 
 .. todolist::
 

--- a/fr/contents.rst
+++ b/fr/contents.rst
@@ -2,20 +2,6 @@ Contenu
 #######
 
 .. toctree::
-    :hidden:
-
-    index
-    topics
-    bake
-    bake/usage
-    chronos
-    debug-kit
-    elasticsearch
-    migrations
-    phinx
-
-
-.. toctree::
     :maxdepth: 3
     :caption: Préface
 
@@ -99,6 +85,20 @@ Contenu
     :caption: Phinx
 
     Phinx <https://book.cakephp.org/phinx/0/fr/>
+
+.. toctree::
+    :hidden:
+
+    index
+    topics
+    bake
+    bake/usage
+    chronos
+    debug-kit
+    elasticsearch
+    migrations
+    phinx
+
 
 .. todolist::
 

--- a/ja/contents.rst
+++ b/ja/contents.rst
@@ -2,20 +2,6 @@
 ############
 
 .. toctree::
-    :hidden:
-
-    index
-    topics
-    chronos
-    debug-kit
-    elasticsearch
-    bake
-    bake/development
-    bake/usage
-    migrations
-    phinx
-
-.. toctree::
     :maxdepth: 3
     :caption: はじめに
 
@@ -102,6 +88,20 @@
     :caption: Phinx
 
     Phinx <https://book.cakephp.org/phinx/0/ja/>
+
+.. toctree::
+    :hidden:
+
+    index
+    topics
+    chronos
+    debug-kit
+    elasticsearch
+    bake
+    bake/development
+    bake/usage
+    migrations
+    phinx
 
 .. todolist::
 

--- a/pt/contents.rst
+++ b/pt/contents.rst
@@ -1,19 +1,6 @@
 Conteúdo
 ########
 
-.. toctree::
-    :hidden:
-
-    index
-    topics
-    chronos
-    bake
-    bake/development
-    bake/usage
-    debug-kit
-    elasticsearch
-    migrations
-
 
 .. toctree::
     :maxdepth: 3
@@ -93,6 +80,19 @@ Conteúdo
 
     core-libraries/global-constants-and-functions
     appendices
+
+.. toctree::
+    :hidden:
+
+    index
+    topics
+    chronos
+    bake
+    bake/development
+    bake/usage
+    debug-kit
+    elasticsearch
+    migrations
 
 .. todolist::
 

--- a/ru/contents.rst
+++ b/ru/contents.rst
@@ -2,18 +2,6 @@
 ##########
 
 .. toctree::
-    :hidden:
-
-    index
-    topics
-    bake
-    bake/usage
-    bake/development
-    chronos
-    debug-kit
-    migrations
-
-.. toctree::
     :maxdepth: 3
     :caption: Введение
 
@@ -91,6 +79,19 @@
 
     core-libraries/global-constants-and-functions
     appendices
+
+.. toctree::
+    :hidden:
+
+    index
+    topics
+    bake
+    bake/usage
+    bake/development
+    chronos
+    debug-kit
+    migrations
+
 
 .. todolist::
 

--- a/zh/contents.rst
+++ b/zh/contents.rst
@@ -2,12 +2,6 @@ Contents
 ########
 
 .. toctree::
-   :hidden:
-
-   index
-   topics
-
-.. toctree::
     :maxdepth: 3
     :caption: Preface
 
@@ -85,6 +79,13 @@ Contents
 
     core-libraries/global-constants-and-functions
     appendices
+
+.. toctree::
+   :hidden:
+
+   index
+   topics
+
 
 .. todolist::
 


### PR DESCRIPTION
Reorder the TOC entries to get better forward and back buttons at the bottom of each page.

Refs #6707