### PR TITLE
Improve Docs: Update helpers.rst to utilize existing method

### DIFF
--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -310,7 +310,7 @@ Accessing View Variables Inside Your Helper
 -------------------------------------------
 
 If you would like to access a View variable inside a helper, you can use
-``$this->_View->get()`` like::
+``$this->getView()->get()`` like::
 
     class AwesomeHelper extends Helper
     {
@@ -320,7 +320,7 @@ If you would like to access a View variable inside a helper, you can use
         {
             // set meta description
             return $this->Html->meta(
-                'description', $this->_View->get('metaDescription'), ['block' => 'meta']
+                'description', $this->getView()->get('metaDescription'), ['block' => 'meta']
             );
         }
     }
@@ -329,13 +329,13 @@ Rendering A View Element Inside Your Helper
 -------------------------------------------
 
 If you would like to render an Element inside your Helper you can use
-``$this->_View->element()`` like::
+``$this->getView()->element()`` like::
 
     class AwesomeHelper extends Helper
     {
         public function someFunction()
         {
-            return $this->_View->element(
+            return $this->getView()->element(
                 '/path/to/element',
                 ['foo'=>'bar','bar'=>'foo']
             );


### PR DESCRIPTION
I suggest to improve this part of docs because in `/src/View/Helper.php` we already have `getView()` method:

[Cakephp Code Reference](https://github.com/cakephp/cakephp/blob/master/src/View/Helper.php#L121-L129)
```php
    /**
     * Get the view instance this helper is bound to.
     *
     * @return \Cake\View\View The bound view instance.
     */
    public function getView(): View
    {
        return $this->_View;
    }
```

I think it's better to use `getView()` method as part of **best practices**.

Please correct me if I'm wrong.

Thank you.
