### PR TITLE
Properly nest window functions heading, rename to avoid duplicates.

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -327,8 +327,8 @@ You can access existing wrappers for several SQL functions through ``Query::func
 ``dayOfWeek()``
     Returns a FunctionExpression representing a call to SQL WEEKDAY function.
 
-Window Functions
-----------------
+Window-Only Functions
+^^^^^^^^^^^^^^^^^^^^^
 
 These window-only functions contain a window expression by default:
 


### PR DESCRIPTION
This section isn't a child of the "Using SQL Functions" section, causing
it to act as a parent for the following "Custom Functions" section.

Also there are two "Window Functions" headings, causing the second one
to generate a not overly descriptive link anchor named `id0`.