### PR TITLE
Update installation.rst to specify cakephp/app to install ^3.9 version

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -82,7 +82,7 @@ command :
 
 .. code-block:: bash
 
-    composer create-project --prefer-dist cakephp/app:^3.8 my_app_name
+    composer create-project --prefer-dist cakephp/app:^3.9 my_app_name
 
 Once Composer finishes downloading the application skeleton and the core CakePHP
 library, you should have a functioning CakePHP application installed via


### PR DESCRIPTION
Since @othercorey [released version](https://github.com/cakephp/app/releases/tag/3.9.0) 3.9.0 for cakephp/app, we should update installation steps to use that version.