### PR TITLE
[PATCH] Fix Adding Password Hashing documentation section

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -48,7 +48,7 @@ add the following::
     <?php
     namespace App\Model\Entity;
 
-    use Authentication\PasswordHasher\DefaultPasswordHasher; // Add this line
+    use Cake\Auth\DefaultPasswordHasher; // Add this line
     use Cake\ORM\Entity;
 
     class User extends Entity


### PR DESCRIPTION
https://github.com/cakephp/docs/issues/6733

<!-- Make sure to verify that your submitted issue has not raised in another issue proposal and has not been addressed in any PR. -->

**Issue Description**

CakePHP  4.x.

``
Error: Class 'App\Model\Entity\DefaultPasswordHasher' not found.
``
[Doc link](https://book.cakephp.org/4/en/tutorials-and-examples/cms/authentication.html#adding-password-hashing)

https://github.com/cakephp/docs/edit/4.x/en/tutorials-and-examples/cms/authentication.rst

<img width="1432" alt="Screen Shot 2020-08-01 at 16 20 57" src="https://user-images.githubusercontent.com/36732489/89108927-2812a880-d413-11ea-8e19-bc77b11e57d2.png">


---

Error fixed replacing: 

`use Cake\Auth\DefaultPasswordHasher;` by `use Cake\Auth\DefaultPasswordHasher;`

_src/Model/Entity/User.php_

<img width="1175" alt="Screen Shot 2020-08-01 at 16 21 21" src="https://user-images.githubusercontent.com/36732489/89108950-58f2dd80-d413-11ea-9a6c-7c7e518f5f8c.png">
