### PR TITLE
use getResponse() method, $response is protected.

### DIFF
--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -176,7 +176,7 @@ error pages when this error is handled::
     {
         public function missingWidget($error)
         {
-            $response = $this->controller->response;
+            $response = $this->controller->getResponse();
 
             return $response->withStringBody('Oops that widget is missing.');
         }


### PR DESCRIPTION
Use the correct method to access the $response object, which cannot be accessed directly.