### PR TITLE
Update testing.rst

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -200,11 +200,11 @@ our code creates the output we expect::
     public function testBar(): void
     {
         $result = $this->Progress->bar(90);
-        $this->assertContains('width: 90%', $result);
-        $this->assertContains('progress-bar', $result);
+        $this->assertStringContainsString('width: 90%', $result);
+        $this->assertStringContainsString('progress-bar', $result);
 
         $result = $this->Progress->bar(33.3333333);
-        $this->assertContains('width: 33%', $result);
+        $this->assertStringContainsString('width: 33%', $result);
     }
 
 The above test is a simple one but shows the potential benefit of using test


### PR DESCRIPTION
In response to message from PHPUnit 8.5: `Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead`.
