### PR TITLE
Update validation.rst 

### DIFF
--- a/en/core-libraries/validation.rst
+++ b/en/core-libraries/validation.rst
@@ -270,7 +270,7 @@ accept a callback function as their last argument. If present, the callback
 determines whether or not the rule should be applied. For example, a field is
 sometimes allowed to be empty::
 
-    $validator->allowEmptyString('tax', function ($context) {
+    $validator->allowEmptyString('tax', 'This field is required', function ($context) {
         return !$context['data']['is_taxable'];
     });
 


### PR DESCRIPTION
Please correct me if I'm wrong.
This method expects the **second parameter to be a _string_ error message**, while **_callable_ is passed at the third parameter**.

Original code reference: https://github.com/cakephp/cakephp/blob/master/src/Validation/Validator.php#L850-L866
```php 
    /**
     * Allows a field to be an empty string.
     *
     * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING flag.
     *
     * @param string $field The name of the field.
     * @param string|null $message The message to show if the field is not
     * @param bool|string|callable $when Indicates when the field is allowed to be empty
     * Valid values are true, false, 'create', 'update'. If a callable is passed then
     * the field will allowed to be empty only when the callback returns true.
     * @return $this
     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
     */
    public function allowEmptyString(string $field, ?string $message = null, $when = true)
    {
        return $this->allowEmptyFor($field, self::EMPTY_STRING, $when, $message);
    }
```