### PR TITLE
Promote passing resultset instances to views instead of query instances.

### DIFF
--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -352,9 +352,10 @@ table/collection that is not the controller's default one::
     // In a controller method.
     $this->loadModel('Articles');
     $recentArticles = $this->Articles->find('all', [
-        'limit' => 5,
-        'order' => 'Articles.created DESC'
-    ]);
+            'limit' => 5,
+            'order' => 'Articles.created DESC'
+        ])
+        ->all();
 
 If you are using a table provider other than the built-in ORM you can
 link that table system into CakePHP's controllers by connecting its

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -967,7 +967,7 @@ To take advantage of this header, you must either call the
 
     public function index()
     {
-        $articles = $this->Articles->find('all');
+        $articles = $this->Articles->find('all')->all();
 
         // Simple checksum of the article contents.
         // You should use a more efficient implementation

--- a/en/core-libraries/text.rst
+++ b/en/core-libraries/text.rst
@@ -26,7 +26,7 @@ of a ``View``, use the ``Text`` class::
 
         public function afterLogin()
         {
-            $message = $this->Users->find('new_message');
+            $message = $this->Users->find('new_message')->first();
             if (!empty($message)) {
                 // Notify user of new message
                 $this->Flash->success(__(

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -32,7 +32,7 @@ controller might look something like this::
 
         public function index()
         {
-            $recipes = $this->Recipes->find('all');
+            $recipes = $this->Recipes->find('all')->all();
             $this->set('recipes', $recipes);
             $this->viewBuilder()->setOption('serialize', ['recipes']);
         }

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -784,7 +784,7 @@ now looks like this::
 
         public function testFindPublished(): void
         {
-            $query = $this->Articles->find('published');
+            $query = $this->Articles->find('published')->all();
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $result = $query->enableHydration(false)->toArray();
             $expected = [
@@ -865,10 +865,11 @@ controller code looks like::
             }
             if (!empty($short)) {
                 $result = $this->Articles->find('all', [
-                    'fields' => ['id', 'title']
-                ]);
+                        'fields' => ['id', 'title']
+                    ])
+                    ->all();
             } else {
-                $result = $this->Articles->find();
+                $result = $this->Articles->find()->all();
             }
 
             $this->set([

--- a/en/intro.rst
+++ b/en/intro.rst
@@ -38,8 +38,8 @@ The model objects can be thought of as "Friend", "User", "Comment", or
     use Cake\ORM\Locator\LocatorAwareTrait;
 
     $users = $this->getTableLocator()->get('Users');
-    $query = $users->find();
-    foreach ($query as $row) {
+    $resultset = $users->find()->all();
+    foreach ($resultset as $row) {
         echo $row->username;
     }
 

--- a/en/orm.rst
+++ b/en/orm.rst
@@ -36,9 +36,9 @@ from our ``articles`` table we could do::
     {
         $articles = $this->getTableLocator()->get('Articles');
 
-        $query = $articles->find();
+        $resultset = $articles->find()->all();
 
-        foreach ($query as $row) {
+        foreach ($resultset as $row) {
             echo $row->title;
         }
     }
@@ -91,9 +91,9 @@ load entities from the database we'll get instances of our new Article class::
     use Cake\ORM\Locator\LocatorAwareTrait;
 
     $articles = $this->getTableLocator()->get('Articles');
-    $query = $articles->find();
+    $resultset = $articles->find()->all();
 
-    foreach ($query as $row) {
+    foreach ($resultset as $row) {
         // Each row is now an instance of our Article class.
         echo $row->title;
     }

--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -243,7 +243,7 @@ Once this association has been defined, find operations on the Users table can
 contain the Address record if it exists::
 
     // In a controller or table method.
-    $query = $users->find('all')->contain(['Addresses']);
+    $query = $users->find('all')->contain(['Addresses'])->all();
     foreach ($query as $user) {
         echo $user->address->street;
     }
@@ -332,7 +332,7 @@ Once this association has been defined, find operations on the Addresses table c
 contain the User record if it exists::
 
     // In a controller or table method.
-    $query = $addresses->find('all')->contain(['Users']);
+    $query = $addresses->find('all')->contain(['Users'])->all();
     foreach ($query as $address) {
         echo $address->user->username;
     }
@@ -458,7 +458,7 @@ Once this association has been defined, find operations on the Articles table
 can contain the Comment records if they exist::
 
     // In a controller or table method.
-    $query = $articles->find('all')->contain(['Comments']);
+    $query = $articles->find('all')->contain(['Comments'])->all();
     foreach ($query as $article) {
         echo $article->comments[0]->text;
     }
@@ -612,7 +612,7 @@ Once this association has been defined, find operations on the Articles table ca
 contain the Tag records if they exist::
 
     // In a controller or table method.
-    $query = $articles->find('all')->contain(['Tags']);
+    $query = $articles->find('all')->contain(['Tags'])->all();
     foreach ($query as $article) {
         echo $article->tags[0]->text;
     }

--- a/en/orm/behaviors/translate.rst
+++ b/en/orm/behaviors/translate.rst
@@ -388,7 +388,7 @@ TranslateBehavior does not substitute find conditions by default. You need to us
 ``translationField()`` method to compose find conditions on translated fields::
 
     $this->Articles->setLocale('es');
-    $data = $this->Articles->find()->where([
+    $query = $this->Articles->find()->where([
         $this->Articles->translationField('title') => 'Otro Título'
     ]);
 

--- a/en/orm/behaviors/tree.rst
+++ b/en/orm/behaviors/tree.rst
@@ -76,7 +76,8 @@ If you need to pass conditions you do so as per normal::
 
     $descendants = $categories
         ->find('children', ['for' => 1])
-        ->where(['name LIKE' => '%Foo%']);
+        ->where(['name LIKE' => '%Foo%'])
+        ->all();
 
     foreach ($descendants as $category) {
         echo $category->name . "\n";
@@ -99,7 +100,7 @@ only require a result set containing a single field from each level so you can
 display a list, in an HTML select for example, it is better to use the
 'treeList' finder::
 
-    $list = $categories->find('treeList');
+    $list = $categories->find('treeList')->toArray();
 
     // In a CakePHP template file:
     echo $this->Form->control('categories', ['options' => $list]);
@@ -152,7 +153,7 @@ of the tree. This is useful, for example, for adding the breadcrumbs list for
 a menu structure::
 
     $nodeId = 5;
-    $crumbs = $categories->find('path', ['for' => $nodeId]);
+    $crumbs = $categories->find('path', ['for' => $nodeId])->all();
 
     foreach ($crumbs as $crumb) {
         echo $crumb->name . ' > ';
@@ -295,7 +296,7 @@ The deletion of a node is based off of the lft and rght values of the entity. Th
 is important to note when looping through the various children of a node for
 conditional deletes::
 
-    $descendants = $teams->find('children', ['for' => 1]);
+    $descendants = $teams->find('children', ['for' => 1])->all();
 
     foreach ($descendants as $descendant) {
         $team = $teams->get($descendant->id); // search for the up-to-date entity object

--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -10,8 +10,9 @@ objects, entities represent individual rows or domain objects in your
 application. Entities contain methods to manipulate and
 access the data they contain. Fields can also be accessed as properties on the object.
 
-Entities are created for you each time you use ``find()`` on a table
-object.
+Entities are created for you each time you iterate the query instance returned 
+by ``find()`` of a table object or when you call ``all()`` or ``first()`` method
+of the query instance.
 
 Creating Entity Classes
 =======================

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -44,7 +44,7 @@ Selecting Rows From A Table
 
     $query = $this->getTableLocator()->get('Articles')->find();
 
-    foreach ($query as $article) {
+    foreach ($query->all() as $article) {
         debug($article->title);
     }
 
@@ -67,7 +67,7 @@ You can of course chain the methods you call on Query objects::
         ->where(['id !=' => 1])
         ->order(['created' => 'DESC']);
 
-    foreach ($query as $article) {
+    foreach ($query->all() as $article) {
         debug($article->created);
     }
 
@@ -133,7 +133,7 @@ Getting A List Of Values From A Column
 
     // Use the extract() method from the collections library
     // This executes the query as well
-    $allTitles = $articles->find()->extract('title');
+    $allTitles = $articles->find()->all()->extract('title');
 
     foreach ($allTitles as $title) {
         echo $title;
@@ -141,7 +141,7 @@ Getting A List Of Values From A Column
 
 You can also get a key-value list out of a query result::
 
-    $list = $articles->find('list');
+    $list = $articles->find('list')->all();
 
     foreach ($list as $id => $title) {
         echo "$id : $title"
@@ -161,7 +161,7 @@ can also do in a Query object::
 
     // Use the combine() method from the collections library
     // This is equivalent to find('list')
-    $keyValueList = $articles->find()->combine('id', 'title');
+    $keyValueList = $articles->find()->all()->combine('id', 'title');
 
     // An advanced example
     $results = $articles->find()
@@ -171,6 +171,7 @@ can also do in a Query object::
             $row->trimmedTitle = trim($row->title);
             return $row;
         })
+        ->all()
         ->combine('id', 'trimmedTitle') // combine() is another collection method
         ->toArray(); // Also a collections library method
 
@@ -209,7 +210,7 @@ you can use the ``select()`` method::
 
     $query = $articles->find();
     $query->select(['id', 'title', 'body']);
-    foreach ($query as $row) {
+    foreach ($query->all() as $row) {
         debug($row->title);
     }
 

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -105,7 +105,7 @@ execute until you start fetching rows, convert it to an array, or when the
     $query = $articles->find('all');
 
     // Iteration will execute the query.
-    foreach ($query as $row) {
+    foreach ($query->all() as $row) {
     }
 
     // Calling all() will execute the query
@@ -1100,6 +1100,7 @@ Finally, we can put these two functions together to do the grouping::
 
     $articlesByStatus = $articles->find()
         ->where(['author_id' => 1])
+        ->all()
         ->mapReduce($mapper, $reducer);
 
     foreach ($articlesByStatus as $status => $articles) {
@@ -1145,6 +1146,7 @@ Finally, we put everything together::
         ->where(['published' => true])
         ->andWhere(['published_date >=' => new DateTime('2014-01-01')])
         ->disableHydration()
+        ->all()
         ->mapReduce($mapper, $reducer)
         ->toArray();
 
@@ -1205,6 +1207,7 @@ And we supply our functions to a query::
 
     $fakeFriends = $friends->find()
         ->disableHydration()
+        ->all()
         ->mapReduce($mapper, $reducer)
         ->toArray();
 
@@ -1271,7 +1274,7 @@ than 20 times across all articles::
         }
     };
 
-    $articles->find('commonWords')->mapReduce($mapper);
+    $articles->find('commonWords')->all()->mapReduce($mapper);
 
 Removing All Stacked Map-reduce Operations
 ------------------------------------------

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -79,7 +79,7 @@ utilities bundled with CakePHP::
     {
         public function index()
         {
-            $this->set('users', $this->Users->find('all'));
+            $this->set('users', $this->Users->find()->all());
         }
 
         public function view($id)

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -251,7 +251,8 @@ the tree::
         public function index()
         {
             $categories = $this->Categories->find()
-                ->order(['lft' => 'ASC']);
+                ->order(['lft' => 'ASC'])
+                ->all();
             $this->set(compact('categories'));
             $this->viewBuilder()->setOption('serialize', ['categories']);
         }
@@ -358,7 +359,7 @@ it::
 
             // Just added the categories list to be able to choose
             // one category for an article
-            $categories = $this->Articles->Categories->find('treeList');
+            $categories = $this->Articles->Categories->find('treeList')->all();
             $this->set(compact('categories'));
         }
     }

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -88,7 +88,7 @@ articles. The code for that action would look like this::
     {
         public function index()
         {
-            $articles = $this->Articles->find('all');
+            $articles = $this->Articles->find()->all();
             $this->set(compact('articles'));
         }
     }
@@ -106,10 +106,11 @@ access that at www.example.com/articles/foobar.
     readable, understandable action names. You can map URLs to your code using
     :doc:`/development/routing` covered later on.
 
-The single instruction in the action uses ``set()`` to pass data
-from the controller to the view (which we'll create next). The line
-sets the view variable called 'articles' equal to the return value of
-the ``find('all')`` method of the ``ArticlesTable`` object.
+The single instruction in the action uses ``set()`` to pass resultset
+from the controller to the view (which we'll create next). The ``find()`` method 
+of the ``ArticlesTable`` object returns an instance of ``Cake\\ORM\\Query`` and
+calling its ``all()`` method returns as instance of ``Cake\\Collection\\CollectionInterface``
+which is set as a view variable called 'articles'.
 
 .. note::
 
@@ -213,7 +214,7 @@ you are very sneaky. Otherwise, we'll create it in the
     {
         public function index()
         {
-             $this->set('articles', $this->Articles->find('all'));
+            $this->set('articles', $this->Articles->find()->all());
         }
 
         public function view($id = null)
@@ -224,7 +225,7 @@ you are very sneaky. Otherwise, we'll create it in the
     }
 
 The ``set()`` call should look familiar. Notice we're using
-``get()`` rather than ``find('all')`` because we only really want
+``get()`` rather than ``find()`` because we only really want
 a single article's information.
 
 Notice that our view action takes a parameter: the ID of the article
@@ -279,7 +280,7 @@ First, start by creating an ``add()`` action in the
 
         public function index()
         {
-            $this->set('articles', $this->Articles->find('all'));
+            $this->set('articles', $this->Articles->find()->all());
         }
 
         public function view($id)

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -366,8 +366,9 @@ add the following::
 
         // Use the BookmarksTable to find tagged bookmarks.
         $bookmarks = $this->Bookmarks->find('tagged', [
-            'tags' => $tags
-        ]);
+                'tags' => $tags
+            ])
+            ->all();
 
         // Pass variables into the view template context.
         $this->set([
@@ -394,7 +395,8 @@ method has not been implemented yet, so let's do that. In
     public function findTagged(Query $query, array $options)
     {
         $bookmarks = $this->find()
-            ->select(['id', 'url', 'title', 'description']);
+            ->select(['id', 'url', 'title', 'description'])
+            ->all();
 
         if (empty($options['tags'])) {
             $bookmarks

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -238,7 +238,7 @@ like::
             }
             $this->Flash->error('The bookmark could not be saved. Please, try again.');
         }
-        $tags = $this->Bookmarks->Tags->find('list');
+        $tags = $this->Bookmarks->Tags->find('list')->all();
         $this->set(compact('bookmark', 'tags'));
         $this->viewBuilder()->setOption('serialize', ['bookmark']);
     }
@@ -262,7 +262,7 @@ edit form and action. Your ``edit()`` action from
             }
             $this->Flash->error('The bookmark could not be saved. Please, try again.');
         }
-        $tags = $this->Bookmarks->Tags->find('list');
+        $tags = $this->Bookmarks->Tags->find('list')->all();
         $this->set(compact('bookmark', 'tags'));
         $this->viewBuilder()->setOption('serialize', ['bookmark']);
     }
@@ -373,18 +373,18 @@ to **src/Model/Table/BookmarksTable.php**::
         $newTags = array_unique($newTags);
 
         $out = [];
-        $query = $this->Tags->find()
-            ->where(['Tags.title IN' => $newTags]);
+        $tags = $this->Tags->find()
+            ->where(['Tags.title IN' => $newTags])->all();
 
         // Remove existing tags from the list of new tags.
-        foreach ($query->extract('title') as $existing) {
+        foreach ($tags->extract('title') as $existing) {
             $index = array_search($existing, $newTags);
             if ($index !== false) {
                 unset($newTags[$index]);
             }
         }
         // Add existing tags.
-        foreach ($query as $tag) {
+        foreach ($tags as $tag) {
             $out[] = $tag;
         }
         // Add new tags.

--- a/en/tutorials-and-examples/cms/authorization.rst
+++ b/en/tutorials-and-examples/cms/authorization.rst
@@ -206,7 +206,7 @@ logged in user. Replace your add action with the following::
             }
             $this->Flash->error(__('Unable to add your article.'));
         }
-        $tags = $this->Articles->Tags->find('list');
+        $tags = $this->Articles->Tags->find('list')->all();
         $this->set(compact('article', 'tags'));
     }
 
@@ -233,7 +233,7 @@ Next we'll update the ``edit`` action. Replace the edit method with the followin
             }
             $this->Flash->error(__('Unable to update your article.'));
         }
-        $tags = $this->Articles->Tags->find('list');
+        $tags = $this->Articles->Tags->find('list')->all();
         $this->set(compact('article', 'tags'));
     }
 

--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -90,7 +90,7 @@ articles. First, update the ``add`` action to look like::
                 $this->Flash->error(__('Unable to add your article.'));
             }
             // Get a list of tags.
-            $tags = $this->Articles->Tags->find('list');
+            $tags = $this->Articles->Tags->find('list')->all();
 
             // Set tags to the view context
             $this->set('tags', $tags);
@@ -131,7 +131,7 @@ edit method should now look like::
         }
 
         // Get a list of tags.
-        $tags = $this->Articles->Tags->find('list');
+        $tags = $this->Articles->Tags->find('list')->all();
 
         // Set tags to the view context
         $this->set('tags', $tags);
@@ -192,8 +192,9 @@ add the following::
 
         // Use the ArticlesTable to find tagged articles.
         $articles = $this->Articles->find('tagged', [
-            'tags' => $tags
-        ]);
+                'tags' => $tags
+            ])
+            ->all();
 
         // Pass variables into the view template context.
         $this->set([
@@ -212,8 +213,9 @@ action using PHP's variadic argument::
     {
         // Use the ArticlesTable to find tagged articles.
         $articles = $this->Articles->find('tagged', [
-            'tags' => $tags
-        ]);
+                'tags' => $tags
+            ])
+            ->all();
 
         // Pass variables into the view template context.
         $this->set([
@@ -406,18 +408,19 @@ to **src/Model/Table/ArticlesTable.php**::
         $newTags = array_unique($newTags);
 
         $out = [];
-        $query = $this->Tags->find()
-            ->where(['Tags.title IN' => $newTags]);
+        $tags = $this->Tags->find()
+            ->where(['Tags.title IN' => $newTags])
+            ->all();
 
         // Remove existing tags from the list of new tags.
-        foreach ($query->extract('title') as $existing) {
+        foreach ($tags->extract('title') as $existing) {
             $index = array_search($existing, $newTags);
             if ($index !== false) {
                 unset($newTags[$index]);
             }
         }
         // Add existing tags.
-        foreach ($query as $tag) {
+        foreach ($tags as $tag) {
             $out[] = $tag;
         }
         // Add new tags.

--- a/en/views/cells.rst
+++ b/en/views/cells.rst
@@ -267,7 +267,7 @@ creating a cell object::
         public function display($userId)
         {
             $this->loadModel('Users');
-            $result = $this->Users->find('friends', ['for' => $userId]);
+            $result = $this->Users->find('friends', ['for' => $userId])->all();
             $this->set('favorites', $result);
         }
     }

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -483,7 +483,7 @@ If you want to create a ``select`` form field while using a *belongsTo* (or
 *hasOne*) relation, you can add the following to your UsersController
 (assuming your User *belongsTo* Group)::
 
-    $this->set('groups', $this->Users->Groups->find('list'));
+    $this->set('groups', $this->Users->Groups->find('list')->all());
 
 Afterwards, add the following to your view template::
 
@@ -492,7 +492,7 @@ Afterwards, add the following to your view template::
 To make a ``select`` box for a *belongsToMany* Groups association you can
 add the following to your UsersController::
 
-    $this->set('groups', $this->Users->Groups->find('list'));
+    $this->set('groups', $this->Users->Groups->find('list')->all());
 
 Afterwards, add the following to your view template::
 
@@ -504,7 +504,7 @@ data in a pluralised and
 `lower camelCased <https://en.wikipedia.org/wiki/Camel_case#Variations_and_synonyms>`_
 format as follows::
 
-    $this->set('userGroups', $this->UserGroups->find('list'));
+    $this->set('userGroups', $this->UserGroups->find('list')->all());
 
 .. note::
 

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -150,7 +150,7 @@ prefix::
 
     public function sitemap()
     {
-        $pages = $this->Pages->find();
+        $pages = $this->Pages->find()->all();
         $urls = [];
         foreach ($pages as $page) {
             $urls[] = [
@@ -235,7 +235,7 @@ mappings in your controller::
             $this->viewBuilder()->setClassName($formats[$format]);
 
             // Get data
-            $videos = $this->Videos->find('latest');
+            $videos = $this->Videos->find('latest')->all();
 
             // Set Data View
             $this->set(compact('videos'));


### PR DESCRIPTION
Passing query instances to the views is a bad practice IMO. Also it's often confusing to new users how fetching records with ORM works due to the implicit generation of resultset when iterating a query. Explicitly calling `Query::all()` makes things much clearer.

I can search for and replace other `find()` usage examples throughout the manual if this change is approved in general.