### PR TITLE
4.x - Fix outdated database type examples.

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -546,13 +546,15 @@ value object and into SQL expressions::
     namespace App\Database\Type;
 
     use App\Database\Point;
+    use Cake\Database\DriverInterface;
     use Cake\Database\Expression\FunctionExpression;
-    use Cake\Database\Type as BaseType;
+    use Cake\Database\ExpressionInterface;
+    use Cake\Database\Type\BaseType;
     use Cake\Database\Type\ExpressionTypeInterface;
 
     class PointType extends BaseType implements ExpressionTypeInterface
     {
-        public function toPHP($value, Driver $d)
+        public function toPHP($value, DriverInterface $d)
         {
             return Point::parse($value);
         }
@@ -568,7 +570,7 @@ value object and into SQL expressions::
             return null;
         }
 
-        public function toExpression($value)
+        public function toExpression($value): ExpressionInterface
         {
             if ($value instanceof Point) {
                 return new FunctionExpression(
@@ -583,6 +585,11 @@ value object and into SQL expressions::
                 return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
             // Handle other cases.
+        }
+
+        public function toDatabase($value, DriverInterface $driver)
+        {
+            return $value;
         }
     }
 

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -557,13 +557,15 @@ faire correspondre les données dans cet objet et les expressions SQL::
     namespace App\Database\Type;
 
     use App\Database\Point;
+    use Cake\Database\DriverInterface;
     use Cake\Database\Expression\FunctionExpression;
-    use Cake\Database\Type as BaseType;
+    use Cake\Database\ExpressionInterface;
+    use Cake\Database\Type\BaseType;
     use Cake\Database\Type\ExpressionTypeInterface;
 
     class PointType extends BaseType implements ExpressionTypeInterface
     {
-        public function toPHP($value, Driver $d)
+        public function toPHP($value, DriverInterface $d)
         {
             return Point::parse($value);
         }
@@ -579,7 +581,7 @@ faire correspondre les données dans cet objet et les expressions SQL::
             return null;
         }
 
-        public function toExpression($value)
+        public function toExpression($value): ExpressionInterface
         {
             if ($value instanceof Point) {
                 return new FunctionExpression(
@@ -593,7 +595,12 @@ faire correspondre les données dans cet objet et les expressions SQL::
             if (is_array($value)) {
                 return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
-            // Handle other cases.
+            // Manipulez d'autres cas.
+        }
+
+        public function toDatabase($value, DriverInterface $driver)
+        {
+            return $value;
         }
     }
 

--- a/ja/orm/database-basics.rst
+++ b/ja/orm/database-basics.rst
@@ -509,13 +509,15 @@ Type クラスが必要になります。 ::
     namespace App\Database\Type;
 
     use App\Database\Point;
+    use Cake\Database\DriverInterface;
     use Cake\Database\Expression\FunctionExpression;
-    use Cake\Database\Type as BaseType;
+    use Cake\Database\ExpressionInterface;
+    use Cake\Database\Type\BaseType;
     use Cake\Database\Type\ExpressionTypeInterface;
 
     class PointType extends BaseType implements ExpressionTypeInterface
     {
-        public function toPHP($value, Driver $d)
+        public function toPHP($value, DriverInterface $d)
         {
             return Point::parse($value);
         }
@@ -531,7 +533,7 @@ Type クラスが必要になります。 ::
             return null;
         }
 
-        public function toExpression($value)
+        public function toExpression($value): ExpressionInterface
         {
             if ($value instanceof Point) {
                 return new FunctionExpression(
@@ -546,6 +548,11 @@ Type クラスが必要になります。 ::
                 return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
             // その他のケースを処理
+        }
+
+        public function toDatabase($value, DriverInterface $driver)
+        {
+            return $value;
         }
     }
 

--- a/pt/orm/database-basics.rst
+++ b/pt/orm/database-basics.rst
@@ -504,13 +504,15 @@ mapear dados nesse objeto de valor e em expressões SQL::
     namespace App\Database\Type;
 
     use App\Database\Point;
+    use Cake\Database\DriverInterface;
     use Cake\Database\Expression\FunctionExpression;
-    use Cake\Database\Type as BaseType;
+    use Cake\Database\ExpressionInterface;
+    use Cake\Database\Type\BaseType;
     use Cake\Database\Type\ExpressionTypeInterface;
 
     class PointType extends BaseType implements ExpressionTypeInterface
     {
-        public function toPHP($value, Driver $d)
+        public function toPHP($value, DriverInterface $d)
         {
             return Point::parse($value);
         }
@@ -526,7 +528,7 @@ mapear dados nesse objeto de valor e em expressões SQL::
             return null;
         }
 
-        public function toExpression($value)
+        public function toExpression($value): ExpressionInterface
         {
             if ($value instanceof Point) {
                 return new FunctionExpression(
@@ -540,7 +542,12 @@ mapear dados nesse objeto de valor e em expressões SQL::
             if (is_array($value)) {
                 return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
-            // Handle other cases.
+            // Lidar com outros casos.
+        }
+
+        public function toDatabase($value, DriverInterface $driver)
+        {
+            return $value;
         }
     }
 

--- a/ru/orm/database-basics.rst
+++ b/ru/orm/database-basics.rst
@@ -510,13 +510,15 @@ json
     namespace App\Database\Type;
 
     use App\Database\Point;
+    use Cake\Database\DriverInterface;
     use Cake\Database\Expression\FunctionExpression;
-    use Cake\Database\Type as BaseType;
+    use Cake\Database\ExpressionInterface;
+    use Cake\Database\Type\BaseType;
     use Cake\Database\Type\ExpressionTypeInterface;
 
     class PointType extends BaseType implements ExpressionTypeInterface
     {
-        public function toPHP($value, Driver $d)
+        public function toPHP($value, DriverInterface $d)
         {
             return Point::parse($value);
         }
@@ -532,7 +534,7 @@ json
             return null;
         }
 
-        public function toExpression($value)
+        public function toExpression($value): ExpressionInterface
         {
             if ($value instanceof Point) {
                 return new FunctionExpression(
@@ -547,6 +549,11 @@ json
                 return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
             // Обработка других случаев.
+        }
+
+        public function toDatabase($value, DriverInterface $driver)
+        {
+            return $value;
         }
     }
 

--- a/tl/orm/database-basics.rst
+++ b/tl/orm/database-basics.rst
@@ -520,13 +520,15 @@ value object and into SQL expressions::
     namespace App\Database\Type;
 
     use App\Database\Point;
+    use Cake\Database\DriverInterface;
     use Cake\Database\Expression\FunctionExpression;
-    use Cake\Database\Type as BaseType;
+    use Cake\Database\ExpressionInterface;
+    use Cake\Database\Type\BaseType;
     use Cake\Database\Type\ExpressionTypeInterface;
 
     class PointType extends BaseType implements ExpressionTypeInterface
     {
-        public function toPHP($value, Driver $d)
+        public function toPHP($value, DriverInterface $d)
         {
             return Point::parse($value);
         }
@@ -542,7 +544,7 @@ value object and into SQL expressions::
             return null;
         }
 
-        public function toExpression($value)
+        public function toExpression($value): ExpressionInterface
         {
             if ($value instanceof Point) {
                 return new FunctionExpression(
@@ -557,6 +559,11 @@ value object and into SQL expressions::
                 return new FunctionExpression('POINT', [$value[0], $value[1]]);
             }
             // Handle other cases.
+        }
+
+        public function toDatabase($value, DriverInterface $driver)
+        {
+            return $value;
         }
     }
 


### PR DESCRIPTION
`Cake\Database\Type` has been turned into a pure factory, database types
should now extend from `\Cake\Database\Type\BaseType`.