### PR TITLE
4.x - Fix parsing in point database type examples.

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -519,8 +519,10 @@ PHP::
         // Factory method.
         public static function parse($value)
         {
-            // Parse the data from MySQL.
-            return new static($value[0], $value[1]);
+            // Parse the WKB data from MySQL.
+            $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
+
+            return new static($unpacked['lat'], $unpacked['long']);
         }
 
         public function __construct($lat, $long)

--- a/fr/orm/database-basics.rst
+++ b/fr/orm/database-basics.rst
@@ -518,20 +518,22 @@ Comme exemple, nous allons construire une simple classe Type pour manipuler le t
 données ``POINT`` de MysQL. Premièrement, nous allons définir un objet 'value' que nous
 allons pouvoir utiliser pour représenter les données de ``POINT`` en PHP::
 
-    // in src/Database/Point.php
+    // dans src/Database/Point.php
     namespace App\Database;
 
-    // Our value object is immutable.
+    // Notre objet de valeur est immuable.
     class Point
     {
         protected $_lat;
         protected $_long;
 
-        // Factory method.
+        // Méthode d'usine.
         public static function parse($value)
         {
-            // Parse the data from MySQL.
-            return new static($value[0], $value[1]);
+            // Analysez les données WKB de MySQL.
+            $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
+
+            return new static($unpacked['lat'], $unpacked['long']);
         }
 
         public function __construct($lat, $long)

--- a/ja/orm/database-basics.rst
+++ b/ja/orm/database-basics.rst
@@ -482,8 +482,10 @@ JSON データを変換してクエリーを作成します。
         // ファクトリーメソッド
         public static function parse($value)
         {
-            // MySQL からのデータをパース
-            return new static($value[0], $value[1]);
+            // MySQLからWKBデータを解析します。
+            $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
+
+            return new static($unpacked['lat'], $unpacked['long']);
         }
 
         public function __construct($lat, $long)

--- a/pt/orm/database-basics.rst
+++ b/pt/orm/database-basics.rst
@@ -465,20 +465,22 @@ expressão SQL. Como exemplo, nós vamos construir uma simples classe Type para
 manipular dados do tipo ``POINT`` do MySQL. Primeiramente, vamos definir um
 objeto 'value' que podemos usar para representar dados ``POINT`` no PHP::
 
-    // in src/Database/Point.php
+    // no src/Database/Point.php
     namespace App\Database;
 
-    // Our value object is immutable.
+    // Nosso objeto de valor é imutável.
     class Point
     {
         protected $_lat;
         protected $_long;
 
-        // Factory method.
+        // Método de fábrica.
         public static function parse($value)
         {
-            // Parse the data from MySQL.
-            return new static($value[0], $value[1]);
+            // Analise os dados WKB do MySQL.
+            $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
+
+            return new static($unpacked['lat'], $unpacked['long']);
         }
 
         public function __construct($lat, $long)

--- a/ru/orm/database-basics.rst
+++ b/ru/orm/database-basics.rst
@@ -482,8 +482,10 @@ json
         // Factory метод.
         public static function parse($value)
         {
-            // Парсинг данных из MySQL.
-            return new static($value[0], $value[1]);
+            // Разберите данные WKB из MySQL.
+            $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
+
+            return new static($unpacked['lat'], $unpacked['long']);
         }
 
         public function __construct($lat, $long)

--- a/tl/orm/database-basics.rst
+++ b/tl/orm/database-basics.rst
@@ -493,8 +493,10 @@ PHP::
         // Factory method.
         public static function parse($value)
         {
-            // Parse the data from MySQL.
-            return new static($value[0], $value[1]);
+            // Parse the WKB data from MySQL.
+            $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
+
+            return new static($unpacked['lat'], $unpacked['long']);
         }
 
         public function __construct($lat, $long)


### PR DESCRIPTION
For now database types do not support generating expressions for the `SELECT` clause, so unless one would manually select the fields using specific geometry function calls, MySQL would return a [**WKB**](https://dev.mysql.com/doc/refman/8.0/en/gis-data-formats.html#gis-wkb-format) string.

Not overly nice to have to do this parsing in PHP, but until support for generating select expressions is added to types it's good to have a working example in the docs.