### PR TITLE
Update validation.rst

### DIFF
--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -220,7 +220,7 @@ a validation rule::
 You can also use closures for validation rules::
 
     $validator->add('name', 'myRule', [
-        'rule' => function ($value, $context) {
+        'rule' => function ($value, array $context) {
             if ($value > 1) {
                 return true;
             }

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -220,8 +220,8 @@ a validation rule::
 You can also use closures for validation rules::
 
     $validator->add('name', 'myRule', [
-        'rule' => function ($data, $provider) {
-            if ($data > 1) {
+        'rule' => function ($value, $context) {
+            if ($value > 1) {
                 return true;
             }
             return 'Not a good value.';


### PR DESCRIPTION
Hi.

I think the proper parameters should be:

**$value** and **$context**

Because when we dump the parameters we got the following:

**dump($value):**
```
^ "10000"
```

**dump($context):**
```
^ array:4 [▼
  "newRecord" => true
  "data" => array:5 [▶]
  "field" => "ttx_amount"
  "providers" => array:3 [▶]
]
```

My suggestion is to change the parameter name so that developers will not get confused.

Please correct me if I'm wrong.

Thank you.