### PR TITLE
implementedEvents must return array

### DIFF
--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -171,7 +171,7 @@ as necessary. Our ``UserStatistics`` listener might start out like::
 
     class UserStatistic implements EventListenerInterface
     {
-        public function implementedEvents()
+        public function implementedEvents(): array
         {
             return [
                 'Model.Order.afterPlace' => 'updateBuyStatistic',


### PR DESCRIPTION
Return type of `array` must be set for `EventListenerInterface::implementedEvents`