### PR TITLE
4.x - Improve Windows compatibility in composer require command.

### DIFF
--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -119,7 +119,7 @@ install the Authentication Plugin:
 
 .. code-block:: bash
 
-    composer require cakephp/authentication:^2.0
+    composer require "cakephp/authentication:^2.0"
 
 Then add the following to your application's ``bootstrap()`` method::
 

--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -14,7 +14,7 @@ Use composer to install the Authentication Plugin:
 
 .. code-block:: bash
 
-    composer require cakephp/authentication:^2.0
+    composer require "cakephp/authentication:^2.0"
 
 
 Adding Password Hashing
@@ -23,7 +23,7 @@ Adding Password Hashing
 You need to have created the ``Controller``, ``Table``, ``Entity`` and
 templates for the ``users`` table in your database. You can do this manually
 like you did before for the ArticlesController, or you can use the bake shell
-to generate the classes for you using: 
+to generate the classes for you using:
 
 .. code-block:: bash
 

--- a/en/tutorials-and-examples/cms/authorization.rst
+++ b/en/tutorials-and-examples/cms/authorization.rst
@@ -12,7 +12,7 @@ Use composer to install the Auhorization Plugin:
 
 .. code-block:: bash
 
-    composer require cakephp/authorization:^2.0
+    composer require "cakephp/authorization:^2.0"
 
 Load the plugin by adding the following statement to the ``bootstrap()`` method in **src/Application.php**::
 
@@ -173,7 +173,7 @@ name::
 Lastly add the following to the ``tags``, ``view``, and ``index`` methods on the
 ``ArticlesController``::
 
-    // View, index and tags actions are public methods 
+    // View, index and tags actions are public methods
     // and don't require authorization checks.
     $this->Authorization->skipAuthorization();
 

--- a/fr/tutorials-and-examples/cms/authorization.rst
+++ b/fr/tutorials-and-examples/cms/authorization.rst
@@ -12,7 +12,7 @@ Utilisez composer pour installer le plugin Authorization:
 
 .. code-block:: bash
 
-    composer require cakephp/authorization:^2.0
+    composer require "cakephp/authorization:^2.0"
 
 Chargez le plugin en ajoutant le code suivant à la méthode ``bootstrap()`` dans le fichier **src/Application.php**::
 

--- a/ja/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/ja/tutorials-and-examples/blog-auth-example/auth.rst
@@ -120,7 +120,7 @@ composerを使ってAuthenticationプラグインをインストールします�
 
 .. code-block:: bash
 
-    composer require cakephp/authentication:^2.0
+    composer require "cakephp/authentication:^2.0"
 
 
 パスワードハッシュの追加

--- a/ja/tutorials-and-examples/cms/authentication.rst
+++ b/ja/tutorials-and-examples/cms/authentication.rst
@@ -13,7 +13,7 @@ composer を使用して認証プラグインをインストール
 
 .. code-block:: bash
 
-    composer require cakephp/authentication:^2.0
+    composer require "cakephp/authentication:^2.0"
 
 パスワードハッシュ化の追加
 --------------------------


### PR DESCRIPTION
On the Windows command line the caret is an escape character, thus
composer would not receive the literal character and always install
version 2.0.0.

This will not fix the problem in Powershell, which
would require using additional escape characters that are incompatible
with other environments.