### PR TITLE
Replace French string in English docs with en equivalent

### DIFF
--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -565,8 +565,7 @@ use the ``HttpsEnforcerMiddleware``::
         'disableOnDebug' => true,
     ]);
 
-Si une demande non-HTTP est reçue qui n'utilise pas GET
-une ``BadRequestException`` sera déclenchée.
+If a non-HTTP request is received that does not use GET a ``BadRequestException`` will be raised.
 
 .. meta::
     :title lang=en: Http Middleware


### PR DESCRIPTION
While browsing the en docs, I found this French string at the bottom. Translated it and replaced it.