### PR TITLE
Specify upgrade tool URL

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -23,7 +23,7 @@ Upgrade Tool
 While this document covers all the breaking changes and improvements made in
 CakePHP 3.0, we've also created a console application to help you complete some
 of the time consuming mechanical changes. You can `get the upgrade tool from
-github <https://github.com/cakephp/upgrade>`_.
+github <https://github.com/cakephp/upgrade/tree/3.x>`_.
 
 Application Directory Layout
 ============================


### PR DESCRIPTION
Changing the URL to the upgrade tool to go to the 3.x tag, since this doc is about upgrading from 2.x to 3.x.