### PR TITLE
Fix issue in Bookmarks documentation.

### DIFF
--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -402,16 +402,16 @@ method has not been implemented yet, so let's do that. In
     {
         if (empty($options['tags'])) {
             $bookmarks = $query
-                ->select(['Bookmarks.id','Bookmarks.url','Bookmarks.title',Bookmarks.description'])
+                ->select(['Bookmarks.id','Bookmarks.url','Bookmarks.title','Bookmarks.description'])
                 ->leftJoinWith('Tags')
                 ->where(['Tags.title IS' => null])
-                ->group(['Bookmarks.id'])
+                ->group(['Bookmarks.id']);
         } else {
             $bookmarks = $query
-                ->select(['Bookmarks.id','Bookmarks.url','Bookmarks.title',Bookmarks.description'])
+                ->select(['Bookmarks.id','Bookmarks.url','Bookmarks.title','Bookmarks.description'])
                 ->innerJoinWith('Tags')
                 ->where(['Tags.title IN ' => $options['tags']])
-                ->group(['Bookmarks.id'])
+                ->group(['Bookmarks.id']);
         }
         return $query;
     }

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -400,29 +400,19 @@ method has not been implemented yet, so let's do that. In
      */
     public function findTagged(Query $query, array $options)
     {
-        $columns = [
-            'Bookmarks.id',
-            'Bookmarks.url',
-            'Bookmarks.title',
-            'Bookmarks.description', 
-        ];
-        
         if (empty($options['tags'])) {
             $bookmarks = $query
-                ->select($columns)
+                ->select(['Bookmarks.id','Bookmarks.url','Bookmarks.title',Bookmarks.description'])
                 ->leftJoinWith('Tags')
                 ->where(['Tags.title IS' => null])
                 ->group(['Bookmarks.id'])
-                ->all();
         } else {
             $bookmarks = $query
-                ->select($columns)
+                ->select(['Bookmarks.id','Bookmarks.url','Bookmarks.title',Bookmarks.description'])
                 ->innerJoinWith('Tags')
                 ->where(['Tags.title IN ' => $options['tags']])
                 ->group(['Bookmarks.id'])
-                ->all();
         }
-        
         return $query;
     }
 

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -389,26 +389,41 @@ application's logic in the models. If you were to visit the
 method has not been implemented yet, so let's do that. In
 **src/Model/Table/BookmarksTable.php** add the following::
 
-    // The $query argument is a query builder instance.
-    // The $options array will contain the 'tags' option we passed
-    // to find('tagged') in our controller action.
+    /**
+     * The $query argument is a query builder instance.
+     * The $options array will contain the 'tags' option we passed
+     * to find('tagged') in our controller action
+     * @param \Cake\ORM\Query $query
+     * @param array $options
+     * @return \Cake\ORM\Query 
+     *  -Modified query object.
+     */
     public function findTagged(Query $query, array $options)
     {
-        $bookmarks = $this->find()
-            ->select(['id', 'url', 'title', 'description'])
-            ->all();
-
+        $columns = [
+            'Bookmarks.id',
+            'Bookmarks.url',
+            'Bookmarks.title',
+            'Bookmarks.description', 
+        ];
+        
         if (empty($options['tags'])) {
-            $bookmarks
+            $bookmarks = $query
+                ->select($columns)
                 ->leftJoinWith('Tags')
-                ->where(['Tags.title IS' => null]);
+                ->where(['Tags.title IS' => null])
+                ->group(['Bookmarks.id'])
+                ->all();
         } else {
-            $bookmarks
+            $bookmarks = $query
+                ->select($columns)
                 ->innerJoinWith('Tags')
-                ->where(['Tags.title IN ' => $options['tags']]);
+                ->where(['Tags.title IN ' => $options['tags']])
+                ->group(['Bookmarks.id'])
+                ->all();
         }
-
-        return $bookmarks->group(['Bookmarks.id']);
+        
+        return $query;
     }
 
 We just implemented a :ref:`custom finder method <custom-find-methods>`. This is


### PR DESCRIPTION
Hi, small mistake in the 4.x Bookmarks tutorial (I'm guessing it's just a little outdated).

src/Model/Table/BookmarksTable 
function findTagged

Issues:
$bookmarks couldn't be split over multiple statements.
 - I'm not used to CakePHP so perhaps there is a way, but the way the documentation laid it out was incorrect.

The return type was incorrect (RecordSet vs Query object).