### PR TITLE
Replace deprecated method

### DIFF
--- a/ja/core-libraries/form.rst
+++ b/ja/core-libraries/form.rst
@@ -27,28 +27,22 @@
 
     class ContactForm extends Form
     {
-
-        protected function _buildSchema(Schema $schema)
+        protected function _buildSchema(Schema $schema): Schema
         {
             return $schema->addField('name', 'string')
                 ->addField('email', ['type' => 'string'])
                 ->addField('body', ['type' => 'text']);
         }
 
-        protected function _buildValidator(Validator $validator)
+        public function validationDefault(Validator $validator): Validator
         {
-            $validator->add('name', 'length', [
-                    'rule' => ['minLength', 10],
-                    'message' => '名前は必須です'
-                ])->add('email', 'format', [
-                    'rule' => 'email',
-                    'message' => '有効なメールアドレスが要求されます',
-                ]);
+            $validator->minLength('name', 10)
+                ->email('email');
 
             return $validator;
         }
 
-        protected function _execute(array $data)
+        protected function _execute(array $data): bool
         {
             // メールを送信する
             return true;


### PR DESCRIPTION
Copied latest sample source code from `LANGUAGE: en` since:
 - `_buildSchema` method signature is updated (See 714107fd75c019031ae4526dbb2825ee7f66efd7)
 - `_buildValidator` method is deprecated (See 8d742add211db9f8ab7423260e2e34c29275f270)
 - `_execute` method signature is updated (See 714107fd75c019031ae4526dbb2825ee7f66efd7)