### PR TITLE
Add Entity::isEmpty() fix to migration notes

### DIFF
--- a/en/appendices/4-3-migration-guide.rst
+++ b/en/appendices/4-3-migration-guide.rst
@@ -37,7 +37,7 @@ change the semantics or behavior of methods.
 ORM
 ---
 
-- Aligned Entity::isEmpty() and Entity::hasValue() to treat '0' as a non-empty value. 
+- Aligned ``Entity::isEmpty()`` and ``Entity::hasValue()`` to treat '0' as a non-empty value. 
   This aligns the behavior with documentation and original intent.
 
 

--- a/en/appendices/4-3-migration-guide.rst
+++ b/en/appendices/4-3-migration-guide.rst
@@ -34,6 +34,12 @@ Behavior Changes
 While the following changes do not change the signature of any methods they do
 change the semantics or behavior of methods.
 
+ORM
+---
+
+- Aligned Entity::isEmpty() and Entity::hasValue() to treat '0' as a non-empty value. 
+  This aligns the behavior with documentation and original intent.
+
 
 Breaking Changes
 ================


### PR DESCRIPTION
This was fixed in 4.2.4 but seems like we should document in migration notes for people who update their code with point release.