### PR TITLE
Replace single quote in code example

### DIFF
--- a/en/core-libraries/internationalization-and-localization.rst
+++ b/en/core-libraries/internationalization-and-localization.rst
@@ -247,7 +247,7 @@ When using named placeholders, pass the placeholder and replacement in an array 
 for example::
 
     // echos:  Hi. My name is Sara. I'm 12 years old.
-    echo __('Hi. My name is {name}. I'm {age} years old.', ['name' => 'Sara', 'age' => 12]);
+    echo __("Hi. My name is {name}. I'm {age} years old.", ['name' => 'Sara', 'age' => 12]);
 
 Plurals
 -------


### PR DESCRIPTION
Replace the single quotes in the code example for double quotes because a single quote is used in the text string itself. The example code would result in a PHP error if used.