### PR TITLE
Update articles-controller.rst

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -440,11 +440,12 @@ using :ref:`a validator <validating-request-data>`::
     public function validationDefault(Validator $validator)
     {
         $validator
-            ->allowEmptyString('title', false)
+            ->allowEmptyString('title', 'Title cannot be empty', false)
             ->minLength('title', 10)
-            ->maxLength('title', 255)
-
-            ->allowEmptyString('body', false)
+            ->maxLength('title', 255);
+            
+        $validator
+            ->allowEmptyString('body', 'Body cannot be empty', false)
             ->minLength('body', 10);
 
         return $validator;


### PR DESCRIPTION
Bug fixes for validation in the tutorial. 

**Explanation:**
The parameter used is in the wrong sequence. The sequence of parameters should be like this `string $field`, `?string $message = null`, `$when = true`.

Reference:https://github.com/cakephp/cakephp/blob/113d451895aae3815c60acad4dc16ca1a4fbb98d/src/Validation/Validator.php#L876-L892

```php
    /**
     * Allows a field to be an empty string.
     *
     * This method is equivalent to calling allowEmptyFor() with EMPTY_STRING flag.
     *
     * @param string $field The name of the field.
     * @param string|null $message The message to show if the field is not
     * @param bool|string|callable $when Indicates when the field is allowed to be empty
     * Valid values are true, false, 'create', 'update'. If a callable is passed then
     * the field will allowed to be empty only when the callback returns true.
     * @return $this
     * @see \Cake\Validation\Validator::allowEmptyFor() For detail usage
     */
    public function allowEmptyString(string $field, ?string $message = null, $when = true)
    {
        return $this->allowEmptyFor($field, self::EMPTY_STRING, $when, $message);
    }

```

Thank you.