### PR TITLE
Update query-builder.rst

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -299,6 +299,15 @@ portable::
     $query = $articles->find();
     $query->select(['count' => $query->func()->count('*')]);
 
+Note that most of the functions accept an additional argument to specify the types to bind to the arguments and/or the return type,
+for example:
+
+
+    $query->select(['minDate' => $query->func()->min('date', ['text']);
+
+
+For details, see the documentation for [FunctionsBuilder](https://api.cakephp.org/4.1/class-Cake.Database.FunctionsBuilder.html)
+
 You can access existing wrappers for several SQL functions through ``Query::func()``:
 
 ``rand()``
@@ -368,6 +377,7 @@ is enabled.  If not marked as literal or identifier, arguments will be bound
 parameters allowing you to safely pass user data to the function.
 
 The above example generates something like this in MYSQL.
+
 
 .. code-block:: mysql
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -299,14 +299,12 @@ portable::
     $query = $articles->find();
     $query->select(['count' => $query->func()->count('*')]);
 
-Note that most of the functions accept an additional argument to specify the types to bind to the arguments and/or the return type,
-for example:
+Note that most of the functions accept an additional argument to specify the types
+to bind to the arguments and/or the return type, for example::
 
+    $query->select(['minDate' => $query->func()->min('date', ['date']);
 
-    $query->select(['minDate' => $query->func()->min('date', ['text']);
-
-
-For details, see the documentation for [FunctionsBuilder](https://api.cakephp.org/4.1/class-Cake.Database.FunctionsBuilder.html)
+For details, see the documentation for :php:class:`Cake\\Database\\FunctionsBuilder`.
 
 You can access existing wrappers for several SQL functions through ``Query::func()``:
 


### PR DESCRIPTION
I added a note under functions. ($query->func()) to let users know that they can bind types.  It's not obvious from this documentation and caused an issue for me with the function returning the wrong type.  I'm not sure I got the markdown right.