### PR TITLE
Update SimpleXML extension name

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -8,7 +8,7 @@ CakePHP has a few system requirements:
 - Minimum PHP |minphpversion| (|phpversion| supported).
 - mbstring PHP extension
 - intl PHP extension
-- simplexml PHP extension
+- SimpleXML PHP extension
 - PDO PHP extension
 
 .. note::


### PR DESCRIPTION
Using the official PHP 8.0 Apache docker image, I noticed that the _simplexml_ extension is called _SimpleXML_ , at least in that environment. While this might seem unimportant, checking the successfull installation of required extensions via a quick `php -m | grep simplexml` yields a negative result due to grep being case-sensitive, while `php -m | grep SimpleXML` reflects the correct status. With the CakePHP doc using the correct extension naming, such a short confusion might be avoided in the future. All other required extensions (_mbstring_, _intl_ and _PDO_) are cased correctly.