### PR TITLE
AuthComponent::user() fix translation

### DIFF
--- a/fr/controllers/components/authentication.rst
+++ b/fr/controllers/components/authentication.rst
@@ -793,8 +793,7 @@ Accéder à l'Utilisateur Connecté
 
 Une fois que l'utilisateur est connecté, vous avez souvent besoin
 d'information particulière à propos de l'utilisateur courant. Vous pouvez
-accéder à l'utilisateur en cours de connexion en utilisant
-``AuthComponent::user()``::
+accéder à l'utilisateur en cours de connexion de la façon suivante::
 
     // Depuis l'intérieur du controler
     $this->Auth->user('id');


### PR DESCRIPTION
Translation for AuthComponent::user() fix, this method not being static any longer.