### PR TITLE
Fix incorrect translation in 3-0-migration-guide.rst

### DIFF
--- a/fr/appendices/3-0-migration-guide.rst
+++ b/fr/appendices/3-0-migration-guide.rst
@@ -666,7 +666,7 @@ AuthComponent
 - La méthode ``login()`` a été retirée et remplacée par ``setUser()``.
   Pour connecter un utilisateur, vous devez maintenant appeler ``identify()``
   qui retourne les informations d'utilisateur en cas de succès d'identification
-  et utilise ensuite ``setUser()`` pour sauvegarder les informations de session
+  et utiliser ensuite ``setUser()`` pour sauvegarder les informations de session
   pour la persistance au cours des différentes requêtes.
 
 - ``BaseAuthenticate::_password()`` a été retirée. Utilisez ``PasswordHasher``


### PR DESCRIPTION
In french, the previous translation meant that identify() calls itself setUser(). The latter would be therefore unnecessary to log in.