### PR TITLE
Update 4-0-upgrade-guide.rst

### DIFF
--- a/en/appendices/4-0-upgrade-guide.rst
+++ b/en/appendices/4-0-upgrade-guide.rst
@@ -17,15 +17,14 @@ Once your application is running on latest CakePHP 3.x, enable deprecation warni
 
 Now that you can see all the warnings, make sure these are fixed before proceding with the upgrade.
 
-Upgrade to PHP 7.2
+Upgrade to PHP 7.3
 ==================
 
-If you are not running on **PHP 7.2 or higher**, you will need to upgrade PHP before updating CakePHP.
+If you are not running on **PHP 7.3 or higher**, you will need to upgrade PHP before updating CakePHP.
 
 .. note::
     CakePHP 4.0 requires **a minimum of PHP 7.2**.
-
-.. _upgrade-tool-use:
+    The upgrade tool makes use of nikic/rector, which requires **a minimum of PHP 7.3**.
 
 Use the Upgrade Tool
 ====================


### PR DESCRIPTION
For the upgrade tool on master branch, the rector package required php 7.3.* during the upgrade process.
I did not further investigate, if prior versions of the tool (other than master) are satisfied with php 7.2