### PR TITLE
Useless use declaration in code example

### DIFF
--- a/en/development/application.rst
+++ b/en/development/application.rst
@@ -54,7 +54,6 @@ global event listeners::
     // in src/Application.php
     namespace App;
 
-    use Cake\Core\Plugin;
     use Cake\Http\BaseApplication;
 
     class Application extends BaseApplication


### PR DESCRIPTION
use Cake\Core\Plugin was related to old Plugin::load('MyPlugin') instruction, which has been replaced by $this->addPlugin('MyPlugin').
The use instruction shall now be useless.