### PR TITLE
Support subdirectory installation in CMS Tutorial

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -112,6 +112,7 @@ In **src/Application.php**, add the following imports::
     use Authentication\AuthenticationServiceInterface;
     use Authentication\AuthenticationServiceProviderInterface;
     use Authentication\Middleware\AuthenticationMiddleware;
+    use Cake\Routing\Router;
     use Psr\Http\Message\ServerRequestInterface;
 
 Then implement the authentication interface on your ``Application`` class::
@@ -138,7 +139,7 @@ Then add the following::
     public function getAuthenticationService(ServerRequestInterface $request): AuthenticationServiceInterface
     {
         $authenticationService = new AuthenticationService([
-            'unauthenticatedRedirect' => '/users/login',
+            'unauthenticatedRedirect' => Router::url('/users/login'),
             'queryParam' => 'redirect',
         ]);
 
@@ -158,7 +159,7 @@ Then add the following::
                 'username' => 'email',
                 'password' => 'password',
             ],
-            'loginUrl' => '/users/login',
+            'loginUrl' => Router::url('/users/login'),
         ]);
 
         return $authenticationService;

--- a/fr/tutorials-and-examples/cms/authentication.rst
+++ b/fr/tutorials-and-examples/cms/authentication.rst
@@ -116,6 +116,7 @@ Dans **src/Application.php**, ajoutez les imports suivants::
     use Authentication\AuthenticationServiceInterface;
     use Authentication\AuthenticationServiceProviderInterface;
     use Authentication\Middleware\AuthenticationMiddleware;
+    use Cake\Routing\Router;
     use Psr\Http\Message\ServerRequestInterface;
 
 Ensuite, implémentez l'interface d'authentification pour votre classe ``Application```::
@@ -142,7 +143,7 @@ Puis ajoutez le code suivant::
     public function getAuthenticationService(ServerRequestInterface $request): AuthenticationServiceInterface
     {
         $authenticationService = new AuthenticationService([
-            'unauthenticatedRedirect' => '/users/login',
+            'unauthenticatedRedirect' => Router::url('/users/login'),
             'queryParam' => 'redirect',
         ]);
 
@@ -162,7 +163,7 @@ Puis ajoutez le code suivant::
                 'username' => 'email',
                 'password' => 'password',
             ],
-            'loginUrl' => '/users/login',
+            'loginUrl' => Router::url('/users/login'),
         ]);
 
         return $authenticationService;

--- a/ja/tutorials-and-examples/cms/authentication.rst
+++ b/ja/tutorials-and-examples/cms/authentication.rst
@@ -103,6 +103,7 @@ bcrypt は `PHPの推奨パスワードハッシュアルゴリズム <https://w
     use Authentication\AuthenticationServiceInterface;
     use Authentication\AuthenticationServiceProviderInterface;
     use Authentication\Middleware\AuthenticationMiddleware;
+    use Cake\Routing\Router;
     use Psr\Http\Message\ServerRequestInterface;
 
 次に ``Application`` クラスに認証インターフェースを実装します::
@@ -129,7 +130,7 @@ bcrypt は `PHPの推奨パスワードハッシュアルゴリズム <https://w
     public function getAuthenticationService(ServerRequestInterface $request): AuthenticationServiceInterface
     {
         $authenticationService = new AuthenticationService([
-            'unauthenticatedRedirect' => '/users/login',
+            'unauthenticatedRedirect' => Router::url('/users/login'),
             'queryParam' => 'redirect',
         ]);
 
@@ -149,7 +150,7 @@ bcrypt は `PHPの推奨パスワードハッシュアルゴリズム <https://w
                 'username' => 'email',
                 'password' => 'password',
             ],
-            'loginUrl' => '/users/login',
+            'loginUrl' => Router::url('/users/login'),
         ]);
 
         return $authenticationService;


### PR DESCRIPTION
This pull request...

- adds sub-directory installation support to the authentication page of CMS tutorial.
- updates only `en`, `fr` and `ja` languages, because other ones don't have corresponding page or the page is too old.

URLs

- en : https://book.cakephp.org/4/en/tutorials-and-examples/cms/authentication.html#adding-login
- fr : https://book.cakephp.org/4/fr/tutorials-and-examples/cms/authentication.html#ajouter-la-connexion
- ja : https://book.cakephp.org/4/ja/tutorials-and-examples/cms/authentication.html#id3