### PR TITLE
Update to reflect FrozenTime

### DIFF
--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -284,7 +284,7 @@ Likewise, it is possible to alter the default formatting string to be used for
     Date::setToStringFormat(\IntlDateFormatter::SHORT); // For any mutable Date
     FrozenDate::setToStringFormat(\IntlDateFormatter::SHORT); // For any immutable Date
 
-    // The same method exists on Date, FrozenDate, Time and FrozenTime
+    // The same method exists on Date, FrozenDate, and Time
     FrozenTime::setToStringFormat([
         \IntlDateFormatter::FULL,
         \IntlDateFormatter::SHORT

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -139,7 +139,6 @@ Formatting
 
 This method sets the default format used when converting an object to json::
 
-    
     Time::setJsonEncodeFormat('yyyy-MM-dd HH:mm:ss');  // For any mutable DateTime
     FrozenTime::setJsonEncodeFormat('yyyy-MM-dd HH:mm:ss');  // For any immutable DateTime
     Date::setJsonEncodeFormat('yyyy-MM-dd HH:mm:ss');  // For any mutable Date

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -112,7 +112,7 @@ You can create another instance with modified dates, through subtraction and add
 
     $time = FrozenTime::create(2021, 1, 31, 22, 11, 30);
     $newTime = $time->subDays(5)
-		->addHours(-2)
+        ->addHours(-2)
         ->addMonth(1);
     // Outputs '2/26/21, 8:11 PM'
     echo $newTime;

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -311,7 +311,7 @@ Formatting Relative Times
 Often it is useful to print times relative to the present::
 
     $time = new FrozenTime('Jan 31, 2021');
-    // On 12-Jun-21, outputs '4 months, 1 week, 6 days ago'
+    // On June 12, 2021, this would output '4 months, 1 week, 6 days ago'
     echo $time->timeAgoInWords(
         ['format' => 'MMM d, YYY', 'end' => '+1 year']
     );

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -292,7 +292,7 @@ Likewise, it is possible to alter the default formatting string to be used for
     // Outputs 'Sunday, January 31, 2021 at 10:11 PM'
     echo $time; 
 
-    // The same method exists on Date, FrozenDate, Time and FrozenTime
+    // The same method exists on Date, FrozenDate, and Time
     FrozenTime::setToStringFormat("EEEE, MMMM dd, yyyy 'at' KK:mm:ss a");
     // Outputs 'Sunday, January 31, 2021 at 10:11:30 PM'
     echo $time; 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -120,8 +120,8 @@ You can create another instance with modified dates, through subtraction and add
     echo $newTime;
 
     // Using strtotime strings.
-	$newTime = $time->modify('+1 month -5 days -2 hours');
-	// Outputs '2/26/21, 8:11 PM'
+    $newTime = $time->modify('+1 month -5 days -2 hours');
+    // Outputs '2/26/21, 8:11 PM'
     echo $newTime;
 
 You can get the internal components of a date by accessing its properties::

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -272,7 +272,6 @@ You can, however, modify this default at runtime::
     
     // Outputs '31 ene. 2021 22:11'
     echo $time->nice(); 
-    
 
 From now on, datetimes will be displayed in the Spanish preferred format unless
 a different locale is specified directly in the formatting method.

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -151,7 +151,6 @@ This method sets the default format used when converting an object to json::
     FrozenDate::setJsonEncodeFormat(static function($time) {
         return $time->format(DATE_ATOM);
     });
-    
 
 .. note::
     This method must be called statically.

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -78,7 +78,7 @@ In test cases, you can mock out ``now()`` using ``setTestNow()``::
 
     // Outputs '2021-01-31 22:11:30'
     $now = FrozenTime::now();
-	echo $now->i18nFormat('yyyy-MM-dd HH:mm:ss');
+    echo $now->i18nFormat('yyyy-MM-dd HH:mm:ss');
 
     // Outputs '2021-01-31 22:11:30'
     $now = FrozenTime::parse('now');
@@ -87,12 +87,12 @@ In test cases, you can mock out ``now()`` using ``setTestNow()``::
 Manipulation
 ============
 
-Once created, ``FrozenTime`` instances cannot be manipulated as it is immutable. You will need to create another instance. You can also use the methods provided by PHP's built-in ``DateTime`` class::
+Once created, ``FrozenTime`` instances cannot be manipulated or changed anymore, as they are immutable. Manipulating them will create new instance::
 
     $time = FrozenTime::now();
     
     // Create and reassign a new instance
-    $time = $now->year(2013)
+    $newTime = $time->year(2013)
         ->month(10)
         ->day(31);
     // Outputs '2013-10-31 22:11:30'

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -378,7 +378,7 @@ You can see if a ``FrozenTime`` instance falls within a given range using
     debug($time->isWithinNext('2 days'));
 
     // Within 2 next weeks. Outputs 'true'
-    var_export($time->isWithinNext('2 weeks'));
+    debug($time->isWithinNext('2 weeks'));
 
 .. php:method:: wasWithinLast($interval)
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -204,8 +204,6 @@ You can also format dates with non-gregorian calendars::
     
     // Outputs 'Sunday, Jumada II 18, 1442 AH at 10:11:30 PM Eastern Standard Time'
     echo $time->i18nFormat(\IntlDateFormatter::FULL, null, 'en-SA@calendar=islamic');
-    
-    
 
 The following calendar types are supported:
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -68,36 +68,39 @@ The ``FrozenTime`` class constructor can take any parameter that the internal ``
 PHP class can. When passing a number or numeric string, it will be interpreted
 as a UNIX timestamp.
 
-In test cases you can mock out ``now()`` using ``setTestNow()``::
+In test cases, you can mock out ``now()`` using ``setTestNow()``::
 
     // Fixate time.
     $time = new FrozenTime('2021-01-31 22:11:30');
     FrozenTime::setTestNow($time);
 
-    // Outputs '1/31/21, 10:11 PM'
-    echo FrozenTime::now();
+    // Outputs '2021-01-31 22:11:30'
+    $now = FrozenTime::now();
+	echo $now->i18nFormat('yyyy-MM-dd HH:mm:ss');
 
-    // Outputs '1/31/21, 10:11 PM'
-    echo FrozenTime::parse('now');
+    // Outputs '2021-01-31 22:11:30'
+    $now = FrozenTime::parse('now');
+	echo $now->i18nFormat('yyyy-MM-dd HH:mm:ss');
 
 Manipulation
 ============
 
-Once created, you cannot manipulate ``FrozenTime`` instances as it is immutable. Using setter methods will not work::
+Once created, ``FrozenTime`` instances cannot be manipulated as it is immutable. You will need to create another instance. You can also use the methods provided by PHP's built-in ``DateTime`` class::
 
-    $time = FrozenTime::create(2021, 1, 31, 22, 11, 30);
+    $time = FrozenTime::parse('2021-01-31 22:11:30');
+    
+    // Create another instance
+    $newTime = $time->setDate(2013, 10, 31);
+    // Outputs '2013-10-31 22:11:30'
+    echo $newTime->i18nFormat('yyyy-MM-dd HH:mm:ss');
+
+Using setter methods to manipulate ``FrozenTime`` instances will not work::
+
     $time->year(2013)
         ->month(10)
         ->day(31);
-    // Output '1/31/21, 10:11 PM'
-    echo $time;
-        
-
-You will need to create another instance. You can also use the methods provided by PHP's built-in ``DateTime`` class::
-
-    $newTime = $time->setDate(2013, 10, 31);
-    // Outputs '10/31/13, 10:11 PM'
-    echo $newTime;
+    // Outputs '2021-01-31 22:11:30'
+    echo $time->i18nFormat('yyyy-MM-dd HH:mm:ss');
 
 You can create another instance with modified dates, through subtraction and addition of their components::
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -164,7 +164,7 @@ This method sets the default format used when converting an object to json::
 A very common thing to do with ``Time`` instances is to print out formatted
 dates. CakePHP makes this a snap::
 
-	$time = FrozenTime::parse('2021-01-31 22:11:30');
+    $time = FrozenTime::parse('2021-01-31 22:11:30');
 
 	// Prints a localized datetime stamp. Outputs '1/31/21, 10:11 PM'
 	echo $time;

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -356,10 +356,10 @@ You can compare a ``FrozenTime`` instance with the present in a variety of ways:
 
     $time = new FrozenTime('+3 days');
 
-    var_export($time->isYesterday());
-    var_export($time->isThisWeek());
-    var_export($time->isThisMonth());
-    var_export($time->isThisYear());
+    debug($time->isYesterday());
+    debug($time->isThisWeek());
+    debug($time->isThisMonth());
+    debug($time->isThisYear());
 
 Each of the above methods will return ``true``/``false`` based on whether or
 not the ``FrozenTime`` instance matches the present.

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -378,7 +378,7 @@ You can see if a ``FrozenTime`` instance falls within a given range using
     var_export($time->isWithinNext('2 days'));
 
     // Within 2 next weeks. Outputs 'true'
-     var_export($time->isWithinNext('2 weeks'));
+    var_export($time->isWithinNext('2 weeks'));
 
 .. php:method:: wasWithinLast($interval)
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -166,8 +166,8 @@ dates. CakePHP makes this a snap::
 
     $time = FrozenTime::parse('2021-01-31 22:11:30');
 
-	// Prints a localized datetime stamp. Outputs '1/31/21, 10:11 PM'
-	echo $time;
+    // Prints a localized datetime stamp. Outputs '1/31/21, 10:11 PM'
+    echo $time;
 
     // Outputs '1/31/21, 10:11 PM' for the en-US locale
 	echo $time->i18nFormat();

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -425,7 +425,6 @@ As an example::
     // Outputs '2021-02-10 00:00:00'
     echo $newDate->format('Y-m-d H:i:s');
 
-    
 
 Attempts to modify the timezone on a ``FrozenDate`` instance are also ignored::
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -82,7 +82,7 @@ In test cases, you can mock out ``now()`` using ``setTestNow()``::
 
     // Outputs '2021-01-31 22:11:30'
     $now = FrozenTime::parse('now');
-	echo $now->i18nFormat('yyyy-MM-dd HH:mm:ss');
+    echo $now->i18nFormat('yyyy-MM-dd HH:mm:ss');
 
 Manipulation
 ============

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -375,7 +375,7 @@ You can see if a ``FrozenTime`` instance falls within a given range using
     $time = new FrozenTime('+3 days');
 
     // Within 2 days. Outputs 'false'
-    var_export($time->isWithinNext('2 days'));
+    debug($time->isWithinNext('2 days'));
 
     // Within 2 next weeks. Outputs 'true'
     var_export($time->isWithinNext('2 weeks'));

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -387,7 +387,7 @@ You can also compare a ``FrozenTime`` instance within a range in the past::
     $time = new FrozenTime('-72 hours');
     
     // Within past 2 days. Outputs 'false'
-    var_export($time->wasWithinLast('2 days'));
+    debug($time->wasWithinLast('2 days'));
 
     // Within past 3 days. Outputs 'true'
     var_export($time->wasWithinLast('3 days'));

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -40,9 +40,11 @@ For more details on Chronos please see `the API documentation
 Creating FrozenTime Instances
 =======================
 
-``FrozenTime`` are immutable objects that useful when you want to prevent
+``FrozenTime`` are immutable objects that are useful when you want to prevent
 accidental changes to data, or when you want to avoid order based dependency
-issues. Refer to ``Time`` instances for mutable objects. There are a few ways to create ``FrozenTime`` instances::
+issues. Refer to ``Time`` instances for mutable objects.
+
+There are a few ways to create ``FrozenTime`` instances::
 
     use Cake\I18n\FrozenTime;
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -173,7 +173,7 @@ dates. CakePHP makes this a snap::
     echo $time->i18nFormat();
 
     // Use the full date and time format. Outputs 'Sunday, January 31, 2021 at 10:11:30 PM Eastern Standard Time'
-	echo $time->i18nFormat(\IntlDateFormatter::FULL);
+    echo $time->i18nFormat(\IntlDateFormatter::FULL);
 
     // Use full date but short time format. Outputs 'Sunday, January 31, 2021 at 10:11 PM'
     echo $time->i18nFormat([\IntlDateFormatter::FULL, \IntlDateFormatter::SHORT]);

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -89,10 +89,12 @@ Manipulation
 
 Once created, ``FrozenTime`` instances cannot be manipulated as it is immutable. You will need to create another instance. You can also use the methods provided by PHP's built-in ``DateTime`` class::
 
-    $time = FrozenTime::parse('2021-01-31 22:11:30');
+    $time = FrozenTime::now();
     
-    // Create another instance
-    $newTime = $time->setDate(2013, 10, 31);
+    // Create and reassign a new instance
+    $time = $now->year(2013)
+        ->month(10)
+        ->day(31);
     // Outputs '2013-10-31 22:11:30'
     echo $newTime->i18nFormat('yyyy-MM-dd HH:mm:ss');
 

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -96,7 +96,11 @@ Once created, ``FrozenTime`` instances cannot be manipulated as it is immutable.
     // Outputs '2013-10-31 22:11:30'
     echo $newTime->i18nFormat('yyyy-MM-dd HH:mm:ss');
 
-Using setter methods to manipulate ``FrozenTime`` instances will not work::
+You can also use the methods provided by PHP's built-in ``DateTime`` class::
+
+    $time = $time->setDate(2013, 10, 31);
+
+Failing to reassign the new ``FrozenTime`` instances will result in the original, unmodified instance being used::
 
     $time->year(2013)
         ->month(10)

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -390,7 +390,7 @@ You can also compare a ``FrozenTime`` instance within a range in the past::
     debug($time->wasWithinLast('2 days'));
 
     // Within past 3 days. Outputs 'true'
-    var_export($time->wasWithinLast('3 days'));
+    debug($time->wasWithinLast('3 days'));
     
     // Within past 2 weeks. Outputs 'true'
     debug($time->wasWithinLast('2 weeks'));

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -170,7 +170,7 @@ dates. CakePHP makes this a snap::
     echo $time;
 
     // Outputs '1/31/21, 10:11 PM' for the en-US locale
-	echo $time->i18nFormat();
+    echo $time->i18nFormat();
 
     // Use the full date and time format. Outputs 'Sunday, January 31, 2021 at 10:11:30 PM Eastern Standard Time'
 	echo $time->i18nFormat(\IntlDateFormatter::FULL);

--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -393,7 +393,7 @@ You can also compare a ``FrozenTime`` instance within a range in the past::
     var_export($time->wasWithinLast('3 days'));
     
     // Within past 2 weeks. Outputs 'true'
-    var_export($time->wasWithinLast('2 weeks'));
+    debug($time->wasWithinLast('2 weeks'));
 
 .. end-time
 


### PR DESCRIPTION
Minor wordings update to reflect FrozenTime usage. Updated the examples with more outputs. 

`Day-month` using `31-01` to avoid format-confusion
`Hour:minute` using `22:11` to show 24 hour format