### PR TITLE
Update articles-controller.rst

### DIFF
--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -319,12 +319,12 @@ typically a URL-safe version of an article's title. We can use the
     use Cake\ORM\Table;
     // the Text class
     use Cake\Utility\Text;
-    // the EventInterface class
-    use Cake\Event\EventInterface;
+    // the Event class
+    use Cake\Event\Event;
 
     // Add the following method.
 
-    public function beforeSave(EventInterface $event, $entity, $options)
+    public function beforeSave(Event $event, $entity, $options)
     {
         if ($entity->isNew() && !$entity->slug) {
             $sluggedTitle = Text::slug($entity->title);


### PR DESCRIPTION
Using this example, after adding the beforeSave() function, when you add a new article and click save, you get this error:

Argument 1 passed to App\Model\Table\ArticlesTable::beforeSave() must be an instance of Cake\Event\EventInteface, instance of Cake\Event\Event given, called in /d/Jim/Documents/sources/cms/vendor/cakephp/cakephp/src/Event/EventManager.php on line 309

Changing the parameter from EventInterface to Event fixes the problem.