### PR TITLE
Added info about query returning same reference

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -198,7 +198,7 @@ of the following things occur:
 Until one of these conditions are met, the query can be modified without additional
 SQL being sent to the database. It also means that if a Query hasn't been
 evaluated, no SQL is ever sent to the database. Once executed, modifying and
-re-evaluating a query will result in additional SQL being run.
+re-evaluating a query will result in additional SQL being run. Calling the same query without modification multiple times will return same reference.
 
 If you want to take a look at what SQL CakePHP is generating, you can turn
 database :ref:`query logging <database-query-logging>` on.


### PR DESCRIPTION
From https://github.com/cakephp/docs/pull/7045

Info moved here, as it seems to be more appropriate.

Example :
    $first  = $query->first();
    $first->title = 'Modified Title';
    $firstAgain = $query->first();
    // Outputs 'Modified Title'
    echo $firstAgain->title;