### PR TITLE
Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -229,7 +229,7 @@ data::
     ];
 
 With no additional options the keys of ``$data`` will be the primary key of your
-table, while the values will be the 'displayField' of the table. The default ‘displayField’ of the table are ``title`` or ``name``. While, you can use the
+table, while the values will be the 'displayField' of the table. The default ‘displayField’ of the table is ``title`` or ``name``. While, you can use the
 ``setDisplayField()`` method on a table object to configure the display field of
 a table::
 

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -229,7 +229,7 @@ data::
     ];
 
 With no additional options the keys of ``$data`` will be the primary key of your
-table, while the values will be the 'displayField' of the table. You can use the
+table, while the values will be the 'displayField' of the table. The default ‘displayField’ of the table are ``title`` or ``name``. While, you can use the
 ``setDisplayField()`` method on a table object to configure the display field of
 a table::
 
@@ -237,7 +237,7 @@ a table::
     {
         public function initialize(array $config): void
         {
-            $this->setDisplayField('title');
+            $this->setDisplayField('label');
         }
     }
 
@@ -247,7 +247,7 @@ with the ``keyField`` and ``valueField`` options respectively::
     // In a controller or table method.
     $query = $articles->find('list', [
         'keyField' => 'slug',
-        'valueField' => 'title'
+        'valueField' => 'label'
     ]);
     $data = $query->toArray();
 
@@ -263,7 +263,7 @@ bucketed sets, or want to build ``<optgroup>`` elements with FormHelper::
     // In a controller or table method.
     $query = $articles->find('list', [
         'keyField' => 'slug',
-        'valueField' => 'title',
+        'valueField' => 'label',
         'groupField' => 'author_id'
     ]);
     $data = $query->toArray();


### PR DESCRIPTION
Improved the documents by mentioning the default value for 'displayField'
Source code reference: https://github.com/cakephp/cakephp/blob/master/src/ORM/Table.php#L676-L696
```php
    /**
     * Returns the display field.
     *
     * @return string|string[]|null
     */
    public function getDisplayField()
    {
        if ($this->_displayField === null) {
            $schema = $this->getSchema();
            $primary = (array)$this->getPrimaryKey();
            $this->_displayField = array_shift($primary);
            if ($schema->getColumn('title')) {
                $this->_displayField = 'title';
            }
            if ($schema->getColumn('name')) {
                $this->_displayField = 'name';
            }
        }

        return $this->_displayField;
    }
```