### PR TITLE
Fixing Number::config function name in example

### DIFF
--- a/en/core-libraries/number.rst
+++ b/en/core-libraries/number.rst
@@ -349,7 +349,7 @@ to various methods.
 
 Example::
 
-    Number::setConfig('en_IN', \NumberFormatter::CURRENCY, [
+    Number::config('en_IN', \NumberFormatter::CURRENCY, [
         'pattern' => '#,##,##0'
     ]);
 


### PR DESCRIPTION
I believe the correct function name is Number::config and not Number::setConfig