### PR TITLE
Add slug placeholder to entity routing example

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -1538,7 +1538,7 @@ rework when URLs require more parameters::
 
     // Create the route just like before.
     $routes->get(
-        '/view/{id}',
+        '/view/{id}/{slug}',
         ['controller' => 'Articles', 'action' => 'view'],
         'articles:view'
     );


### PR DESCRIPTION
The example descriptions talks about adding a `slug` to the URL but never uses it in the url.