### PR TITLE
Update entities.rst

### DIFF
--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -404,11 +404,11 @@ in the database. In those situations use the ``isNew()`` method::
     }
 
 If you are certain that an entity has already been persisted, you can use
-``isNew()`` as a setter::
+``setNew()`` as a setter::
 
-    $article->isNew(false);
+    $article->setNew(false);
 
-    $article->isNew(true);
+    $article->setNew(true);
 
 .. _lazy-load-associations:
 


### PR DESCRIPTION
According to the CakePHP source code: 
```php
    /**
     * Returns whether or not this entity has already been persisted.
     *
     * @return bool Whether or not the entity has been persisted.
     */
    public function isNew(): bool
    {
        if (func_num_args()) {
            deprecationWarning('Using isNew() as setter is deprecated. Use setNew() instead.');

            $this->setNew(func_get_arg(0));
        }

        return $this->_new;
    }
```
we should use `setNew()` instead

[ Source code reference:](https://github.com/cakephp/cakephp/blob/09e876f4b56fa33f1914cd3cc49cd402471899c5/src/Datasource/EntityTrait.php#L823-L837)