### PR TITLE
Adjust as per 5.x addHelper changes.

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -108,7 +108,8 @@ View
 - ``ViewBuilder`` options are now truly associative (string keys).
 - ``NumberHelper`` and ``TextHelper`` no longer accept an ``engine`` config.
 - ``ViewBuilder::setHelpers()`` parameter ``$merge`` was removed. Use ``ViewBuilder::addHelpers()`` instead.
-- Inside ``View::initialize()``, prefer using ``addHelper()`` instead of ``loadHelper()``. All configured helpers will be loaded afterwards, anyway.
+- Inside ``View::initialize()``, prefer using ``addHelper()``/``setHelper()`` instead of ``loadHelper()``.
+  All configured helpers will be loaded afterwards, anyway.
 
 New Features
 ============

--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -108,7 +108,7 @@ View
 - ``ViewBuilder`` options are now truly associative (string keys).
 - ``NumberHelper`` and ``TextHelper`` no longer accept an ``engine`` config.
 - ``ViewBuilder::setHelpers()`` parameter ``$merge`` was removed. Use ``ViewBuilder::addHelpers()`` instead.
-- Inside ``View::initialize()``, prefer using ``addHelper()``/``setHelper()`` instead of ``loadHelper()``.
+- Inside ``View::initialize()``, prefer using ``addHelper()`` instead of ``loadHelper()``.
   All configured helpers will be loaded afterwards, anyway.
 
 New Features

--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -108,7 +108,7 @@ View
 - ``ViewBuilder`` options are now truly associative (string keys).
 - ``NumberHelper`` and ``TextHelper`` no longer accept an ``engine`` config.
 - ``ViewBuilder::setHelpers()`` parameter ``$merge`` was removed. Use ``ViewBuilder::addHelpers()`` instead.
-
+- Inside ``View::initialize()``, prefer using ``addHelper()`` instead of ``loadHelper()``. All configured helpers will be loaded afterwards, anyway.
 
 New Features
 ============

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -171,7 +171,7 @@ assign a set of information to the view::
     $data = [
         'color' => 'pink',
         'type' => 'sugar',
-        'base_price' => 23.95
+        'base_price' => 23.95,
     ];
 
     // Make $color, $type, and $base_price

--- a/en/views.rst
+++ b/en/views.rst
@@ -54,7 +54,7 @@ is invoked at the end of a View’s constructor for this kind of use:
         public function initialize(): void
         {
             // Always enable the MyUtils Helper
-            $this->loadHelper('MyUtils');
+            $this->addHelper('MyUtils');
         }
     }
 

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -236,7 +236,7 @@ Like most components of CakePHP, helper classes have a few conventions:
   **src/View/Helper/LinkHelper.php**
 * Helper classes should be suffixed with ``Helper``. For example: ``LinkHelper``.
 * When referencing helper class names you should omit the ``Helper`` suffix. For
-  example: ``$this->addHelper('Link');`` or ``$this->loadHelper('Link');``.
+  example: ``$this->addHelper('Link');`` or ``$this->setHelper('Link');``.
 
 You'll also want to extend ``Helper`` to ensure things work correctly::
 

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -235,8 +235,8 @@ Like most components of CakePHP, helper classes have a few conventions:
 * Helper class files should be put in **src/View/Helper**. For example:
   **src/View/Helper/LinkHelper.php**
 * Helper classes should be suffixed with ``Helper``. For example: ``LinkHelper``.
-* When referencing helper class names you should omit the ``Helper`` suffix. For
-  example: ``$this->addHelper('Link');`` or ``$this->setHelper('Link');``.
+* When referencing helper names you should omit the ``Helper`` suffix. For
+  example: ``$this->addHelper('Link');`` or ``$this->loadHelper('Link');``.
 
 You'll also want to extend ``Helper`` to ensure things work correctly::
 

--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -30,30 +30,30 @@ helpers included in CakePHP, check out the chapter for each helper:
 Configuring Helpers
 ===================
 
-You load helpers in CakePHP by declaring them in a view class. An ``AppView``
-class comes with every CakePHP application and is the ideal place to load
-helpers::
+You configure helpers in CakePHP by declaring them in a view class. An ``AppView``
+class comes with every CakePHP application and is the ideal place to add
+helpers for global use::
 
     class AppView extends View
     {
         public function initialize(): void
         {
             parent::initialize();
-            $this->loadHelper('Html');
-            $this->loadHelper('Form');
-            $this->loadHelper('Flash');
+            $this->addHelper('Html');
+            $this->addHelper('Form');
+            $this->addHelper('Flash');
         }
     }
 
-To load helpers from plugins use the :term:`plugin syntax` used elsewhere in
+To add helpers from plugins use the :term:`plugin syntax` used elsewhere in
 CakePHP::
 
-    $this->loadHelper('Blog.Comment');
+    $this->addHelper('Blog.Comment');
 
-You don't have to explicitly load Helpers that come from CakePHP or your
+You don't have to explicitly add Helpers that come from CakePHP or your
 application. These helpers can be lazily loaded upon first use. For example::
 
-    // Loads the FormHelper if it has not already been loaded.
+    // Loads the FormHelper if it has not already been explicitly added/loaded.
     $this->Form->create($article);
 
 From within a plugin's views, plugin helpers can also be lazily loaded. For
@@ -63,7 +63,7 @@ same plugin.
 Conditionally Loading Helpers
 -----------------------------
 
-You can use the current action name to conditionally load helpers::
+You can use the current action name to conditionally add helpers::
 
     class AppView extends View
     {
@@ -71,12 +71,12 @@ You can use the current action name to conditionally load helpers::
         {
             parent::initialize();
             if ($this->request->getParam('action') === 'index') {
-                $this->loadHelper('ListPage');
+                $this->addHelper('ListPage');
             }
         }
     }
 
-You can also use your controller's ``beforeRender`` method to load helpers::
+You can also use your controller's ``beforeRender`` method to add helpers::
 
     class ArticlesController extends AppController
     {
@@ -119,6 +119,9 @@ your helper requires. For example::
     {
         use StringTemplateTrait;
 
+        /**
+         * @var array<string, mixed>
+         */
         protected $_defaultConfig = [
             'errorClass' => 'error',
             'templates' => [
@@ -166,7 +169,7 @@ implementation::
     {
         public function initialize(): void
         {
-            $this->loadHelper('Html', [
+            $this->addHelper('Html', [
                 'className' => 'MyHtml'
             ]);
         }
@@ -233,7 +236,7 @@ Like most components of CakePHP, helper classes have a few conventions:
   **src/View/Helper/LinkHelper.php**
 * Helper classes should be suffixed with ``Helper``. For example: ``LinkHelper``.
 * When referencing helper class names you should omit the ``Helper`` suffix. For
-  example: ``$this->loadHelper('Link');``.
+  example: ``$this->addHelper('Link');`` or ``$this->loadHelper('Link');``.
 
 You'll also want to extend ``Helper`` to ensure things work correctly::
 
@@ -265,7 +268,7 @@ just as you would in a controller::
 
     class LinkHelper extends Helper
     {
-        public $helpers = ['Html'];
+        protected $helpers = ['Html'];
 
         public function makeEdit($title, $url)
         {
@@ -291,7 +294,7 @@ load it in your views::
         public function initialize(): void
         {
             parent::initialize();
-            $this->loadHelper('Link');
+            $this->addHelper('Link');
         }
     }
 


### PR DESCRIPTION
Docs for
- https://github.com/cakephp/cakephp/pull/16120
- https://github.com/cakephp/cakephp/pull/16121

also consolidated a bit more the word add vs load
load is at runtime within code, where as is at config level.
Same as from controller side (where addHelper is used within actions etc).