### PR TITLE
remove unintended escape character

### DIFF
--- a/en/core-libraries/global-constants-and-functions.rst
+++ b/en/core-libraries/global-constants-and-functions.rst
@@ -212,7 +212,7 @@ Most of the following constants refer to paths in your application.
 
     Path to the temporary files directory.
 
-.. php:const:: WWW\_ROOT
+.. php:const:: WWW_ROOT
 
     Full path to the webroot.
 


### PR DESCRIPTION
It should be `WWW_ROOT` instead of `WWW\_ROOT`