### PR TITLE
viewRender of email configuration renamed to viewRenderer

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -109,8 +109,8 @@ following configuration keys are used:
 - ``'message'``: Content of message. Do not set this field if you are using rendered content.
 - ``'priority'``: Priority of the email as numeric value (usually from 1 to 5 with 1 being the highest).
 - ``'headers'``: Headers to be included. See ``Mailer::setHeaders()``.
-- ``'viewRender'``: If you are using rendered content, set the view classname.
-  See ``Mailer::viewRender()``.
+- ``'viewRenderer'``: If you are using rendered content, set the view classname.
+  See ``ViewBuilder::setClassName()``.
 - ``'template'``: If you are using rendered content, set the template name. See
   ``ViewBuilder::setTemplate()``.
 - ``'theme'``: Theme used when rendering template. See ``ViewBuilder::setTheme()``.


### PR DESCRIPTION
https://github.com/cakephp/cakephp/commit/ffa43b6eaec52fce74e153b27a99f1d717948ac2

Also, `viewRender()` was removed at 4.0.0.
https://github.com/cakephp/cakephp/commit/ee00209d6b45bf6890dc164ba633d92e9d17386d