### PR TITLE
Full path should be specified in file logger DSN

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -76,7 +76,7 @@ Configuration options can also be provided as a :term:`DSN` string. This is
 useful when working with environment variables or :term:`PaaS` providers::
 
     Log::setConfig('error', [
-        'url' => 'file:///?levels[]=warning&levels[]=error&file=error',
+        'url' => 'file:///full/path/to/logs/?levels[]=warning&levels[]=error&file=error',
     ]);
 
 .. warning::


### PR DESCRIPTION
`file:///` leads to `'path' => '/'` and normally cause `Failed to open stream: Permission denied`