### PR TITLE
further explain belongsToMany usage for the CounterCache behavior

### DIFF
--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -39,7 +39,7 @@ count for each article with the following::
 The CounterCache configuration should be a map of relation names and the
 specific configuration for that relation.
 
-A you see you need to add the behavior on the "other side" of the association
+As you see you need to add the behavior on the "other side" of the association
 where you actually want the field to be updated. In this example the behavior
 is added to the ``CommentsTable`` even though it updates the ``comment_count``
 field in the ``ArticlesTable``

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -42,7 +42,7 @@ specific configuration for that relation.
 As you see you need to add the behavior on the "other side" of the association
 where you actually want the field to be updated. In this example the behavior
 is added to the ``CommentsTable`` even though it updates the ``comment_count``
-field in the ``ArticlesTable``
+field in the ``ArticlesTable``.
 
 The counter's value will be updated each time an entity is saved or deleted.
 The counter **will not** be updated when you
@@ -141,7 +141,7 @@ First of all you need to add the ``through`` and ``cascadeCallbacks`` options to
     'through'          => 'CommentsArticles',
     'cascadeCallbacks' => true
 
-Also see :ref:`using-the-through-option` how to configure a custom join table
+Also see :ref:`using-the-through-option` how to configure a custom join table.
 
 The ``CommentsArticles`` is the name of the junction table classname.
 If you don't have it you should create it with the bake CLI tool.
@@ -153,4 +153,4 @@ with the same code as described above.::
         'Articles' => ['comments_count'],
     ]);
 
-Finally clear all caches with ``bin/cake cache clear_all`` and try it out
+Finally clear all caches with ``bin/cake cache clear_all`` and try it out.

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -31,12 +31,26 @@ count for each article with the following::
         }
     }
 
+
+.. note::
+
+    The column ``comment_count`` should exists in the ``articles`` table.
+
 The CounterCache configuration should be a map of relation names and the
 specific configuration for that relation.
 
-The counter's value will be updated each time an entity is saved or deleted. The
-counter **will not** be updated when you use ``updateAll()`` or ``deleteAll()``,
-or execute SQL you have written.
+A you see you need to add the behavior on the "other side" of the association
+where you actually want the field to be updated. In this example the behavior
+is added to the ``CommentsTable`` even though it updates the ``comment_count``
+field in the ``ArticlesTable``
+
+The counter's value will be updated each time an entity is saved or deleted.
+The counter **will not** be updated when you
+
+- save the entity without changing data or
+- use ``updateAll()`` or
+- use ``deleteAll()`` or
+- execute SQL you have written
 
 Advanced Usage
 ==============
@@ -120,5 +134,28 @@ then updates the counter of the *previously* associated item.
     It is possible though to make this work for ``belongsToMany`` associations.
     You need to enable the CounterCache behavior in a custom ``through`` table
     configured in association options and set the ``cascadeCallbacks`` configuration
-    option to true. See how to configure a custom join table
-    :ref:`using-the-through-option`.
+    option to true.
+
+Belongs to many Usage
+==============
+
+It is possible to use the CounterCache behavior in a ``belongsToMany`` association.
+First of all you need to add the ``through`` and ``cascadeCallbacks`` options to the
+``belongsToMany`` association
+
+    'through'          => 'CommentsArticles',
+    'cascadeCallbacks' => true
+
+Also see :ref:`using-the-through-option` how to configure a custom join table
+
+The ``CommentsArticles`` is the name of the junction table classname.
+If you don't have it you should create it with the bake CLI tool.
+
+In this ``src/Model/Table/CommentsArticlesTable.php`` you then need to add the behavior
+with the same code as described above.
+
+    $this->addBehavior( 'CounterCache', [
+      'Articles' => [ 'comments_count' ],
+    ] );
+
+Finally clear all caches with ``bin/cake cache clear_all`` and try it out

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -132,7 +132,7 @@ then updates the counter of the *previously* associated item.
     Articles table.
 
 Belongs to many Usage
-==============
+=====================
 
 It is possible to use the CounterCache behavior in a ``belongsToMany`` association.
 First of all you need to add the ``through`` and ``cascadeCallbacks`` options to the

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -34,7 +34,7 @@ count for each article with the following::
 
 .. note::
 
-    The column ``comment_count`` should exists in the ``articles`` table.
+    The column ``comment_count`` should exist in the ``articles`` table.
 
 The CounterCache configuration should be a map of relation names and the
 specific configuration for that relation.

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -149,8 +149,8 @@ If you don't have it you should create it with the bake CLI tool.
 In this ``src/Model/Table/CommentsArticlesTable.php`` you then need to add the behavior
 with the same code as described above.
 
-    $this->addBehavior( 'CounterCache', [
-      'Articles' => [ 'comments_count' ],
-    ] );
+    $this->addBehavior('CounterCache', [
+        'Articles' => ['comments_count'],
+    ]);
 
 Finally clear all caches with ``bin/cake cache clear_all`` and try it out

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -136,7 +136,7 @@ Belongs to many Usage
 
 It is possible to use the CounterCache behavior in a ``belongsToMany`` association.
 First of all you need to add the ``through`` and ``cascadeCallbacks`` options to the
-``belongsToMany`` association
+``belongsToMany`` association::
 
     'through'          => 'CommentsArticles',
     'cascadeCallbacks' => true

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -131,11 +131,6 @@ then updates the counter of the *previously* associated item.
     behavior to the ``CommentsTable`` in order to generate ``comment_count`` for
     Articles table.
 
-    It is possible though to make this work for ``belongsToMany`` associations.
-    You need to enable the CounterCache behavior in a custom ``through`` table
-    configured in association options and set the ``cascadeCallbacks`` configuration
-    option to true.
-
 Belongs to many Usage
 ==============
 

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -147,7 +147,7 @@ The ``CommentsArticles`` is the name of the junction table classname.
 If you don't have it you should create it with the bake CLI tool.
 
 In this ``src/Model/Table/CommentsArticlesTable.php`` you then need to add the behavior
-with the same code as described above.
+with the same code as described above.::
 
     $this->addBehavior('CounterCache', [
         'Articles' => ['comments_count'],

--- a/en/orm/behaviors/counter-cache.rst
+++ b/en/orm/behaviors/counter-cache.rst
@@ -135,7 +135,7 @@ Belongs to many Usage
 =====================
 
 It is possible to use the CounterCache behavior in a ``belongsToMany`` association.
-First of all you need to add the ``through`` and ``cascadeCallbacks`` options to the
+First, you need to add the ``through`` and ``cascadeCallbacks`` options to the
 ``belongsToMany`` association::
 
     'through'          => 'CommentsArticles',


### PR DESCRIPTION
As there has been a pretty long discussion in the support channel yesterday this PR adds a more elaborate example on how to use the CounterCache behavior with a belongsToMany association.

Also I added some missing info that e.g.

- the `comment_count` column should exists in the table
- saving an entity without changed data won't update the count