### PR TITLE
Fixed outdate example

### DIFF
--- a/fr/views/helpers/url.rst
+++ b/fr/views/helpers/url.rst
@@ -45,7 +45,7 @@ URL avec une extension::
 
 URL (commençant par '/') avec le chemin complet::
 
-    echo $this->Url->build('/posts', true);
+    echo $this->Url->build('/posts', ['fullBase' => true]);
 
     // Affiche
     http://somedomain.com/posts


### PR DESCRIPTION
The example I replaced was not working anymore in CakePhp 4.3 as the signature of the method UrlHelper::build() has changed.