### PR TITLE
Add a warning about BaseCommand::executeCommand() open files limit

### DIFF
--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -234,6 +234,12 @@ You may need to call other commands from your command. You can use
     $command = new OtherCommand($otherArgs);
     $this->executeCommand($command, ['--verbose', 'deploy']);
 
+.. note::
+
+    When calling ``executeCommand`` in a loop, it is recommended to pass in the
+    parent command's ``ConsoleIo`` instance as the optional 3rd argument to
+    avoid a potential "open files" limit that could occur in some environments.
+
 .. _console-integration-testing:
 
 Testing Commands


### PR DESCRIPTION
When using `BaseCommand::executeCommand()` in a loop/iteration, it's possible to reach a "Too many open files" (or similar) limitation because a new instance of `ConsoleIo` is created if not supplied as the 3rd argument, and that opens `stdin`, `stdout`, and `stderr`.

This adds a note about this potential edge-case usage.

See: https://github.com/cakephp/cakephp/issues/16259

It might be worth fixing, but for the time being, I think documenting this behavior is a good idea.

A few questions/notes:
1. I'm bad at writing documentation, so if the wording can be improved, please let me know.
2. This applies to 3.x as well.  Should I open a separate PR there, or is there a procedure for that?

Thanks!