### PR TITLE
Add warning about executeCommand/open files

### DIFF
--- a/en/console-and-shells/commands.rst
+++ b/en/console-and-shells/commands.rst
@@ -244,6 +244,14 @@ You may need to call other commands from your command. You can use
 .. versionadded:: 3.8.0
     ``executeCommand()`` was added.
 
+
+.. note::
+
+    When calling ``executeCommand`` in a loop, it is recommended to pass in the
+    parent command's ``ConsoleIo`` instance as the optional 3rd argument to
+    avoid a potential "open files" limit that could occur in some environments.
+
+
 .. _console-integration-testing:
 
 Testing Commands

--- a/en/console-and-shells/commands.rst
+++ b/en/console-and-shells/commands.rst
@@ -247,7 +247,7 @@ You may need to call other commands from your command. You can use
 
 .. note::
 
-    When calling ``executeCommand`` in a loop, it is recommended to pass in the
+    When calling ``executeCommand()`` in a loop, it is recommended to pass in the
     parent command's ``ConsoleIo`` instance as the optional 3rd argument to
     avoid a potential "open files" limit that could occur in some environments.
 


### PR DESCRIPTION
This is the same as https://github.com/cakephp/docs/pull/7304 but for 3.x as it applies here as well.