### PR TITLE
Add missing `()` per code review

### DIFF
--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -236,7 +236,7 @@ You may need to call other commands from your command. You can use
 
 .. note::
 
-    When calling ``executeCommand`` in a loop, it is recommended to pass in the
+    When calling ``executeCommand()`` in a loop, it is recommended to pass in the
     parent command's ``ConsoleIo`` instance as the optional 3rd argument to
     avoid a potential "open files" limit that could occur in some environments.
 


### PR DESCRIPTION
Same thing but in 4.x docs

refs: https://github.com/cakephp/docs/pull/7308