### PR TITLE
remove unstable API notice from DI Container docs

### DIFF
--- a/en/development/dependency-injection.rst
+++ b/en/development/dependency-injection.rst
@@ -1,10 +1,6 @@
 Dependency Injection
 ####################
 
-.. warning::
-    The Dependency Injection container is an experimental feature that is not
-    API stable yet.
-
 The CakePHP service container enables you to manage class dependencies for your
 application services through dependency injection. Dependency injection
 automatically "injects" an object's dependencies via the constructor without
@@ -33,9 +29,9 @@ A short example would be::
             }
         }
     }
-    
+
     // In src/Application.php
-    public function services(ContainerInterface $container): void 
+    public function services(ContainerInterface $container): void
     {
         $container->add(UsersService::class);
     }
@@ -54,21 +50,21 @@ Here is an example of an injected service inside a command::
         /** @var UsersService */
         public $users;
 
-        public function __construct(UsersService $users) 
+        public function __construct(UsersService $users)
         {
             parent::__construct();
             $this->users = $users;
         }
 
-        public function execute( Arguments $args, ConsoleIo $io ) 
+        public function execute( Arguments $args, ConsoleIo $io )
         {
             $valid = $this->users->check('all');
         }
-    
+
     }
-    
+
     // In src/Application.php
-    public function services( ContainerInterface $container ): void 
+    public function services( ContainerInterface $container ): void
     {
         $container
             ->add(CheckUsersCommand::class)
@@ -76,10 +72,10 @@ Here is an example of an injected service inside a command::
         $container->add(UsersService::class);
     }
 
-The injection process is a bit different here. Instead of adding the 
+The injection process is a bit different here. Instead of adding the
 ``UsersService`` to the container we first have to add the Command as
 a whole to the Container and add the ``UsersService`` as an argument.
-With that you can then access that service inside the constructor 
+With that you can then access that service inside the constructor
 of the command.
 
 Adding Services
@@ -183,7 +179,7 @@ injectable configuration reader::
 
     use Cake\Core\ServiceConfig;
 
-    // Use a shared instance 
+    // Use a shared instance
     $container->share(ServiceConfig::class);
 
 The ``ServiceConfig`` class provides a read-only view of all the data available
@@ -286,7 +282,7 @@ Any defined mocks will be replaced in your application's container during
 testing, and automatically injected into your controllers and commands. Mocks
 are cleaned up at the end of each test.
 
-Auto Wiring 
+Auto Wiring
 ===============
 
 Auto Wiring is turned off by default. To enable it::
@@ -295,14 +291,14 @@ Auto Wiring is turned off by default. To enable it::
     public function services(ContainerInterface $container): void
     {
         $container->delegate(
-            new \League\Container\ReflectionContainer() 
+            new \League\Container\ReflectionContainer()
         );
     }
-    
+
 While your dependencies will now be resolved automatically, this approach will not cache resolutions which can be detrimental to performance. To enable caching::
 
     $container->delegate(
-        new \League\Container\ReflectionContainer(true) // or consider using the value of Configure::read('debug') 
+        new \League\Container\ReflectionContainer(true) // or consider using the value of Configure::read('debug')
     );
 
 Read more about auto wiring in the `PHP League Container documentation <https://container.thephpleague.com/4.x/auto-wiring/>`_.

--- a/fr/development/dependency-injection.rst
+++ b/fr/development/dependency-injection.rst
@@ -1,10 +1,6 @@
 Injection de Dépendance
 #######################
 
-.. warning::
-    Le conteneur d'injection de dépendance est une fonctionnalité expérimentale
-    dont l'API n'est pas encore stabilisé.
-
 Le conteneur de services de CakePHP vous permet de gérer les dépendances de
 classes de vos services applicatifs par l'injection de dépendance. L'injection
 de dépendance "injecte" automatiquement les dépendances d'un objet dans son
@@ -35,9 +31,9 @@ Un exemple simple serait::
             }
         }
     }
-    
+
     // Dans src/Application.php
-    public function services(ContainerInterface $container): void 
+    public function services(ContainerInterface $container): void
     {
         $container->add(UsersService::class);
     }
@@ -56,28 +52,28 @@ Voici un exemple de service injecté dans une commande::
         /** @var UsersService */
         public $users;
 
-        public function __construct(UsersService $users) 
+        public function __construct(UsersService $users)
         {
             parent::__construct();
             $this->users = $users;
         }
 
-        public function execute( Arguments $args, ConsoleIo $io ) 
+        public function execute( Arguments $args, ConsoleIo $io )
         {
             $valid = $this->users->check('all');
         }
-    
+
     }
-    
+
     // Dans src/Application.php
-    public function services( ContainerInterface $container ): void 
+    public function services( ContainerInterface $container ): void
     {
         $container
             ->add(CheckUsersCommand::class)
             ->addArgument(UsersService::class);
         $container->add(UsersService::class);
     }
-    
+
 Ici, le processus d'injection est un peu différent. Au lieu d'ajouter le
 ``UsersService`` au conteneur, nous devons d'abord ajouter la commande comme un
 tout dans le <em>Container</em> et ajouter le ``UsersService`` en argument. Avec
@@ -295,7 +291,7 @@ conteneur par des Mocks ou des stubs::
     $this->removeMockService(StripeService::class);
 
 Tous les Mocks définis seront remplacés dans le conteneur de votre application
-pendant le test, et automatiquement injectés dans vos contrôleurs et vos 
+pendant le test, et automatiquement injectés dans vos contrôleurs et vos
 commandes. Les Mocks sont supprimés à la fin de chaque test.
 
 Auto Wiring
@@ -310,7 +306,7 @@ L'autowWiring est désactivé par défaut. Pour l'activer::
             new \League\Container\ReflectionContainer()
         );
     }
-    
+
 À présent, vos dépendances sont résolues automatiquement. Pour en savoir plus
 sur l'auto wiring, consultez la
 `PHP League Container documentation <https://container.thephpleague.com/4.x/auto-wiring/>`.

--- a/ja/development/dependency-injection.rst
+++ b/ja/development/dependency-injection.rst
@@ -1,9 +1,6 @@
 依存性の注入(DI)
 ####################
 
-.. warning::
-    DIコンテナはAPIがまだ安定していない実験的な特徴になります。
-
 CakePHPのサービスコンテナは依存性の注入(DI)によりアプリケーションのサービスのためのクラス依存性を管理できます。
 DIは手動でインスタンス化することなく、自動でコンストラクタを通してオブジェクトの依存性を"注入"します。
 
@@ -41,21 +38,21 @@ CakePHPはコントローラーでアクションを呼ぶ際サービスコン�
         /** @var UsersService */
         public $users;
 
-        public function __construct(UsersService $users) 
+        public function __construct(UsersService $users)
         {
             parent::__construct();
             $this->users = $users;
         }
 
-        public function execute( Arguments $args, ConsoleIo $io ) 
+        public function execute( Arguments $args, ConsoleIo $io )
         {
             $valid = $this->users->check('all');
         }
-    
+
     }
-    
+
     // In src/Application.php
-    public function services( ContainerInterface $container ): void 
+    public function services( ContainerInterface $container ): void
     {
         $container
             ->add(CheckUsersCommand::class)


### PR DESCRIPTION
The DI Container has been released in CakePHP 4.2 which has been out since 21 Dec 2020.

We are also using the latest league/container versions which doesn't seem to have any major changes planned in the future.

Therefore I would argue that the DI Container is API stable and can/should be used by everyone who wants to use it.

PS: My IDE seems to have removed some whitespaces in empty lines or at the end of lines 😅 