### PR TITLE
Fix wrong order of methods

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -1278,7 +1278,7 @@ than 20 times across all articles::
         }
     };
 
-    $articles->find('commonWords')->all()->mapReduce($mapper);
+    $articles->find('commonWords')->mapReduce($mapper)->all();
 
 Removing All Stacked Map-reduce Operations
 ------------------------------------------


### PR DESCRIPTION
`$articles->find('commonWords')->all()->mapReduce($mapper);` throws an error: `Call to undefined method ArrayIterator::mapReduce()` ... `->mapReduce($mapper)` needs to be called before `->all()` in order for this example to work.