### PR TITLE
4.x - Fix and sync table of contents.

### DIFF
--- a/en/Makefile
+++ b/en/Makefile
@@ -41,7 +41,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/$(LANG)
+	$(SPHINXBUILD) -b html -D "exclude_patterns=*-contents.rst" $(ALLSPHINXOPTS) $(BUILDDIR)/html/$(LANG)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/$(LANG)."
 

--- a/en/epub-contents.rst
+++ b/en/epub-contents.rst
@@ -8,7 +8,7 @@ Contents
 
     intro
     quickstart
-    appendices/4-0-migration-guide
+    appendices/migration-guides
     tutorials-and-examples
     contributing
 

--- a/en/pdf-contents.rst
+++ b/en/pdf-contents.rst
@@ -8,7 +8,7 @@ Contents
 
     intro
     quickstart
-    appendices/4-0-migration-guide
+    appendices/migration-guides
     tutorials-and-examples
     contributing
 


### PR DESCRIPTION
The HTML build should not include the EPUB and PDF TOCs, as this can
lead to incorrect outlines when the files aren't properly in sync.