### PR TITLE
4.x - Remove base TOC tree limits.

### DIFF
--- a/en/contents.rst
+++ b/en/contents.rst
@@ -7,7 +7,6 @@ Contents
     index
 
 .. toctree::
-    :maxdepth: 3
     :caption: Preface
 
     intro
@@ -18,7 +17,6 @@ Contents
     release-policy
 
 .. toctree::
-    :maxdepth: 3
     :caption: Getting Started
 
     installation
@@ -33,7 +31,6 @@ Contents
     orm
 
 .. toctree::
-    :maxdepth: 3
     :caption: Using CakePHP
 
     core-libraries/caching
@@ -55,7 +52,6 @@ Contents
     core-libraries/validation
 
 .. toctree::
-    :maxdepth: 3
     :caption: Utility Classes
 
     core-libraries/app
@@ -72,7 +68,6 @@ Contents
     core-libraries/xml
 
 .. toctree::
-    :maxdepth: 3
     :caption: Plugins & Packages
 
     standalone-packages
@@ -87,7 +82,6 @@ Contents
     Queue <https://book.cakephp.org/queue/1/en/>
 
 .. toctree::
-    :maxdepth: 3
     :caption: Other
 
     core-libraries/global-constants-and-functions

--- a/es/contents.rst
+++ b/es/contents.rst
@@ -7,7 +7,6 @@ Contenidos
    index
 
 .. toctree::
-    :maxdepth: 3
     :caption: Prólogo
 
     intro
@@ -17,7 +16,6 @@ Contenidos
     contributing
 
 .. toctree::
-    :maxdepth: 3
     :caption: Comenzando
 
     installation
@@ -30,7 +28,6 @@ Contenidos
     orm
 
 .. toctree::
-    :maxdepth: 3
     :caption: Usando CakePHP
 
     controllers/components/authentication
@@ -53,7 +50,6 @@ Contenidos
     core-libraries/validation
 
 .. toctree::
-    :maxdepth: 3
     :caption: Clases de utilidad
 
     core-libraries/app
@@ -69,7 +65,6 @@ Contenidos
     core-libraries/xml
 
 .. toctree::
-    :maxdepth: 3
     :caption: Plugins
 
     Bake <https://book.cakephp.org/bake/2/es/>
@@ -79,7 +74,6 @@ Contenidos
     elasticsearch
 
 .. toctree::
-    :maxdepth: 3
     :caption: Otros
 
     core-libraries/global-constants-and-functions

--- a/fr/contents.rst
+++ b/fr/contents.rst
@@ -7,7 +7,6 @@ Contenu
     index
 
 .. toctree::
-    :maxdepth: 3
     :caption: Préface
 
     intro
@@ -18,7 +17,6 @@ Contenu
     release-policy
 
 .. toctree::
-    :maxdepth: 3
     :caption: Pour Commencer
 
     installation
@@ -33,7 +31,6 @@ Contenu
     orm
 
 .. toctree::
-    :maxdepth: 3
     :caption: Généralités
 
     core-libraries/caching
@@ -55,7 +52,6 @@ Contenu
     core-libraries/validation
 
 .. toctree::
-    :maxdepth: 3
     :caption: Utilitaires
 
     core-libraries/app
@@ -72,7 +68,6 @@ Contenu
     core-libraries/xml
 
 .. toctree::
-    :maxdepth: 3
     :caption: Plugins & Packages
 
     standalone-packages
@@ -87,7 +82,6 @@ Contenu
     Queue <https://book.cakephp.org/queue/1/en/>
 
 .. toctree::
-    :maxdepth: 3
     :caption: Divers
 
     core-libraries/global-constants-and-functions

--- a/ja/contents.rst
+++ b/ja/contents.rst
@@ -7,7 +7,6 @@
     index
 
 .. toctree::
-    :maxdepth: 3
     :caption: はじめに
 
     intro
@@ -18,7 +17,6 @@
     release-policy
 
 .. toctree::
-    :maxdepth: 3
     :caption: CakePHP 入門
 
     installation
@@ -33,7 +31,6 @@
     orm
 
 .. toctree::
-    :maxdepth: 3
     :caption: 一般的なトピック
 
     core-libraries/caching
@@ -55,7 +52,6 @@
     core-libraries/validation
 
 .. toctree::
-    :maxdepth: 3
     :caption: ユーティリティ
 
     core-libraries/app
@@ -72,7 +68,6 @@
     core-libraries/xml
 
 .. toctree::
-    :maxdepth: 3
     :caption: プラグインとパッケージ
 
     standalone-packages
@@ -87,7 +82,6 @@
     Queue <https://book.cakephp.org/queue/1/en/>
 
 .. toctree::
-    :maxdepth: 3
     :caption: その他
 
     core-libraries/global-constants-and-functions

--- a/pt/contents.rst
+++ b/pt/contents.rst
@@ -7,7 +7,6 @@ Conteúdo
     index
 
 .. toctree::
-    :maxdepth: 3
     :caption: Prefácio
 
     intro
@@ -17,7 +16,6 @@ Conteúdo
     contributing
 
 .. toctree::
-    :maxdepth: 3
     :caption: Começando
 
     installation
@@ -31,7 +29,6 @@ Conteúdo
     orm
 
 .. toctree::
-    :maxdepth: 3
     :caption: Using CakePHP
 
     controllers/components/authentication
@@ -54,7 +51,6 @@ Conteúdo
     core-libraries/validation
 
 .. toctree::
-    :maxdepth: 3
     :caption: Classes utilitárias
 
     core-libraries/app
@@ -70,7 +66,6 @@ Conteúdo
     core-libraries/xml
 
 .. toctree::
-    :maxdepth: 3
     :caption: Plugins
 
     Bake <https://book.cakephp.org/bake/1/pt/>
@@ -80,7 +75,6 @@ Conteúdo
     Elasticsearch <https://book.cakephp.org/elasticsearch/3/pt/>
 
 .. toctree::
-    :maxdepth: 3
     :caption: Diversos
 
     core-libraries/global-constants-and-functions


### PR DESCRIPTION
This will generate a fully expanded table of contents (in the
`contents.html` file only) that can be used for figuring which files to
index for the search.