### PR TITLE
1.1 - Fix JS message files inclusion.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,12 @@ clean-website:
 build/html/%/_static:
 	mkdir -p build/html/$*/_static
 
+build/html/%/_static/css: build/html/%/_static
+	mkdir -p build/html/$*/_static/css
+
+build/html/%/_static/js: build/html/%/_static
+	mkdir -p build/html/$*/_static/js
+
 CSS_FILES = $(THEME_DIR)/themes/cakephp/static/css/fonts.css \
   $(THEME_DIR)/themes/cakephp/static/css/bootstrap.min.css \
   $(THEME_DIR)/themes/cakephp/static/css/font-awesome.min.css \
@@ -102,10 +108,10 @@ JS_FILES = $(THEME_DIR)/themes/cakephp/static/js/vendor.js \
   $(THEME_DIR)/themes/cakephp/static/js/mega-menu.js \
   $(THEME_DIR)/themes/cakephp/static/js/header.js \
   $(THEME_DIR)/themes/cakephp/static/js/search.js \
-  $(THEME_DIR)/themes/cakephp/static/js/search.messages.$*.js \
+  $(THEME_DIR)/themes/cakephp/static/js/search.messages.*.js \
   $(THEME_DIR)/themes/cakephp/static/js/inline-search.js \
   $(THEME_DIR)/themes/cakephp/static/js/standalone-search.js
 
-build/html/%/_static/js/dist.js: build/html/%/_static $(JS_FILES)
+build/html/%/_static/js/dist.js: build/html/%/_static/js $(JS_FILES)
 	# build js dependencies for distribution into '$@'
 	cat $(JS_FILES) > $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docutils==0.17.1
 sphinx==4.3.1
 sphinxcontrib-phpdomain==0.8.0
-cakephpsphinx>=0.1.47,<1.0
+cakephpsphinx>=0.1.48,<1.0


### PR DESCRIPTION
Need to include all files, referring to the value from `%` doesn't work
when `$(JS_FILES)` is referenced in a rule.