### PR TITLE
1.2 - Fix search version to match the index name and not require transforming.

### DIFF
--- a/config/all.py
+++ b/config/all.py
@@ -10,7 +10,7 @@ version = '1.2'
 release = '1.2'
 
 # Search index version
-search_version = '12'
+search_version = '1-2'
 
 version_name = ''
 


### PR DESCRIPTION
This way the search endpoint can just use the passed version as-is to
generate the index name.