### PR TITLE
1.3 - Fix search version to match the index name and not require transforming.

### DIFF
--- a/config/all.py
+++ b/config/all.py
@@ -9,7 +9,7 @@ version = '1.3'
 release = '1.3'
 
 # Search index version
-search_version = '13'
+search_version = '1-3'
 
 version_name = ''
 


### PR DESCRIPTION
This way the search endpoint can just use the passed version as-is to
generate the index name.