### PR TITLE
Add description of email log scope

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -123,7 +123,8 @@ following configuration keys are used:
 - ``'emailFormat'``: Format of email (html, text or both). See ``Mailer::setEmailFormat()``.
 - ``'transport'``: Transport configuration name. See :ref:`email-transport`.
 - ``'log'``: Log level to log the email headers and message. ``true`` will use
-  LOG_DEBUG. See also :ref:`logging-levels`.
+  LOG_DEBUG. See :ref:`logging-levels`. Note that logs will be emitted under the scope named ``email``.
+  See also :ref:`logging-scopes`.
 - ``'helpers'``: Array of helpers used in the email template.
   ``ViewBuilder::setHelpers()``/``ViewBuilder::addHelpers()``.
 

--- a/fr/core-libraries/email.rst
+++ b/fr/core-libraries/email.rst
@@ -139,7 +139,9 @@ sont utilisées:
 - ``'transport'``: Nom du Transport. Regardez
   :php:meth:`~Cake\\Mailer\\Email::configTransport()`.
 - ``'log'``: Niveau de Log pour connecter les headers de l'email headers et le
-  message. ``true`` va utiliser LOG_DEBUG. Regardez aussi :ref:`logging-levels`.
+  message. ``true`` va utiliser LOG_DEBUG. Regardez :ref:`logging-levels`.
+  Notez que les logs seront émis sous le scope nommé ``email``.
+  Regardez aussi :ref:`logging-scopes`.
 - ``'helpers'``: Tableau de helpers utilisés dans le template email.
   ``ViewBuilder::setHelpers()``/``ViewBuilder::addHelpers()``
 

--- a/ja/core-libraries/email.rst
+++ b/ja/core-libraries/email.rst
@@ -117,6 +117,7 @@ Mailer
 - ``'transport'``: トランスポート名。 トランスポート設定を参照。
 - ``'log'``: メールヘッダーとメッセージをログに記録するログレベル。
   ``true`` なら LOG_DEBUG を使用します。 :ref:`logging-levels` を参照。
+  ログはスコープ名 ``email`` で出力されることに注意してください。 :ref:`logging-scopes` を参照。
 - ``'helpers'``: メールテンプレート内で使用するヘルパーの配列。 ``ViewBuilder::setHelpers()`` 。
 
 .. note::

--- a/pt/core-libraries/email.rst
+++ b/pt/core-libraries/email.rst
@@ -120,8 +120,8 @@ necessários. As seguintes chaves de configuração são usadas:
 - ``'emailFormat'``: Formato de email (html, text ou ambos). Veja ``Mailer::setEmailFormat()``.
 - ``'transport'``: Nome da configuração de Transporte. Veja :ref:`email-transport`.
 - ``'log'``: Nível de logs para registrar os cabeçalhos e a mensagem do e-mail. ``true`` usará LOG_DEBUG. 
-  Veja :ref:`logging-levels`. Observe que os logs serão emitidos sob o escopo chamado ``email``.
-  Veja também :ref:`logging-scopes`.
+  Veja `logging-levels`. Observe que os logs serão emitidos sob o escopo chamado ``email``.
+  Veja também `logging-scopes`.
 - ``'helpers'``: Conjunto de auxiliares usados no template de e-mail. ``ViewBuilder::setHelpers()``.
 
 .. note::

--- a/pt/core-libraries/email.rst
+++ b/pt/core-libraries/email.rst
@@ -120,7 +120,8 @@ necessários. As seguintes chaves de configuração são usadas:
 - ``'emailFormat'``: Formato de email (html, text ou ambos). Veja ``Mailer::setEmailFormat()``.
 - ``'transport'``: Nome da configuração de Transporte. Veja :ref:`email-transport`.
 - ``'log'``: Nível de logs para registrar os cabeçalhos e a mensagem do e-mail. ``true`` usará LOG_DEBUG. 
-  Veja também `logging-levels`.
+  Veja :ref:`logging-levels`. Observe que os logs serão emitidos sob o escopo chamado ``email``.
+  Veja também :ref:`logging-scopes`.
 - ``'helpers'``: Conjunto de auxiliares usados no template de e-mail. ``ViewBuilder::setHelpers()``.
 
 .. note::


### PR DESCRIPTION
I spent an hour to find out how to get logs of `Mailer`. So I would like to add description of log scope.

- English : written by me
- Japanese : written by me (I'm a Japanese)
- French : translated from English using Google Translate
- Portuguees : translated from English using Google Translate
  - Note that `ref` link is not working in Portuguees because this version does not have enough content in `Logging` page.
- Español : not included in this PR because this version does not have enough content in `Email` page.