### PR TITLE
Backport changes to improve viewClasses docs from 5.x

### DIFF
--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -282,6 +282,8 @@ This would render **plugins/Users/templates/UserDetails/custom_file.php**
 Content Type Negotiation
 ========================
 
+.. php:method:: viewClasses()
+
 Controllers can define a list of view classes they support. After the
 controller's action is complete CakePHP will use the view list to perform
 content-type negotiation. This enables your application to re-use the same

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -30,7 +30,7 @@ Configuring Components
 
 Many of the core components require configuration. Some examples of components
 requiring configuration are :doc:`/controllers/components/security` and
-:doc:`/controllers/components/request-handling`.  Configuration for these components,
+:doc:`/controllers/components/form-protection`.  Configuration for these components,
 and for components in general, is usually done via ``loadComponent()`` in your
 Controller's ``initialize()`` method or via the ``$components`` array::
 
@@ -39,10 +39,10 @@ Controller's ``initialize()`` method or via the ``$components`` array::
         public function initialize(): void
         {
             parent::initialize();
-            $this->loadComponent('RequestHandler', [
-                'viewClassMap' => ['json' => 'AppJsonView'],
+            $this->loadComponent('FormProtection', [
+                'unlockedActions' => ['index'],
             ]);
-            $this->loadComponent('Security', ['blackholeCallback' => 'blackhole']);
+            $this->loadComponent('Csrf');
         }
 
     }
@@ -53,14 +53,14 @@ also be expressed as::
 
     public function beforeFilter(EventInterface $event)
     {
-        $this->RequestHandler->setConfig('viewClassMap', ['rss' => 'MyRssView']);
+        $this->FormProtection->setConfig('unlockedActions', ['index']);
     }
 
 Like helpers, components implement ``getConfig()`` and ``setConfig()`` methods
 to read and write configuration data::
 
     // Read config data.
-    $this->RequestHandler->getConfig('viewClassMap');
+    $this->FormProtection->getConfig('unlockedActions');
 
     // Set config
     $this->Csrf->setConfig('cookieName', 'token');

--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -645,10 +645,6 @@ Response
 It encapsulates a number of features and functionality for generating HTTP
 responses in your application. It also assists in testing, as it can be
 mocked/stubbed allowing you to inspect headers that will be sent.
-Like :php:class:`Cake\\Http\\ServerRequest`, :php:class:`Cake\\Http\\Response`
-consolidates a number of methods previously found on :php:class:`Controller`,
-:php:class:`RequestHandlerComponent` and :php:class:`Dispatcher`. The old
-methods are deprecated in favour of using :php:class:`Cake\\Http\\Response`.
 
 ``Response`` provides an interface to wrap the common response-related
 tasks such as:

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -193,16 +193,6 @@ prefix. You could create the following class::
     class ErrorController extends AppController
     {
         /**
-         * Initialization hook method.
-         *
-         * @return void
-         */
-        public function initialize(): void
-        {
-            $this->loadComponent('RequestHandler');
-        }
-
-        /**
          * beforeRender callback.
          *
          * @param \Cake\Event\EventInterface $event Event.

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1213,12 +1213,13 @@ JSON is a friendly and common format to use when building a web service.
 Testing the endpoints of your web service is very simple with CakePHP. Let us
 begin with a simple example controller that responds in JSON::
 
+    use Cake\View\JsonView;
+
     class MarkersController extends AppController
     {
-        public function initialize(): void
+        public function viewClasses(): array
         {
-            parent::initialize();
-            $this->loadComponent('RequestHandler');
+            return [JsonView::class];
         }
 
         public function view($id)

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -261,7 +261,6 @@ In you ``AppController`` class add the following code::
     public function initialize(): void
     {
         parent::initialize();
-        $this->loadComponent('RequestHandler');
         $this->loadComponent('Flash');
 
         // Add this line to check authentication result and lock your site

--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -171,7 +171,6 @@ In your ``AppController`` class add the following code::
     public function initialize(): void
     {
         parent::initialize();
-        $this->loadComponent('RequestHandler');
         $this->loadComponent('Flash');
 
         // Add this line to check authentication result and lock your site

--- a/en/views/json-and-xml-views.rst
+++ b/en/views/json-and-xml-views.rst
@@ -1,14 +1,10 @@
 JSON and XML views
 ##################
 
-The ``JsonView`` and ``XmlView``
-let you create JSON and XML responses, and integrate with the
-:php:class:`Cake\\Controller\\Component\\RequestHandlerComponent`.
+The ``JsonView`` and ``XmlView`` integration with CakePHP's
+:ref:`controller-viewclasses` features and  let you create JSON and XML responses.
 
-By enabling ``RequestHandlerComponent`` in your application, and enabling
-support for the ``json`` and/or ``xml`` extensions, you can automatically
-leverage the new view classes. ``JsonView`` and ``XmlView`` will be referred to
-as data views for the rest of this page.
+These view classes are most commonly used alongside :php:meth:`\Cake\Controller\Controller::viewClasses()`.
 
 There are two ways you can generate data views. The first is by using the
 ``serialize`` option, and the second is by creating normal template files.
@@ -16,20 +12,16 @@ There are two ways you can generate data views. The first is by using the
 Enabling Data Views in Your Application
 =======================================
 
-Before you can use the data view classes, you'll first need to load the
-:php:class:`Cake\\Controller\\Component\\RequestHandlerComponent` in your
-controller::
+In your ``AppController`` or in an individual controller you can implement the
+``viewClasses()`` method and provide all of the views you want to support::
 
-    public function initialize(): void
+    use Cake\View\JsonView;
+    use Cake\View\XmlView;
+
+    public function viewClasses(): array
     {
-        ...
-        $this->loadComponent('RequestHandler');
+        return [JsonView::class, XmlView::class];
     }
-
-This can be done in your ``AppController`` and will enable automatic view class
-switching on content types. You can also set the component up with the
-``viewClassMap`` setting, to map types to your custom classes and/or map other
-data types.
 
 You can optionally enable the json and/or xml extensions with
 :ref:`file-extensions`. This will allow you to access the ``JSON``, ``XML`` or
@@ -40,6 +32,10 @@ By default, when not enabling :ref:`file-extensions`, the request, the ``Accept`
 header is used for, selecting which type of format should be rendered to the
 user. An example ``Accept`` format that is used to render ``JSON`` responses is
 ``application/json``.
+
+.. versionchanged:: 4.4.0
+   Prior to 4.4.0, You need to use the ``RequestHandlerComponent`` to do
+   content-type negotitation.
 
 Using Data Views with the Serialize Key
 =======================================
@@ -54,14 +50,16 @@ generating the response, you should use template files. The value of
 ``serialize`` can be either a string or an array of view variables to
 serialize::
 
+
     namespace App\Controller;
+
+    use Cake\View\JsonView;
 
     class ArticlesController extends AppController
     {
-        public function initialize(): void
+        public function viewClasses(): array
         {
-            parent::initialize();
-            $this->loadComponent('RequestHandler');
+            return [JsonView::class];
         }
 
         public function index()
@@ -77,12 +75,13 @@ You can also define ``serialize`` as an array of view variables to combine::
 
     namespace App\Controller;
 
+    use Cake\View\JsonView;
+
     class ArticlesController extends AppController
     {
-        public function initialize(): void
+        public function viewClasses(): array
         {
-            parent::initialize();
-            $this->loadComponent('RequestHandler');
+            return [JsonView::class];
         }
 
         public function index()
@@ -200,13 +199,11 @@ response in the function name provided. If you want to use a custom query string
 parameter name instead of "callback" set ``_jsonp`` to required name instead of
 ``true``.
 
-Example Usage
-=============
+Choosing a View Class
+=====================
 
-While the :doc:`RequestHandlerComponent
-</controllers/components/request-handling>` can automatically set the view based
-on the request content-type or extension, you could also handle view
-mappings in your controller::
+While you can use the ``viewClasses`` hook method most of the time, if you want
+total control over view class selection you can directly choose the view class::
 
     // src/Controller/VideosController.php
     namespace App\Controller;


### PR DESCRIPTION
We're shipping viewClasses in 4.4 so it would be nice if it was in the
docs for new folks and upgrading users.