### PR TITLE
Skip including empty localtoc

### DIFF
--- a/config/conf.py
+++ b/config/conf.py
@@ -47,7 +47,7 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    '**': ['globaltoc.html', 'localtoc.html']
+    '**': ['globaltoc.html']
 }
 
 # -- Options for LaTeX output ------------------------------------------------


### PR DESCRIPTION
The localtoc is an empty file and generates an empty div.

https://github.com/cakephp/sphinxtheme/blob/master/cakephpsphinx/themes/cakephp/localtoc.html