### PR TITLE
Update sessions.rst Bugfix -> not working as expected

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -288,7 +288,7 @@ something like::
         // Removes expired sessions.
         public function gc($expires = null): bool
         {
-            return Cache::clear($this->cacheKey) && parent::gc($expires);
+            return parent::gc($expires);
         }
     }
 


### PR DESCRIPTION
If you call cache clear you will log out all users when gc() is called. CacheSession returns 0 for any gc() call.