### PR TITLE
Fix heading rank of Environment Variables section.

### DIFF
--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -46,7 +46,7 @@ configuration into multiple files. After creating each of the files in your
 .. _environment-variables:
 
 Environment Variables
-=====================
+---------------------
 
 Many modern cloud providers, like Heroku, let you define environment
 variables for configuration data. You can configure your CakePHP through


### PR DESCRIPTION
"Environment Variables" section moved into "Configuring your Application" section at 7cb1783d25faec534c02dbd7921059488b2ee975.