### PR TITLE
add command description feature to 4.4 migration guide

### DIFF
--- a/en/appendices/4-4-migration-guide.rst
+++ b/en/appendices/4-4-migration-guide.rst
@@ -162,6 +162,7 @@ Command
 -------
 
 * ``bin/cake routes`` now highlights collisions in route templates.
+* ``Command::getDescription()`` allows you to set a custom description. See :ref:`console-command-description`
 
 Controller
 ----------

--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -240,6 +240,8 @@ You may need to call other commands from your command. You can use
     parent command's ``ConsoleIo`` instance as the optional 3rd argument to
     avoid a potential "open files" limit that could occur in some environments.
 
+.. _console-command-description:
+
 Setting Command Description
 ===========================
 


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/16366