### PR TITLE
Improve 4.4 migration guide to indicate change needs to be made in bootstrap

### DIFF
--- a/en/appendices/4-4-migration-guide.rst
+++ b/en/appendices/4-4-migration-guide.rst
@@ -44,7 +44,7 @@ The ``ErrorHandler`` and ``ConsoleErrorHandler`` classes are now deprecated.
 They have been replaced by the new ``ExceptionTrap`` and ``ErrorTrap`` classes.
 The trap classes provide a more extensible and consistent error & exception
 handling framework. To upgrade to the new system you can replace the usage of
-``ErrorHandler`` and ``ConsoleErrorHandler`` with::
+``ErrorHandler`` and ``ConsoleErrorHandler`` (such as in your ``config/bootstrap.php``) with::
 
     use Cake\Error\ErrorTrap;
     use Cake\Error\ExceptionTrap;


### PR DESCRIPTION
Indicates that deprecation's to `ErrorHandler` and `ConsoleErrorHandler` are in `config/bootstrap.php`. This is not clear currently and the only clue is the actual deprecation message: 

> Deprecated: Use of `BaseErrorHandler` and subclasses are deprecated. Upgrade to the new `ErrorTrap` and `ExceptionTrap` subsystem. See https://book.cakephp.org/4/en/appendices/4-4-migration-guide.html /srv/app/config/bootstrap.php, line: 128 You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`. **Adding `config/bootstrap.php` to `Error.ignoredDeprecationPaths` in your `config/app.php` config will mute deprecations from that file only**