### PR TITLE
Remove example of iteration executing query

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -104,10 +104,6 @@ execute until you start fetching rows, convert it to an array, or when the
     // At this point the query has not run.
     $query = $articles->find('all');
 
-    // Iteration will execute the query.
-    foreach ($query->all() as $row) {
-    }
-
     // Calling all() will execute the query
     // and return the result set.
     $results = $query->all();


### PR DESCRIPTION
The original code for this example is now deprecated so the fixed version doesn't make sense.