### PR TITLE
registerMiddleware is not scoped

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -938,10 +938,8 @@ registered into the route collection::
     use Cake\Http\Middleware\CsrfProtectionMiddleware;
     use Cake\Http\Middleware\EncryptedCookieMiddleware;
 
-    $routes->scope('/', function (RouteBuilder $routes) {
-        $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware());
-        $routes->registerMiddleware('cookies', new EncryptedCookieMiddleware());
-    });
+    $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware());
+    $routes->registerMiddleware('cookies', new EncryptedCookieMiddleware());
 
 Once registered, scoped middleware can be applied to specific
 scopes::


### PR DESCRIPTION
applyMiddleware is scoped as described, but registerMiddleware is not.
Middlewares applied in scope /cms were registered in scope /, but there were no inheritance between those scopes.
It is even able to apply middlewares registered in scope /some/deep/scope, but it is misleading.