### PR TITLE
Update 3-4-migration-guide.rst

### DIFF
--- a/en/appendices/3-4-migration-guide.rst
+++ b/en/appendices/3-4-migration-guide.rst
@@ -50,7 +50,7 @@ either overlap the PSR-7 methods, or are made obsolete by the PSR-7 stack:
 
 * ``Response::header()`` is deprecated. Use ``getHeaderLine()``, ``hasHeader()`` or
   ``Response::getHeader()`` instead.
-* ``Response::body()`` is deprecated. Use ``Response::withBody()`` instead.
+* ``Response::body()`` is deprecated. Use ``Response::withStringBody()`` instead.
 * ``Response::statusCode()`` is deprecated. Use ``Response::getStatusCode()`` instead.
 * ``Response::httpCodes()`` This method should no longer be used. CakePHP now supports all
   standards recommended status codes.


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/10290
Deprecated response::body() method replacement response::withStringBody()