### PR TITLE
authentication change to keep phpstan from complaining about isValid()

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -205,7 +205,7 @@ In your ``UsersController``, add the following code::
         $this->request->allowMethod(['get', 'post']);
         $result = $this->Authentication->getResult();
         // regardless of POST or GET, redirect if user is logged in
-        if ($result->isValid()) {
+        if ($result && $result->isValid()) {
             // redirect to /articles after login success
             $redirect = $this->request->getQuery('redirect', [
                 'controller' => 'Articles',
@@ -279,7 +279,7 @@ Add the logout action to the ``UsersController`` class::
     {
         $result = $this->Authentication->getResult();
         // regardless of POST or GET, redirect if user is logged in
-        if ($result->isValid()) {
+        if ($result && result->isValid()) {
             $this->Authentication->logout();
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }

--- a/fr/tutorials-and-examples/cms/authentication.rst
+++ b/fr/tutorials-and-examples/cms/authentication.rst
@@ -210,7 +210,7 @@ Dans votre ``UsersController``, ajoutez le code suivant::
         $this->request->allowMethod(['get', 'post']);
         $result = $this->Authentication->getResult();
         // indépendamment de POST ou GET, rediriger si l'utilisateur est connecté
-        if ($result->isValid()) {
+        if ($result && $result->isValid()) {
             // rediriger vers /articles après la connexion réussie
             $redirect = $this->request->getQuery('redirect', [
                 'controller' => 'Articles',
@@ -286,7 +286,7 @@ Ajoutez l'action de logout à la classe ``UsersController``::
     {
         $result = $this->Authentication->getResult();
         // indépendamment de POST ou GET, rediriger si l'utilisateur est connecté
-        if ($result->isValid()) {
+        if ($result && $result->isValid()) {
             $this->Authentication->logout();
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }

--- a/ja/tutorials-and-examples/cms/authentication.rst
+++ b/ja/tutorials-and-examples/cms/authentication.rst
@@ -194,7 +194,7 @@ POSTされたフォームデータ(存在する場合)も検査し、credentials
         $this->request->allowMethod(['get', 'post']);
         $result = $this->Authentication->getResult();
         // POST, GET を問わず、ユーザーがログインしている場合はリダイレクトします
-        if ($result->isValid()) {
+        if ($result && $result->isValid()) {
             // redirect to /articles after login success
             $redirect = $this->request->getQuery('redirect', [
                 'controller' => 'Articles',
@@ -264,7 +264,7 @@ logout アクションを ``UsersController`` に追加します。::
     {
         $result = $this->Authentication->getResult();
         // POST, GET を問わず、ユーザーがログインしている場合はリダイレクトします
-        if ($result->isValid()) {
+        if ($result && $result->isValid()) {
             $this->Authentication->logout();
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }


### PR DESCRIPTION
PHPStan displays the following before the coding changes: 

```
 ------ ------------------------------------------------------------------------------------
  Line   Controller/Admin/UsersController.php
 ------ ------------------------------------------------------------------------------------
  45     Cannot call method isValid() on Authentication\Authenticator\ResultInterface|null.
 ------ ------------------------------------------------------------------------------------
```

This is due to the `$result` could possibly be `null`