### PR TITLE
4.x - Fix PHPUnit listener config.

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -429,7 +429,7 @@ extension and your ``phpunit.xml`` file should contain:
         <listener
         class="\Cake\TestSuite\Fixture\FixtureInjector">
             <arguments>
-                <object class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
             </arguments>
         </listener>
     </listeners>

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -450,7 +450,7 @@ PHPUnit et votre fichier ``phpunit.xml`` devait contenir:
         <listener
         class="\Cake\TestSuite\Fixture\FixtureInjector">
             <arguments>
-                <object class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
             </arguments>
         </listener>
     </listeners>


### PR DESCRIPTION
The old system needs to keep using the fixture manager.