### PR TITLE
Update docs for overriding column type.

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -503,17 +503,14 @@ We then have two ways to use our datatype in our models.
 
 Overwriting the reflected schema with our custom type will enable CakePHP's
 database layer to automatically convert JSON data when creating queries. In your
-Table's :ref:`_initializeSchema() method <saving-complex-types>` add the
+Table's :ref:`initialize() method <saving-complex-types>` add the
 following::
-
-    use Cake\Database\Schema\TableSchemaInterface;
 
     class WidgetsTable extends Table
     {
-        protected function _initializeSchema(TableSchemaInterface $schema): TableSchemaInterface
+        public function initialize(): void
         {
-            $schema->setColumnType('widget_prefs', 'json');
-            return $schema;
+            $this->getSchema()->setColumnType('widget_prefs', 'json');
         }
     }
 

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -1079,15 +1079,12 @@ column Types::
     TypeFactory::map('json', 'Cake\Database\Type\JsonType');
 
     // In src/Model/Table/UsersTable.php
-    use Cake\Database\Schema\TableSchemaInterface;
 
     class UsersTable extends Table
     {
-        protected function _initializeSchema(TableSchemaInterface $schema): TableSchemaInterface
+        public function initialize(): void
         {
-            $schema->setColumnType('preferences', 'json');
-
-            return $schema;
+            $this->getSchema()->setColumnType('preferences', 'json');
         }
     }
 


### PR DESCRIPTION
Using Table::initialize() is more convenient.