### PR TITLE
French update

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -360,8 +360,8 @@ methods. Finder methods are the ideal way to package up commonly used queries,
 allowing you to abstract query details into a simple to use method. Finder
 methods are defined by creating methods following the convention of ``findFoo``
 where ``Foo`` is the name of the finder you want to create. For example if we
-wanted to add a finder to our articles table for finding published articles we
-would do the following::
+wanted to add a finder to our articles table for finding articles written by a
+given user, we would do the following::
 
     use Cake\ORM\Query;
     use Cake\ORM\Table;

--- a/fr/appendices/4-3-migration-guide.rst
+++ b/fr/appendices/4-3-migration-guide.rst
@@ -27,7 +27,7 @@ automatiser la mise à jour des fonctionnalités obsolètes::
     d'appliquer d'abord les modifications de CakePHP 4.2.
 
 Une nouvelle option de configuration a été ajoutée pour désactiver les
-dépéréciations chemin par chemin. Cf. :ref:`deprecation-warnings` pour plus
+dépréciations chemin par chemin. Cf. :ref:`deprecation-warnings` pour plus
 d'informations.
 
 Connection

--- a/fr/appendices/4-4-migration-guide.rst
+++ b/fr/appendices/4-4-migration-guide.rst
@@ -5,22 +5,23 @@ CakePHP 4.4 est une mise à jour de l'API compatible à partir de la version 4.0
 Cette page présente les dépréciations et fonctionnalités ajoutées dans la
 version 4.4.
 
-Mettre à jour vers la version 4.3.0
+Mettre à jour vers la version 4.4.0
 ===================================
 
 Vous pouvez utiliser composer pour mettre à jour vers CakePHP 4.4.0::
 
-    php composer.phar require --update-with-dependencies "cakephp/cakephp:^4.4@RC"
+    php composer.phar require --update-with-dependencies "cakephp/cakephp:^4.4"
 
 .. note::
-    CakePHP 4.4 nécessite PHP 7.4 ou une version supérieure.
+    CakePHP 4.4 nécessite PHP 7.4 ou supérieur.
 
 Dépréciations
 =============
 
 4.4 introduit quelques dépréciations. Toutes ces fonctionnalités continueront
-d'exister dans les versions 4.x mais seront supprimées dans la version 5.0. Vous
-pouvez utiliser l':ref:`outil de mise à niveau <upgrade-tool-use>` pour
+d'exister dans les versions 4.x mais seront supprimées dans la version 5.0.
+
+Vous pouvez utiliser l':ref:`outil de mise à niveau <upgrade-tool-use>` pour
 automatiser la mise à jour des fonctionnalités obsolètes::
 
     bin/cake upgrade rector --rules cakephp44 <path/to/app/src>
@@ -29,71 +30,238 @@ automatiser la mise à jour des fonctionnalités obsolètes::
     Cela ne met à jour que les changements de CakePHP 4.4. Assurez-vous
     d'appliquer d'abord les modifications de CakePHP 4.3.
 
+
 Une nouvelle option de configuration a été ajoutée pour désactiver les
-dépéréciations chemin par chemin. Cf. :ref:`deprecation-warnings` pour plus
+dépréciations chemin par chemin. Cf. :ref:`deprecation-warnings` pour plus
 d'informations.
-
-* La définition de mappings de classes de vue avec ``RequestHandlerComponent``
-  est dépréciée. Utilisez :ref:`controller-viewclasses` à la place.
-
-Changements de comportements
-============================
-
-Bien que les changements qui suivent ne changent la signature d'aucune méthode,
-ils en changent la sémantique ou le comportement.
- 
-* ``Router::parseRequest()`` lève à présent une ``BadRequestException`` au lieu
-  d'une ``InvalidArgumentException`` lorsque le client utilise une méthode HTTP
-  invalide.
-
-Changements entraînant une rupture
-==================================
-
-Derrière l'API, certains changements sont nécessaires pour avancer. Ils
-n'affectent généralement pas les tests.
-
-Global
-------
-
-* La version minimum requise est montée à PHP 7.4.
-
-Nouvelles fonctionnalités
-=========================
-
-Command
--------
-
-* ``bin/cake routes`` met maintenant en valeur les collisions dans les templates
-  de routes.
 
 Controller
 ----------
 
-* ``Controller::viewClasses()`` a été ajoutée. Les controllers qui ont besoin de
-  réaliser une négociation de contenu devraient implémenter cette méthode. Les
-  classes de vue à proposer dans cette négociation de contenu devront
-  implémenter la méthode statique ``contentType()``.
+- L'option ``paginator`` pour ``Controller::paginate()`` est dépréciée. Utilisez
+  l'option ``className`` à la place.
+- L'option ``paginator`` pour ``PaginatorComponent`` est dépréciée. Utilisez
+  l'option ``className`` à la place.
+
+Datasource
+----------
+
+- ``FactoryLocator::add()`` n'accepte plus de fonction de génération de
+  closures. À la place, vous devez passer une instance de ``LocatorInterface``.
+- ``Cake\Datasource\Paging\Paginator`` a été renommé en
+  ``Cake\Datasource\Paging\NumericPaginator``.
+
+ErrorHandler & ConsoleErrorHandler
+----------------------------------
+
+Les classes ``ErrorHandler`` et ``ConsoleErrorHandler`` sont maintenant
+dépréciées. Elles ont été remplacées par les nouvelles classes ``ExceptionTrap``
+et ``ErrorTrap``. Les classes *trap* fournissent des outils plus extensibles et
+cohérents pour gérer les erreurs et exceptions. Pour mettre à niveau vers le
+nouveau système, vous pouvez remplacer l'utilisation de ``ErrorHandler`` et
+``ConsoleErrorHandler`` (notamment dans votre ``config/bootstrap.php``) par::
+
+    use Cake\Error\ErrorTrap;
+    use Cake\Error\ExceptionTrap;
+
+    (new ErrorTrap(Configure::read('Error')))->register();
+    (new ExceptionTrap(Configure::read('Error')))->register();
+
+Si vous avez défini la valeur de configuration de ``Error.errorLogger``, vous
+devrez le modifier en ``Error.logger``.
+
+Consultez la page :doc:`/development/errors` pour une documentation plus
+détaillée (Ndt : sa traduction française n'est pas à jour. Appel aux bonnes
+volontés !).
+De plus, les méthodes suivantes liées au système déprécié de gestion des erreurs
+sont elles-mêmes dépréciées:
+
+* ``Debugger::outputError()``
+* ``Debugger::getOutputFormat()``
+* ``Debugger::setOutputFormat()``
+* ``Debugger::addFormat()``
+* ``Debugger::addRenderer()``
+* ``ErrorLoggerInterface::log()``. Implémentez ``logException()`` à la place.
+* ``ErrorLoggerInterface::logMessage()``. Implémentez ``logError()`` à la place.
+
+
+RequestHandlerComponent
+------------------------
+
+Le RequestHandlerComponent est déprécié "soft". Comme pour ``AuthComponent``,
+l'usage de ``RequestHandler`` ne déclenchera pas d'avertissements à l'exécution
+mais il **sera** supprimé dans 5.0.
+
+- Remplacez ``accepts()`` par ``$this->request->accepts()``.
+- Remplacez ``requestedWith()`` par un détecteur personnalisé de requête (par
+  exemple, ``$this->request->is('json')``).
+- Remplacez ``prefers()`` par ``ContentTypeNegotiation``. Consultez
+  :ref:`controller-viewclasses`.
+- Remplacez ``renderAs()`` par des fonctionnalitées de négociation de contenu
+  dans ``Controller``.
+- Remplacez l'option ``checkHttpCache`` par
+  :doc:`/controllers/components/check-http-cache`.
+- Utilisez les :ref:`controller-viewclasses` au lieu de définir des mappings de
+  classes de vues dans ``RequestHandlerComponent``.
+
+
+PaginationComponent
+-------------------
+
+Le ``PaginationComponent`` est déprécié et sera supprimé dans 5.0. Utilisez la
+propriété ``Controller::$paginate`` ou le paramètre ``$settings`` de la méthode
+``Controller::paginate()`` pour spécifier les réglages de pagination
+nécessaires.
+
+ORM
+---
+
+- ``SaveOptionsBuilder`` a été déprécié. Utilisez un tableau pour les options à
+  la place.
+
+Plugins
+-------
+
+- Les noms de classes de plugin correspondent désormais au nom du plugin avec le
+  suffixe "Plugin". Par exemple, la classe de plugin pour "ADmad/I18n" serait
+  ``ADmad\I18n\I18nPlugin`` au lieu de ``ADmad\I18n\Plugin``, comme c'était le
+  cas pour CakePHP 4.3 et antérieurs.
+  L'ancien style de noms sera toujours supporté pour des raisons de
+  compatibilité descendante.
+
+Routing
+-------
+
+- Les fichiers de route mis en cache ont été dépréciés. Cela soulevait de
+  nombreux cas de figure impossibles à résoudre avec des routes en cache. Comme
+  la fonctionnalité des routes en cache n'est pas fonctionnelles dans de nombeux
+  cas d'utilisation, elle sera supprimée dans 5.x
+
+Suite de Test
+-------------
+
+- ``ConsoleIntegrationTestTrait`` a été déplacé dans le package de la console,
+  au même endroit que les autres dépendances, pour permettre de tester les
+  applications en console sans avoir besoin de tout le package cakephp/cakephp.
+
+  - ``Cake\TestSuite\ConsoleIntegrationTestTrait`` a été déplacé vers ``Cake\Console\TestSuite\ConsoleIntegrationTestTrait``
+  - ``Cake\TestSuite\Constraint\Console\*`` a été déplacé vers ``Cake\Console\TestSuite\Constraint\*``
+  - ``Cake\TestSuite\Stub\ConsoleInput`` a été déplacé vers ``Cake\Console\TestSuite\StubConsoleInput``
+  - ``Cake\TestSuite\Stub\ConsoleOutput`` a été déplacé vers ``Cake\Console\TestSuite\StubConsoleOutput``
+  - ``Cake\TestSuite\Stub\MissingConsoleInputException`` a été déplacé ``Cake\Console\TestSuite\MissingConsoleInputException``
+
+- ``ContainerStubTrait`` a été déplacé vers le package du cœur pour permettre le
+  test des applications en console sans avoir besoin de tout le package
+  cakephp/cakephp.
+
+  - ``Cake\TestSuite\ContainerStubTrait`` a été déplacé vers ``Cake\Core\TestSuite\ContainerStubTrait``
+
+- ``HttpClientTrait`` a été déplacé vers le package http pour permettre de
+  tester les applications http sans avoir besoin de tout le package
+  cakephp/cakephp.
+
+  - ``Cake\TestSuite\HttpClientTrait`` a été déplacé vers ``Cake\Http\TestSuite\HttpClientTrait``
+
+Changements de comportement
+===========================
+
+Bien que les changements suivants ne changent pas la signature des méthodes, ils
+changent la sémantique ou le comportement de certaines d'entre elles.
+
+ORM
+---
+
+* ``Table::saveMany()`` now triggers the ``Model.afterSaveCommit`` event with
+  entities that are still 'dirty' and contain the original field values. This
+  aligns the event payload for ``Model.afterSaveCommit`` with ``Table::save()``.
+
+Routing
+-------
+
+* ``Router::parseRequest()`` soulève maintenant une ``BadRequestException`` au
+  lieu d'une ``InvalidArgumentException`` lorsque le client utilise une méthode
+  HTTP invalide.
+
+Nouvelles Fonctionnalités
+=========================
+
+Cache
+-----
+
+* ``RedisEngine`` supporte désormais les méthodes ``deleteAsync()`` et
+  ``clearBlocking()``. Ces méthodes utilisent l'opération ``UNLINK`` dans redis
+  pour marquer les données en vue d'une suppression ultérieure par Redis.
+
+Command
+-------
+
+* ``bin/cake routes`` met maintenant en valeurs les collisions dans les
+  templates de routes.
+* ``Command::getDescription()`` vous permet de définir une description
+  personnalisée.Cf. :ref:`console-command-description`
+
+Controller
+----------
+
+* ``Controller::viewClasses()`` a été ajoutée. Cette méthode devraient être
+  implémentée par les contrôleurs qui ont besoin d'effectuer des négociations
+  sur le content-type. Les classes de vue auront besoin d'implémenter la méthode
+  statique ``contentType()`` pour participer à la négociation du content-type.
 
 Database
 --------
 
-* Le pilote ``SQLite`` supporte maintenant les base de données partagées en
-  mémoire dans PHP8.1+.
+* Le pilote ``SQLite`` supporte à présent les base de données partagées en
+  mémoire sous PHP8.1+.
 * ``Query::expr()`` a été ajoutée comme alternative à ``Query::newExpr()``.
-* Le builder ``QueryExpression::case()`` supporte maintenant la détection de
-  type à partir d'expressions passées à ``then()`` et ``else()`` qui
+* Le builder ``QueryExpression::case()`` supporte maintenant l'inférence de
+  types à partir d'expressions passées à ``then()`` et à ``else()`` qui
   implémentent ``\Cake\Database\TypedResultInterface``.
-  
-Mailer
-------
 
-* ``Mailer`` accepte à présent une configuration ``autoLayout`` qui, lorsqu'elle
-  est définie à ``false``, désactive l'auto-layout dans le ``ViewBuilder``.
+Error
+-----
+
+* ``ErrorTrap`` et ``ExceptionTrap`` ont été ajoutées. Ces classes forment la
+  fondation d'un système de gestion d'erreur mis à jour pour les applications.
+  Pour en savoir plus, rendez-vous sur :doc:`/development/errors`.
 
 Http
 ----
 
-* ``BaseApplication::handle()`` ajoute désormais tout le temps la ``$request``
+* ``Response::checkNotModified()`` a été dépréciée.
+  Utilisez ``Response::isNotModified()`` à la place.
+* ``BaseApplication::handle()`` ajoute désormais systématiquement ``$request``
   dans le conteneur de service.
-* ``HttpsEnforcerMiddleware`` a désormais une option ``hsts`` qui permet de
-  configure le header ``Strict-Transport-Security``.
+* ``HttpsEnforcerMiddleware`` a maintenant une option ``hsts`` qu vous permet de
+  configurer le header ``Strict-Transport-Security``.
+
+Mailer
+------
+
+* ``Mailer`` accepte désormais une clé de configuration ``autoLayout`` qui
+  qui désactive le layout automatique dans le ``ViewBuilder`` si elle est
+  définie à ``false``.
+
+ORM
+---
+
+* L'option ``cascadeCallbacks`` a été ajoutée ``TreeBehavior``. Lorsqu'elle est
+  activée, ``TreeBehavior`` itérera un résultat de ``find()`` et effacera les
+  enregistrements individuellement. Cela permet d'utiliser les callbacks de
+  l'ORM lors de l'effacement de nœuds.
+
+Routing
+-------
+
+* ``RoutingMiddleware`` définit désormais l'attribut "route" de la requête avec
+  l'instance ``Route`` qui correspond.
+
+
+View
+----
+
+* ``View::contentType()`` a été ajoutée. Les vues peuvent implémenter cette
+  méthode pour participer à une négociation du content-type.
+* ``View::TYPE_MATCH_ALL`` a été ajoutée. Ce content-type spécial vous permet de
+  construire des vues de repli pour les cas où la négociation du content-type
+  ne fournit aucune correspondance.

--- a/fr/console-commands/commands.rst
+++ b/fr/console-commands/commands.rst
@@ -189,6 +189,62 @@ Vous pouvez passer tout code de sortie souhaité dans ``abort()``.
     Vous pouvez en apprendre plus sur les codes de sortie dans la page sysexit du manuel de la plupart des systèmes
     Unix (``man sysexits``), ou la page d'aide sur les ``Codes de Sortie Système`` dans Windows.
 
+Appeler d'Autres Commandes
+==========================
+
+Vous pouvez avoir besoin d'appeler d'autres commandes depuis votre commande.
+Pour ce faire, utilisez ``executeCommand``::
+
+    // Vous pouvez passer un tableau d'options CLI et d'arguments.
+    $this->executeCommand(OtherCommand::class, ['--verbose', 'deploy']);
+
+    // Possibilité de passer une instance de commande si elle a des arguments de constructeur
+    $command = new OtherCommand($otherArgs);
+    $this->executeCommand($command, ['--verbose', 'deploy']);
+
+.. note::
+
+    QUand vous appelez ``executeCommand()`` dans une boucle, il est recommandé
+    de passer l'instance ``ConsoleIo`` en tant que 3ème argument optionnel dans
+    la commande parente pour éviter une potentielle limite de fichiers ouverts,
+    qui pourrait arriver dans certains environnements.
+
+.. _console-command-description:
+
+Définir une Description de Commande
+===================================
+
+Vous pouvez définir une description de commande via::
+
+    class UserCommand extends Command
+    {
+        public static function getDescription(): string
+        {
+            return 'Ma description personnalisée';
+        }
+    }
+
+Cela affichera votre description dans le CLI Cake:
+
+.. code-block:: console
+
+    bin/cake
+
+    App:
+      - user
+      └─── Ma description personnalisée
+
+Ainsi que dans la section *help* de votre commande:
+
+.. code-block:: console
+
+    cake user --help
+    Ma description personnalisée
+
+    Usage:
+    cake user [-h] [-q] [-v]
+
+
 .. _console-integration-testing:
 
 Tester les Commandes

--- a/fr/controllers/components.rst
+++ b/fr/controllers/components.rst
@@ -21,6 +21,8 @@ le chapitre de chaque component:
     /controllers/components/security
     /controllers/components/pagination
     /controllers/components/request-handling
+    /controllers/components/form-protection
+    /controllers/components/check-http-cache
 
 .. _configuring-components:
 

--- a/fr/controllers/components/check-http-cache.rst
+++ b/fr/controllers/components/check-http-cache.rst
@@ -1,0 +1,39 @@
+Checking HTTP Cache
+===================
+
+.. php:class:: CheckHttpCacheComponent(ComponentCollection $collection, array $config = [])
+
+.. versionadded:: 4.4.0
+    La classe ``CheckHttpCacheComponent`` a été ajoutée.
+
+Le modèle de validation du cache HTTP est un des process utilisés pour les
+passerelles de cache, aussi connues comme mandataires inversés (*reverse
+proxies*), pour déterminer si elles peuvent servir à stocker une copie de la
+réponse au client. Dans ce modèle, vous économisez surtout de la bande passante,
+mais quand vous l'utilisez correctement vous pouvez également économiser du CPU,
+et réduire les temps de réponse::
+
+    // dans un Controller
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->addComponent('CheckHttpCache');
+    }
+
+Le fait d'activer ``CheckHttpCacheComponent`` dans votre controller active
+automatiquement une vérification de ``beforeRender``. Cette vérification compare
+les en-têtes de cache définies dans l'objet response avec les en-têtes de cache
+envoyées dans la requête, pour déterminer si la réponse n'a pas été modifiée
+depuis la dernière fois que le client l'a demandée. Les en-têtes de requête
+utilisées sont les suivantes:
+
+* ``If-None-Match`` est comparée avec l'en-tête ``Etag`` de la réponse.
+* ``If-Modified-Since`` est comparée avec l'en-tête ``Last-Modified`` de la
+  réponse.
+
+Si les en-têtes de la réponse correspondent aux critères des en-têtes de la
+requête, alors on saute l'étape de rendu de la vue. Cela évite à votre
+application de générer la vue, ce qui économise de la bande passante et du
+temps. Lorsque les en-têtes de la réponse correspondent, on renvoie une réponse
+vide avec le code de status ``304 Not Modified``.

--- a/fr/orm/entities.rst
+++ b/fr/orm/entities.rst
@@ -59,12 +59,12 @@ les données que vous voulez y stocker::
 
     $article = new Article([
         'id' => 1,
-        'title' => 'New Article',
+        'titre' => 'Nouvel Article',
         'created' => new DateTime('now')
     ]);
 
-La méthode recommandée pour récupérer une nouvelle entity est d'appeler
-``newEntity()`` sur l'objet ``Table``::
+Pour obtenir une entity vierge, le meilleur moyen est d'appeler
+``newEmptyEntity()`` sur l'objet ``Table``::
 
     use Cake\ORM\Locator\LocatorAwareTrait;
 
@@ -96,8 +96,8 @@ en utilisant la notation objet::
     use App\Model\Entity\Article;
 
     $article = new Article;
-    $article->title = 'Ceci est mon premier post';
-    echo $article->title;
+    $article->titre = 'Ceci est mon premier post';
+    echo $article->titre;
 
 Vous pouvez aussi utiliser les méthodes ``get()`` et ``set()``.
 
@@ -128,27 +128,28 @@ Vous pouvez vérifier si des champs sont définis dans vos entities avec
 ``has()``::
 
     $article = new Article([
-        'title' => 'Premier post',
+        'titre' => 'Premier post',
         'user_id' => null
     ]);
-    $article->has('title'); // true
+    $article->has('titre'); // true
     $article->has('user_id'); // false
-    $article->has('undefined'); // false
+    $article->has('indefini'); // false.
 
 La méthode ``has()`` va renvoyer ``true`` si un champ est défini est a une
 valeur non null. Vous pouvez utiliser ``isEmpty()`` et ``hasValue()`` pour
 vérifier si un champ contient une valeur 'non-empty'::
 
     $article = new Article([
-        'title' => 'Premier post',
-        'user_id' => null,
+        'titre' => 'Premier post',
+        'user_id' => null
         'text' => '',
         'links' => []
     ]);
-    $article->has('title'); // true
-    $article->isEmpty('title');  // false
-    $article->hasValue('title'); // true
- 
+    ]);
+    $article->has('titre'); // true
+    $article->isEmpty('titre');  // false
+    $article->hasValue('titre'); // true
+
     $article->has('user_id'); // false
     $article->isEmpty('user_id');  // true
     $article->hasValue('user_id'); // false
@@ -161,20 +162,28 @@ vérifier si un champ contient une valeur 'non-empty'::
     $article->isEmpty('links');  // true
     $article->hasValue('links'); // false
 
+    $article->has('texte'); // true
+    $article->isEmpty('texte');  // true
+    $article->hasValue('texte'); // false
+
+    $article->has('liens'); // true
+    $article->isEmpty('liens');  // true
+    $article->hasValue('liens'); // false
+
 Accesseurs & Mutateurs
 ======================
 
 En plus de l'interface simple get/set, les entities vous permettent de fournir
-des méthodes accesseurs et mutateurs. Ces méthodes vous laissent personnaliser
-la façon dont les champs sont lus ou définis.
+des méthodes accesseurs et mutateurs. Avec ces méthodes, vous pouvez
+personnaliser la façon dont les champs sont lus ou définis.
 
 Accesseurs
 ----------
 
-Les accesseurs vous permettent de personnaliser la façon dont les champ sont
-lus. Ils utilisent la convention ``_get(NomDuChamp)`` où ``(NomDuChamp)`` est le
-nom du champ en version CamelCase (plusieurs mots accollés avec la première
-lettre de chacun en majuscule).
+Les accesseurs personnalisent la façon dont les champs seront lus. Ils suivent
+la convention ``_get(NomDuChamp)`` où ``(NomDuChamp)`` est la version CamelCase
+du nom du champ (les mots sont accollés avec une majuscule pour la première
+lettre de chacun).
 
 Ils reçoivent la valeur basique stockée dans le tableau ``_fields`` pour
 seul argument. Par exemple::
@@ -191,9 +200,9 @@ seul argument. Par exemple::
         }
     }
 
-Cet exemple convertit la valeur du champ ``titre`` en majuscules à chaque fois
-qu'il est lu. Il sera exécuté quand vous récupérerez le champ *via* une de ces
-deux manières::
+Cet exemple convertit en majuscules la valeur du champ ``titre`` à chaque fois
+qu'il est lu. Il sera exécuté quand vous récupérerez le champ *via* une de
+ces deux manières::
 
     echo $article->titre; // renvoie FOO au lieu de foo
     echo $article->get('titre'); // renvoie FOO au lieu de foo
@@ -213,16 +222,16 @@ deux manières::
 
 Mutateurs
 ---------
- 
-Vous pouvez personnaliser la façon dont les champs sont définis
-en implémentant un mutateur. Ils utilisent la convention ``_set(NomDuChamp)`` où
-``(NomDuChamp)`` est le nom du champ en version CamelCase version.
+
+Avec les mutateurs, vous pouvez personnaliser la façon dont les champs seront
+écrits dans l'entity. Ils suivent la convention ``_set(NomDuChamp)`` où
+``(NomDuChamp)`` est la version CamelCase du nom du champ.
 
 Les méthodes mutateurs doivent toujours retourner la valeur qui doit être
-stockée dans le champ. Vous pouvez aussi utiliser les mutateurs pour définir les
-valeurs d'autres champs. Quand vous faites cela, attention à ne pas introduire
-de boucles, puisque CakePHP n'empêchera pas les méthodes mutateurs de faire des
-boucles infinies. Par exemple::
+stockée dans le champ. Vous pouvez aussi utiliser les mutateurs pour définir
+simultanément d'autres champs. Quand vous faites
+cela, soyez vigilant à ne pas introduire de boucles, car CakePHP n'empêchera pas
+les méthodes mutateurs de faire des boucles infinies. Par exemple::
 
     namespace App\Model\Entity;
 
@@ -231,7 +240,6 @@ boucles infinies. Par exemple::
 
     class Article extends Entity
     {
-
         protected function _setTitre($titre)
         {
             $this->minuscules = Text::slug($titre);
@@ -263,7 +271,7 @@ Créer des Champs Virtuels
 
 En définissant des accesseurs, vous pouvez fournir un accès à des champs qui
 n'existent pas réellement. Par exemple si votre table users a des champs
-``first_name`` et ``last_name``, vous pouvez créer une méthode pour le nom
+``prenom`` et ``nom_de_famille``, vous pouvez créer une méthode pour le nom
 complet::
 
     namespace App\Model\Entity;
@@ -272,20 +280,18 @@ complet::
 
     class User extends Entity
     {
-
-        protected function _getFullName()
+        protected function _getNomComplet()
         {
-            return $this->first_name . '  ' . $this->last_name;
+            return $this->prenom . '  ' . $this->nom_de_famille;
         }
-
     }
 
 Vous pouvez accéder aux champs virtuels comme s'ils existaient sur l'entity.
 Le nom du champ sera le nom de la méthode en minuscules, avec des underscores
-pour séparer les mots (``full_name``)::
+pour séparer les mots (``nom_complet``)::
 
-    echo $user->full_name;
-    echo $user->get('full_name');
+    echo $user->nom_complet;
+    echo $user->get('nom_complet');
 
 Souvenez-vous que les champs virtuels ne peuvent pas être utilisés dans
 les finds. Si vous voulez qu'ils fassent partie des données JSON ou dans des
@@ -302,7 +308,7 @@ modifications dans l'entity. Par exemple, vous pourriez vouloir valider
 uniquement les champs lorsqu'ils ont été modifiés::
 
     // Vérifie si le champ title n'a pas été modifié.
-    $article->isDirty('title');
+    $article->isDirty('titre');
 
 Vous pouvez également marquer un champ comme ayant été modifié. C'est pratique
 lorsque vous ajoutez des données dans des champs contenant un tableau car sinon
@@ -310,8 +316,8 @@ cela ne marque pas automatiquement le champ comme ayant été modifié, seule la
 redéfinition du tableau complet aurait cet effet::
 
     // Ajoute un commentaire et marque le champ comme modifié.
-    $article->comments[] = $newComment;
-    $article->setDirty('comments', true);
+    $article->commentaires[] = $nouveauCommentaire;
+    $article->setDirty('commentaires', true);
 
 De plus, vous pouvez également baser votre code conditionnel sur les valeurs
 initiales des champs en utilisant la méthode ``getOriginal()``. Cette
@@ -332,20 +338,20 @@ utiliser la méthode ``clean()``::
 Lors de la création d'un nouvelle entity, vous pouvez empêcher les champs
 d'être marqués *dirty* en passant une option supplémentaire::
 
-    $article = new Article(['title' => 'New Article'], ['markClean' => true]);
+    $article = new Article(['titre' => 'Nouvel Article'], ['markClean' => true]);
 
-Pour récupérer la liste des propriétés *dirty* d'une ``Entity``,
-vous pouvez utiliser la méthode ``getDirty()``::
+Pour récupérer la liste des propriétés *dirty* d'une ``Entity``, vous pouvez
+appeler::
 
     $dirtyFields = $entity->getDirty();
 
 Erreurs de Validation
 =====================
 
-Après avoir :ref:`sauvegardé une entity <saving-entities>` toute erreur de
+Après avoir :ref:`sauvegardé une entity <saving-entities>`, toute erreur de
 validation sera stockée sur l'entity elle-même. Vous pouvez accéder à toutes
-les erreurs de validation en utilisant les méthodes ``getErrors()`` et
-``getError()``::
+les erreurs de validation en utilisant les méthodes ``getErrors()``,
+``getError()`` ou ``hasErrors()``::
 
     // Récupère toutes les erreurs
     $errors = $user->getErrors();
@@ -360,13 +366,13 @@ les erreurs de validation en utilisant les méthodes ``getErrors()`` et
     $user->hasErrors(false);
 
 Les méthodes ``setErrors()`` et ``setError()`` peuvent aussi être utilisées
-pour définir les erreurs sur une entity, facilitant les tests du code qui
+pour définir les erreurs sur une entity, ce qui facilite les tests du code qui
 fonctionne avec des messages d'erreur::
 
     $user->setError('password', ['Le mot de passe est obligatoire.']);
     $user->setErrors([
-      'password' => ['Le mot de passe est obligatoire'],
-      'username' => ['Le nom d'utilisateur est obligatoire']
+        'password' => ['Le mot de passe est obligatoire'],
+        'username' => ['Le nom d\'utilisateur est obligatoire']
     ]);
 
 .. _entities-mass-assignment:
@@ -393,8 +399,8 @@ d'indiquer s'ils peuvent être assignés en masse ou non. Les valeurs ``true`` e
     class Article extends Entity
     {
         protected $_accessible = [
-            'title' => true,
-            'body' => true
+            'titre' => true,
+            'contenu' => true
         ];
     }
 
@@ -408,8 +414,8 @@ comportement par défaut si un champ n'est pas nommé spécifiquement::
     class Article extends Entity
     {
         protected $_accessible = [
-            'title' => true,
-            'body' => true,
+            'titre' => true,
+            'contenu' => true,
             '*' => false,
         ];
     }
@@ -419,15 +425,15 @@ comportement par défaut si un champ n'est pas nommé spécifiquement::
 Éviter la Protection Contre l'Assignement de Masse
 --------------------------------------------------
 
-Lors de la création d'un nouvelle entity un utilisant le mot clé ``new``, vous
+Lors de la création d'un nouvelle entity en utilisant le mot clé ``new``, vous
 pouvez lui spécifier de ne pas se protéger contre l'assignement de masse::
 
     use App\Model\Entity\Article;
 
-    $article = new Article(['id' => 1, 'title' => 'Foo'], ['guard' => false]);
+    $article = new Article(['id' => 1, 'titre' => 'Foo'], ['guard' => false]);
 
-Modifier les Champs Protégés à l'Exécution
-------------------------------------------
+Modifier les Champs Protégés à la Volée
+---------------------------------------
 
 Vous pouvez modifier à la volée la liste des champs protégés en utilisant la
 méthode ``setAccess()``::
@@ -435,8 +441,8 @@ méthode ``setAccess()``::
     // Rendre user_id accessible.
     $article->setAccess('user_id', true);
 
-    // Rendre title protégé.
-    $article->setAccess('title', false);
+    // Rendre titre protégé.
+    $article->setAccess('titre', false);
 
 .. note::
 
@@ -482,39 +488,38 @@ utiliser ``setNew()``::
 Lazy Loading des Associations
 =============================
 
-Alors que les associations chargées en eager loading sont généralement la
-façon la plus efficace pour accéder à vos associations, il peut arriver que
-vous ayez besoin d'utiliser le lazy loading des données associées. Avant de
-voir comment utiliser le Lazy loading d'associations, nous devrions
-discuter des différences entre le chargement des associations eager et lazy:
+Bien que la façon la plus efficace pour accéder à vos associations soit
+généralement de les charger en eager loading, il peut arriver que vous ayez
+besoin d'utiliser le lazy loading des données associées. Avant de voir comment
+utiliser le Lazy loading des associations, nous allons devoir parler des
+différences entre le chargement eager et lazy:
 
 Eager loading
     Le Eager loading utilise les joins (quand c'est possible) pour récupérer les
     données de la base de données avec aussi *peu* de requêtes que possible.
-    Quand une requête séparée est nécessaire comme dans le cas d'une
+    Quand une requête séparée est nécessaire, comme dans le cas d'une
     association HasMany, une requête unique est émise pour récupérer *toutes*
-    les données associées pour l'ensemble courant d'objets.
+    les données associées pour l'ensemble des objets à récupérer.
 Lazy loading
-    Le Lazy loading diffère le chargement des données de l'association jusqu'à
+    Le Lazy loading retarde le chargement des données de l'association jusqu'à
     ce que ce soit absolument nécessaire. Si cela peut certes économiser du temps
     CPU car des données possiblement non utilisées ne sont pas hydratées dans
-    les objets, cela peut aussi résulter en plus de requêtes émises vers la base de
-    données. Par exemple faire des boucles sur un ensemble d'articles et leurs
-    commentaires va fréquemment émettre N requêtes où N est le nombre d'articles
-    itérés.
+    les objets, cela peut aussi résulter en beaucoup plus de requêtes émises
+    vers la base de données. Par exemple faire des boucles sur un ensemble
+    d'articles et leurs commentaires va fréquemment émettre N requêtes, où N est
+    le nombre d'articles itérés.
 
 Bien que le lazy loading ne soit pas inclus dans l'ORM de CakePHP, vous pouvez
 tout simplement utiliser un des plugins de la communauté pour le faire. Nous
 recommandons `le plugin LazyLoad <https://github.com/jeremyharris/cakephp-lazyload>`__
 
-Après avoir ajouté le plugin à votre entity, vous pourrez faire ce qui
-suit::
+Après avoir ajouté le plugin à votre entity, vous pourrez faire ceci::
 
     $article = $this->Articles->findById($id);
 
-    // La propriété comments a été chargée en lazy
-    foreach ($article->comments as $comment) {
-        echo $comment->body;
+    // La propriété commentaires a été chargée en lazy
+    foreach ($article->commentaires as $commentaire) {
+        echo $commentaire->contenu;
     }
 
 Créer du Code Réutilisable avec les Traits
@@ -530,7 +535,7 @@ fonctionnalités pour les objets table et entity.
 
 Par exemple si nous avions un plugin SoftDeletable, il pourrait fournir un trait.
 Ce trait pourrait donner des méthodes pour marquer les entities comme
-'supprimées', la méthode ``softDelete`` pourrait être fournie par un trait::
+'supprimées', la méthode ``softDelete`` pouvant être fournie par un trait::
 
     // SoftDelete/Model/Entity/SoftDeleteTrait.php
 
@@ -538,16 +543,14 @@ Ce trait pourrait donner des méthodes pour marquer les entities comme
 
     trait SoftDeleteTrait
     {
-
         public function softDelete()
         {
-            $this->set('deleted', true);
+            $this->set('supprime', true);
         }
-
     }
 
-Vous pourriez ensuite utiliser ce trait dans votre classe entity en l'intégrant
-et en l'incluant::
+Vous pourriez ensuite utiliser ce trait dans votre classe d'entity par une
+importation et une inclusion::
 
     namespace App\Model\Entity;
 
@@ -562,9 +565,9 @@ et en l'incluant::
 Convertir en Tableaux/JSON
 ==========================
 
-Lors de la construction d'APIs, vous aurez sûrement besoin férquemment de
-convertir des entities en tableaux ou en données JSON. CakePHP rend cela très
-simple::
+Lors de la construction d'APIs, il est probable que vous aurez fréquemment
+besoin de convertir des entities en tableaux ou en données JSON. CakePHP rend
+cela très simple::
 
     // Obtenir un tableau.
     // Les associations seront aussi converties par toArray().
@@ -575,7 +578,7 @@ simple::
     $json = json_encode($user);
 
 Lors de la conversion d'une entity en JSON, les listes de champs virtuels & cachés
-sont utilisées. Les entities sont aussi converties de façon récursive en JSON.
+sont utilisées. Les entities sont aussi converties récursivement en JSON.
 Cela signifie que si les entities et leurs associations sont chargées en eager
 loading, CakePHP va gérer correctement la conversion des données associées dans
 le bon format.
@@ -597,13 +600,13 @@ doivent être exposés::
 
     class User extends Entity
     {
-        protected $_virtual = ['full_name'];
+        protected $_virtual = ['nom_complet'];
     }
 
 Cette liste peut être modifiée à la volée en utilisant la méthode
 ``setVirtual``::
 
-    $user->setVirtual(['full_name', 'is_admin']);
+    $user->setVirtual(['nom_complet', 'is_admin']);
 
 Cacher les Champs
 -----------------
@@ -625,12 +628,12 @@ définition d'une classe entity, définissez quels champs doivent être cachés:
 Cette liste peut être modifiée à la volée en utilisant la méthode
 ``setHidden``::
 
-    $user->setHidden(['password', 'recovery_question']);
+    $user->setHidden(['password', 'question_de_recuperation']);
 
 Stocker des Types Complexes
 ===========================
 
-Les méthodes "accesseurs" et "mutateurs" n'ont pas pour objectif de contenir de
+Les accesseurs et mutateurs n'ont pas pour objectif de contenir de
 la logique pour sérialiser et desérialiser les données complexes venant de la
 base de données. Consultez la section :ref:`saving-complex-types` pour
 comprendre la façon dont votre application peut stocker des types de données

--- a/fr/orm/entities.rst
+++ b/fr/orm/entities.rst
@@ -59,7 +59,7 @@ les données que vous voulez y stocker::
 
     $article = new Article([
         'id' => 1,
-        'titre' => 'Nouvel Article',
+        'title' => 'Nouvel Article',
         'created' => new DateTime('now')
     ]);
 
@@ -96,8 +96,8 @@ en utilisant la notation objet::
     use App\Model\Entity\Article;
 
     $article = new Article;
-    $article->titre = 'Ceci est mon premier post';
-    echo $article->titre;
+    $article->title = 'Ceci est mon premier post';
+    echo $article->title;
 
 Vous pouvez aussi utiliser les méthodes ``get()`` et ``set()``.
 
@@ -128,27 +128,27 @@ Vous pouvez vérifier si des champs sont définis dans vos entities avec
 ``has()``::
 
     $article = new Article([
-        'titre' => 'Premier post',
+        'title' => 'Premier post',
         'user_id' => null
     ]);
-    $article->has('titre'); // true
+    $article->has('title'); // true
     $article->has('user_id'); // false
-    $article->has('indefini'); // false.
+    $article->has('undefined'); // false.
 
 La méthode ``has()`` va renvoyer ``true`` si un champ est défini est a une
 valeur non null. Vous pouvez utiliser ``isEmpty()`` et ``hasValue()`` pour
 vérifier si un champ contient une valeur 'non-empty'::
 
     $article = new Article([
-        'titre' => 'Premier post',
+        'title' => 'Premier post',
         'user_id' => null
         'text' => '',
         'links' => []
     ]);
     ]);
-    $article->has('titre'); // true
-    $article->isEmpty('titre');  // false
-    $article->hasValue('titre'); // true
+    $article->has('title'); // true
+    $article->isEmpty('title');  // false
+    $article->hasValue('title'); // true
 
     $article->has('user_id'); // false
     $article->isEmpty('user_id');  // true
@@ -162,13 +162,13 @@ vérifier si un champ contient une valeur 'non-empty'::
     $article->isEmpty('links');  // true
     $article->hasValue('links'); // false
 
-    $article->has('texte'); // true
-    $article->isEmpty('texte');  // true
-    $article->hasValue('texte'); // false
+    $article->has('text'); // true
+    $article->isEmpty('text');  // true
+    $article->hasValue('text'); // false
 
-    $article->has('liens'); // true
-    $article->isEmpty('liens');  // true
-    $article->hasValue('liens'); // false
+    $article->has('links'); // true
+    $article->isEmpty('links');  // true
+    $article->hasValue('links'); // false
 
 Accesseurs & Mutateurs
 ======================
@@ -194,18 +194,18 @@ seul argument. Par exemple::
 
     class Article extends Entity
     {
-        protected function _getTitre($titre)
+        protected function _getTitle($title)
         {
-            return strtoupper($titre);
+            return strtoupper($title);
         }
     }
 
-Cet exemple convertit en majuscules la valeur du champ ``titre`` à chaque fois
+Cet exemple convertit en majuscules la valeur du champ ``title`` à chaque fois
 qu'il est lu. Il sera exécuté quand vous récupérerez le champ *via* une de
 ces deux manières::
 
-    echo $article->titre; // renvoie FOO au lieu de foo
-    echo $article->get('titre'); // renvoie FOO au lieu de foo
+    echo $article->title; // renvoie FOO au lieu de foo
+    echo $article->get('title'); // renvoie FOO au lieu de foo
 
 .. note::
 
@@ -240,22 +240,22 @@ les méthodes mutateurs de faire des boucles infinies. Par exemple::
 
     class Article extends Entity
     {
-        protected function _setTitre($titre)
+        protected function _setTitle($title)
         {
-            $this->minuscules = Text::slug($titre);
+            $this->slug = Text::slug($title);
 
-            return strtouppercase($titre);
+            return strtouppercase($title);
         }
 
     }
 
 Cet exemple fait deux choses : il stocke une version modifiée de la valeur
-spécifiée dans le champ ``minuscules`` et stocke une version en majuscules dans
+spécifiée dans le champ ``slug`` et stocke une version en majuscules dans
 le champ ``titre``. Il sera executé lorsque vous définirez le champ *via* une de
 ces deux manières::
 
-    $user->titre = 'foo' // définit le champ minuscules et stocke FOO au lieu de foo
-    $user->set('titre', 'foo'); // définit le champ minuscules et stocke FOO au lieu de foo
+    $user->title = 'foo' // définit le champ slug et stocke FOO au lieu de foo
+    $user->set('title', 'foo'); // définit le champ slug et stocke FOO au lieu de foo
 
 .. warning::
 
@@ -271,7 +271,7 @@ Créer des Champs Virtuels
 
 En définissant des accesseurs, vous pouvez fournir un accès à des champs qui
 n'existent pas réellement. Par exemple si votre table users a des champs
-``prenom`` et ``nom_de_famille``, vous pouvez créer une méthode pour le nom
+``first_name`` et ``last_name``, vous pouvez créer une méthode pour le nom
 complet::
 
     namespace App\Model\Entity;
@@ -280,18 +280,18 @@ complet::
 
     class User extends Entity
     {
-        protected function _getNomComplet()
+        protected function _getFullName()
         {
-            return $this->prenom . '  ' . $this->nom_de_famille;
+            return $this->first_name . '  ' . $this->last_name;
         }
     }
 
 Vous pouvez accéder aux champs virtuels comme s'ils existaient sur l'entity.
 Le nom du champ sera le nom de la méthode en minuscules, avec des underscores
-pour séparer les mots (``nom_complet``)::
+pour séparer les mots (``full_name``)::
 
-    echo $user->nom_complet;
-    echo $user->get('nom_complet');
+    echo $user->full_name;
+    echo $user->get('full_name');
 
 Souvenez-vous que les champs virtuels ne peuvent pas être utilisés dans
 les finds. Si vous voulez qu'ils fassent partie des données JSON ou dans des
@@ -308,7 +308,7 @@ modifications dans l'entity. Par exemple, vous pourriez vouloir valider
 uniquement les champs lorsqu'ils ont été modifiés::
 
     // Vérifie si le champ title n'a pas été modifié.
-    $article->isDirty('titre');
+    $article->isDirty('title');
 
 Vous pouvez également marquer un champ comme ayant été modifié. C'est pratique
 lorsque vous ajoutez des données dans des champs contenant un tableau car sinon
@@ -316,8 +316,8 @@ cela ne marque pas automatiquement le champ comme ayant été modifié, seule la
 redéfinition du tableau complet aurait cet effet::
 
     // Ajoute un commentaire et marque le champ comme modifié.
-    $article->commentaires[] = $nouveauCommentaire;
-    $article->setDirty('commentaires', true);
+    $article->comments[] = $nouveauCommentaire;
+    $article->setDirty('comments', true);
 
 De plus, vous pouvez également baser votre code conditionnel sur les valeurs
 initiales des champs en utilisant la méthode ``getOriginal()``. Cette
@@ -338,7 +338,7 @@ utiliser la méthode ``clean()``::
 Lors de la création d'un nouvelle entity, vous pouvez empêcher les champs
 d'être marqués *dirty* en passant une option supplémentaire::
 
-    $article = new Article(['titre' => 'Nouvel Article'], ['markClean' => true]);
+    $article = new Article(['title' => 'Nouvel Article'], ['markClean' => true]);
 
 Pour récupérer la liste des propriétés *dirty* d'une ``Entity``, vous pouvez
 appeler::
@@ -399,8 +399,8 @@ d'indiquer s'ils peuvent être assignés en masse ou non. Les valeurs ``true`` e
     class Article extends Entity
     {
         protected $_accessible = [
-            'titre' => true,
-            'contenu' => true
+            'title' => true,
+            'body' => true
         ];
     }
 
@@ -414,8 +414,8 @@ comportement par défaut si un champ n'est pas nommé spécifiquement::
     class Article extends Entity
     {
         protected $_accessible = [
-            'titre' => true,
-            'contenu' => true,
+            'title' => true,
+            'body' => true,
             '*' => false,
         ];
     }
@@ -430,7 +430,7 @@ pouvez lui spécifier de ne pas se protéger contre l'assignement de masse::
 
     use App\Model\Entity\Article;
 
-    $article = new Article(['id' => 1, 'titre' => 'Foo'], ['guard' => false]);
+    $article = new Article(['id' => 1, 'title' => 'Foo'], ['guard' => false]);
 
 Modifier les Champs Protégés à la Volée
 ---------------------------------------
@@ -441,8 +441,8 @@ méthode ``setAccess()``::
     // Rendre user_id accessible.
     $article->setAccess('user_id', true);
 
-    // Rendre titre protégé.
-    $article->setAccess('titre', false);
+    // Rendre title protégé.
+    $article->setAccess('title', false);
 
 .. note::
 
@@ -518,8 +518,8 @@ Après avoir ajouté le plugin à votre entity, vous pourrez faire ceci::
     $article = $this->Articles->findById($id);
 
     // La propriété commentaires a été chargée en lazy
-    foreach ($article->commentaires as $commentaire) {
-        echo $commentaire->contenu;
+    foreach ($article->comments as $comment) {
+        echo $comment->body;
     }
 
 Créer du Code Réutilisable avec les Traits
@@ -545,7 +545,7 @@ Ce trait pourrait donner des méthodes pour marquer les entities comme
     {
         public function softDelete()
         {
-            $this->set('supprime', true);
+            $this->set('deleted', true);
         }
     }
 
@@ -600,13 +600,13 @@ doivent être exposés::
 
     class User extends Entity
     {
-        protected $_virtual = ['nom_complet'];
+        protected $_virtual = ['full_name'];
     }
 
 Cette liste peut être modifiée à la volée en utilisant la méthode
 ``setVirtual``::
 
-    $user->setVirtual(['nom_complet', 'is_admin']);
+    $user->setVirtual(['full_name', 'is_admin']);
 
 Cacher les Champs
 -----------------
@@ -628,7 +628,7 @@ définition d'une classe entity, définissez quels champs doivent être cachés:
 Cette liste peut être modifiée à la volée en utilisant la méthode
 ``setHidden``::
 
-    $user->setHidden(['password', 'question_de_recuperation']);
+    $user->setHidden(['password', 'recovery_question']);
 
 Stocker des Types Complexes
 ===========================

--- a/fr/orm/retrieving-data-and-resultsets.rst
+++ b/fr/orm/retrieving-data-and-resultsets.rst
@@ -5,69 +5,73 @@ Récupérer les Données et les Ensembles de Résultats
 
 .. php:class:: Table
 
-Alors que les objets table fournissent une abstraction autour d'un 'dépôt' ou
-d'une collection d'objets, quand vous faîtes une requête pour des
-enregistrements individuels, vous récupérez des objets 'entity'. Cette section
-parle des différentes façons pour trouver et charger les entities, mais vous
-pouvez lire la section :doc:`/orm/entities` pour plus d'informations sur les
-entities.
+Tandis que les objets table fournissent une abstraction autour d'un 'dépôt' ou
+d'une collection d'objets, Les objets 'entity' correspondent à ce que vous
+obtenez quand vous faites une requête sur des enregistrements individuels.
+Dans la mesure où cette section parle des différentes façons de trouver et
+charger les entities, vous pouvez lire préalablement la section
+:doc:`/orm/entities` pour en savoir plus sur les entities.
 
-Débugger les Queries et les ResultSets
+Déboguer les Queries et les ResultSets
 ======================================
 
-Etant donné que l'ORM retourne maintenant des Collections et des Entities,
-débugger ces objets peut être plus compliqué qu'avec les versions précédentes
-de CakePHP. Il y a maintenant plusieurs façons d'inspecter les données
+Étant donné que l'ORM retourne maintenant des Collections et des Entities,
+déboguer ces objets peut être plus compliqué qu'avec les versions précédentes
+de CakePHP. Il y a désormais plusieurs façons d'inspecter les données
 retournées par l'ORM.
 
 - ``debug($query)`` Montre le SQL et les paramètres liés, ne montre pas les
   résultats.
 - ``debug($query->all())`` Montre les propriétés de ResultSet (pas les
   résultats).
+- ``debug($query->toList())`` Montre les résultats dans un tableau.
+- ``debug(iterator_to_array($query))`` Montre les résultats de la requête
+  formatés en tableau.
 - ``debug($query->toArray())`` Une façon facile de montrer chacun des résultats.
 - ``debug(json_encode($query, JSON_PRETTY_PRINT))`` Résultats plus lisibles.
-- ``debug($query->first())`` Montre les propriétés de la première entity que
-  votre requête retournera.
-- ``debug((string)$query->first())`` Montre les propriétés de la première entity
-  que votre requête retournera en JSON.
+- ``debug($query->first())`` Montre les propriétés d'une seule entity.
+- ``debug((string)$query->first())`` Montre les propriétés d'une seule entity en
+  JSON.
 
 Récupérer une Entity Unique avec une Clé Primaire
 =================================================
 
 .. php:method:: get($id, $options = [])
 
-C'est souvent pratique de charger une entity unique à partir de la base de
-données quand vous modifiez ou visualisez les entities et leurs données liées.
+Quand vous modifiez ou visualisez des entities et leurs données liées, il est
+souvent pratique de charger une entity unique à partir de la base de données.
 Vous pouvez faire ceci en utilisant ``get()``::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table.
 
     // Récupère un article unique
     $article = $articles->get($id);
 
     // Récupère un article unique, et les commentaires liés
     $article = $articles->get($id, [
-        'contain' => ['Comments']
+        'contain' => ['Commentaires']
     ]);
 
 Si l'opération get ne trouve aucun résultat, une
 ``Cake\Datasource\Exception\RecordNotFoundException`` sera levée. Vous pouvez
-soit attraper cette exception vous-même, ou permettre à CakePHP de la convertir
-en une erreur 404.
+soit attraper cette exception vous-même, soit permettre à CakePHP de la
+convertir en une erreur 404.
 
 Comme ``find()``, ``get()`` a un cache intégré. Vous pouvez utiliser l'option
 ``cache`` quand vous appelez ``get()`` pour appliquer la mise en cache::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table.
 
-    // Utilise toute config de cache ou une instance de CacheEngine & une clé générée
+    // Utiliser une configuration de cache quelconque,
+    // ou une instance de CacheEngine & une clé générée
     $article = $articles->get($id, [
-        'cache' => 'custom',
+        'cache' => 'cache_personnalise',
     ]);
 
-    // Utilise toute config de cache ou une instance de CacheEngine & une clé spécifique
+    // Utilise une configuration de cache quelconque,
+    // ou une instance de CacheEngine & une clé spécifique
     $article = $articles->get($id, [
-        'cache' => 'custom', 'key' => 'mykey'
+        'cache' => 'cache_personnalise', 'key' => 'ma_cle'
     ]);
 
     // Désactive explicitement la mise en cache
@@ -75,13 +79,13 @@ Comme ``find()``, ``get()`` a un cache intégré. Vous pouvez utiliser l'option
         'cache' => false
     ]);
 
-En option, vous pouvez faire un ``get()`` d'une entity en utilisant
-:ref:`custom-find-methods`. Par exemple vous souhaitez récupérer toutes les
-traductions pour une entity. Vous pouvez le faire en utilisant l'option
+Une autre possibilité est de faire un ``get()`` d'une entity en utilisant
+:ref:`custom-find-methods`. Par exemple si vous souhaitez récupérer toutes les
+traductions pour une entity, vous pouvez le faire en utilisant l'option
 ``finder``::
 
     $article = $articles->get($id, [
-        'finder' => 'translations',
+        'finder' => 'traductions',
     ]);
 
 Utiliser les Finders pour Charger les Données
@@ -94,96 +98,91 @@ plus facile de le faire est d'utiliser la méthode ``find``. La méthode find
 est un moyen simple et extensible pour trouver les données qui vous
 intéressent::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table.
 
     // Trouver tous les articles
     $query = $articles->find('all');
 
-La valeur retournée de toute méthode ``find`` est toujours un objet
-:php:class:`Cake\\ORM\\Query`. La classe Query vous permet de redéfinir
-une requête plus tard après l'avoir créée. Les objets Query sont évalués
-lazily, et ne s'exécutent qu'à partir du moment où vous commencez à récupérer
-des lignes, les convertissez en tableau, ou quand la méthode
-``all()`` est appelée::
+La valeur retournée par une méthode ``find`` est toujours un objet
+:php:class:`Cake\\ORM\\Query`. La classe Query vous permet de réaffiner une
+requête après l'avoir créée. Les objets Query sont évalués *lazily*, et ne
+s'exécutent qu'à partir du moment où vous commencez à récupérer des lignes, les
+convertissez en tableau, ou quand la méthode ``all()`` est appelée::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table.
 
     // Trouver tous les articles.
-    // A ce niveau, la requête n'est pas lancée.
+    // À ce niveau, la requête n'est pas lancée.
     $query = $articles->find('all');
 
     // L'itération va exécuter la requête.
-    foreach ($query as $row) {
+    foreach ($query->all() as $row) {
     }
 
     // Appeler all() va exécuter la requête
-    // et retourne l'ensemble de résultats.
+    // et retourner l'ensemble des résultats.
     $results = $query->all();
 
     // Une fois le résultat obtenu, nous pouvons en récupérer toutes les lignes
-    $data = $results->toArray();
+    $data = $results->toList();
 
-    // Convertir la requête en tableau va l'exécuter.
+    // Convertir la requête en tableau associatif va l'exécuter.
     $data = $query->toArray();
 
 .. note::
 
     Une fois que vous avez commencé une requête, vous pouvez utiliser
     l'interface :doc:`/orm/query-builder` pour construire des requêtes
-    plus complexes, d'ajouter des conditions supplémentaires, des limites,
-    ou d'inclure des associations en utilisant l'interface courante.
+    plus complexes, ajouter des conditions supplémentaires, des limites, ou
+    inclure des associations en utilisant l'interface fluide.
 
 ::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table.
     $query = $articles->find('all')
         ->where(['Articles.created >' => new DateTime('-10 days')])
-        ->contain(['Comments', 'Authors'])
+        ->contain(['Commentaires', 'Auteurs'])
         ->limit(10);
 
-Vous pouvez aussi fournir plusieurs options couramment utilisées avec
-``find()``. Ceci peut aider pour le test puisqu'il y a peu de méthodes à
-mocker::
+Vous pouvez aussi fournir à ``find()`` plusieurs options couramment utilisées.
+Cela peut être utile pour les tests puisqu'il y a peu de méthodes à mocker::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table
     $query = $articles->find('all', [
         'conditions' => ['Articles.created >' => new DateTime('-10 days')],
-        'contain' => ['Authors', 'Comments'],
+        'contain' => ['Auteurs', 'Commentaires'],
         'limit' => 10
     ]);
 
-La liste d'options supportées par find() sont:
+La liste des options supportées par find() est :
 
 - ``conditions`` fournit des conditions pour la clause WHERE de la requête.
-- ``limit`` Définit le nombre de lignes que vous voulez.
-- ``offset`` Définit l'offset de la page que vous souhaitez. Vous pouvez aussi
+- ``limit`` définit le nombre de lignes que vous voulez.
+- ``offset`` définit l'offset de la page que vous souhaitez. Vous pouvez aussi
   utiliser ``page`` pour faciliter le calcul.
 - ``contain`` définit les associations à charger en eager.
-- ``fields`` limite les champs chargés dans l'entity. Charger seulement quelques
-  champs peut faire que les entities se comportent de manière incorrecte.
+- ``fields`` limite les champs chargés dans l'entity. Le fait de ne pas charger
+  tous les champs peut cependant faire que les entities se comportent de manière
+  inappropriée.
 - ``group`` ajoute une clause GROUP BY à votre requête. C'est utile quand vous
-  utilisez les fonctions d'agrégation.
+  utilisez des fonctions d'agrégation.
 - ``having`` ajoute une clause HAVING à votre requête.
 - ``join`` définit les jointures personnalisées supplémentaires.
-- ``order`` ordonne l'ensemble des résultats.
+- ``order`` trie l'ensemble des résultats.
 
-Toute option qui n'est pas dans la liste sera passée aux écouteurs de beforeFind
-où ils peuvent être utilisés pour modifier l'objet requête. Vous pouvez utiliser
+Les options qui ne sont pas dans cette liste seront passées aux écouteurs de
+beforeFind, où ils pourront être utilisés pour modifier l'objet requête. Vous pouvez utiliser
 la méthode ``getOptions`` sur un objet query pour récupérer les options
-utilisées. Alors que vous pouvez très facilement passer des objets requête à
-vos controllers, nous recommandons que vous fassiez plutôt des packages de vos
-requêtes en tant que :ref:`custom-find-methods`.
-Utiliser des méthodes finder personnalisées va vous laisser réutiliser vos
-requêtes et faciliter les tests.
+utilisées. Bien que vous puissiez passer des objets requête à vos controllers,
+nous vous recommandons plutôt de les rassembler dans des
+:ref:`custom-find-methods`. En utilisant des méthodes finder personnalisées,
+vous pourrez réutiliser vos requêtes et cela facilitera les tests.
 
-Par défaut, les requêtes et les ensembles de résultat seront retournés
-en objets :doc:`/orm/entities`. Vous pouvez récupérer des tableaux basiques en
-désactivant l'hydratation::
+Par défaut, les requêtes et les result sets renverront des objets
+:doc:`/orm/entities`. Vous pouvez récupérer des tableaux basiques en désactivant
+l'hydratation::
 
-    $query->enableHydration(false);
-
-    // Avant 3.4.0
-    $query->hydrate(false);
+    $query->disableHydration();
 
     // $data est le ResultSet qui contient le tableau de données.
     $data = $query->all();
@@ -194,28 +193,28 @@ Récupérer les Premiers Résultats
 ================================
 
 La méthode ``first()`` vous permet de récupérer seulement la première ligne
-à partir d'une query. Si la query n'a pas été exécutée, une clause ``LIMIT 1``
+d'une requête. Si la requête n'a pas été exécutée, une clause ``LIMIT 1``
 sera appliquée::
 
-    // Dans un controller ou dans une méthode table.
+    // Dans un controller ou dans une méthode de table.
     $query = $articles->find('all', [
-        'order' => ['Article.created' => 'DESC']
+        'order' => ['Articles.created' => 'DESC']
     ]);
     $row = $query->first();
 
 Cette approche remplace le ``find('first')`` des versions précédentes de
-CakePHP. Vous pouvez aussi utiliser la méthode ``get()`` si vous chargez les
-entities avec leur clé primaire.
+CakePHP. Vous pouvez aussi utiliser la méthode ``get()`` si vous recherchez les
+entities par leur clé primaire.
 
 .. note::
 
-    La méthode ``first()`` va retourner ``null`` si aucun résultat n'est trouvé.
+    La méthode ``first()`` renverra ``null`` si aucun résultat n'est trouvé.
 
 Récupérer un Nombre de Résultats
 ================================
 
 Une fois que vous avez créé un objet query, vous pouvez utiliser la méthode
-``count()`` pour récupérer un nombre de résultats de cette query::
+``count()`` pour récupérer un décompte des résultats de cette query::
 
     // Dans un controller ou une méthode de table.
     $query = $articles->find('all', [
@@ -223,7 +222,7 @@ Une fois que vous avez créé un objet query, vous pouvez utiliser la méthode
     ]);
     $number = $query->count();
 
-Consultez :ref:`query-count` pour l'utilisation supplémentaire de la méthode
+Consultez :ref:`query-count` pour d'autres utilisations de la méthode
 ``count()``.
 
 .. _table-find-list:
@@ -231,10 +230,10 @@ Consultez :ref:`query-count` pour l'utilisation supplémentaire de la méthode
 Trouver les Paires de Clé/Valeur
 ================================
 
-C'est souvent pratique pour générer un tableau associatif de données à partir
-des données de votre application. Par exemple, c'est très utile quand vous
-créez des elements `<select>`. CakePHP fournit une méthode simple à utiliser
-pour générer des 'lists' de données::
+Cette fonctionnalité est pratique pour générer un tableau associatif de données
+à partir des données de votre application. C'est notamment très utile pour la
+création des elements `<select>`. CakePHP fournit une méthode simple à utiliser
+pour générer des listes de données::
 
     // Dans un controller ou dans une méthode de table.
     $query = $articles->find('list');
@@ -242,119 +241,119 @@ pour générer des 'lists' de données::
 
     // Les données ressemblent maintenant à ceci
     $data = [
-        1 => 'First post',
-        2 => 'Second article I wrote',
+        1 => 'Premier post',
+        2 => 'Mon deuxième article',
     ];
 
-Avec aucune option supplémentaire, les clés de ``$data`` seront la clé primaire
-de votre table, alors que les valeurs seront le 'displayField' (champAAfficher)
-de la table. Vous pouvez utiliser la méthode ``setDisplayField()`` sur un objet
-table pour configurer le champ à afficher sur une table::
+Sans autre option, les clés de ``$data`` correspondront à la clé primaire de
+votre table, tandis que les valeurs seront celles du champ désigné dans le
+paramètre 'displayField' de la table. Le 'displayField' par défaut est ``title``
+ou ``name``. Vous pouvez utiliser la méthode ``setDisplayField()`` de la table
+pour configurer le champ à afficher::
 
-    class Articles extends Table
+    class ArticlesTable extends Table
     {
 
         public function initialize(array $config): void
         {
-            $this->setDisplayField('title');
-
-            // Avant 3.4.0
-            $this->displayField('title');
+            $this->setDisplayField('libelle');
         }
     }
 
-Quand vous appelez ``list``, vous pouvez configurer les champs utilisés pour
-la clé et la valeur avec respectivement les options ``keyField`` et
+Au moment où vous appelez ``list``, vous pouvez configurer les champs utilisés
+comme clé et comme valeur respectivement avec les options ``keyField`` et
 ``valueField``::
 
     // Dans un controller ou dans une méthode de table.
     $query = $articles->find('list', [
         'keyField' => 'slug',
-        'valueField' => 'title'
+        'valueField' => 'libelle'
     ]);
     $data = $query->toArray();
 
     // Les données ressemblent maintenant à
     $data = [
-        'first-post' => 'First post',
-        'second-article-i-wrote' => 'Second article I wrote',
+        'premier-post' => 'Premier post',
+        'mon-deuxieme-article' => 'Mon deuxième article',
     ];
 
-Les résultats peuvent être groupés en des ensembles imbriqués. C'est utile
-quand vous voulez des ensembles bucketed ou que vous voulez construire des
-elements ``<optgroup>`` avec ``FormHelper``::
+Les résultats peuvent être regroupés. C'est utile quand vous voulez organiser
+valeurs en sous-groupes, ou que vous voulez construire des elements
+``<optgroup>`` avec ``FormHelper``::
 
     // Dans un controller ou dans une méthode de table.
     $query = $articles->find('list', [
         'keyField' => 'slug',
-        'valueField' => 'title',
-        'groupField' => 'author_id'
+        'valueField' => 'libelle',
+        'groupField' => 'auteur_id'
     ]);
     $data = $query->toArray();
 
     // Les données ressemblent maintenant à
     $data = [
         1 => [
-            'first-post' => 'First post',
-            'second-article-i-wrote' => 'Second article I wrote',
+            'premier-post' => 'Premier post',
+            'mon-deuxieme-article' => 'Mon deuxième article',
         ],
         2 => [
-            // Plus de données.
+            // Les articles d'autres auteurs.
         ]
     ];
 
-Vous pouvez aussi créer une liste de données à partir des associations qui
-peuvent être atteintes avec les jointures::
+Vous pouvez aussi créer une liste de données à partir d'associations pouvant
+être réalisées avec une jointure::
 
     $query = $articles->find('list', [
         'keyField' => 'id',
-        'valueField' => 'author.name'
-    ])->contain(['Authors']);
+        'valueField' => 'auteur.nom'
+    ])->contain(['Auteurs']);
 
-Les expressions ``keyField``, ``valueField``, et ``groupField`` agiront sur le
-chemin des attributs des entités, et non sur des colonnes de la bases de
-données. Vous pouvez donc utiliser des champs vrituels dans les résultats de
+Les expressions ``keyField``, ``valueField``, et ``groupField`` font référence
+au chemin des attributs dans les entités, et non sur des colonnes de la base de
+données. Vous pouvez donc utiliser des champs virtuels dans les résultats de
 ``find(list)``.
 
 Personnaliser la Sortie Clé-Valeur
 ----------------------------------
 
-Enfin il est possible d'utiliser les closures pour accéder aux méthodes de
+Pour finir, il est possible d'utiliser les closures pour accéder aux méthodes de
 mutation des entities dans vos finds list. ::
 
-    // Dasn votre Entity Authors, créez un champ virtuel à utiliser en tant que
-    champ à afficher:
-    protected function _getLabel()
+    // Dans votre Entity Auteurs, créez un champ virtuel
+    // à utiliser en tant que champ à afficher:
+    protected function _getLibelle()
     {
-        return $this->_fields['first_name'] . ' ' . $this->_fields['last_name']
+        return $this->_fields['prenom'] . ' ' . $this->_fields['nom']
           . ' / ' . __('User ID %s', $this->_fields['user_id']);
     }
 
-Cet exemple montre l'utilisation de la méthode accesseur ``_getLabel()`` à
-partir de l'entity Author. ::
+Cet exemple montre l'utilisation de la méthode accesseur ``_getLibellel()``
+dans l'entity Auteur. ::
 
     // Dans vos finders/controller:
     $query = $articles->find('list', [
-        'keyField' => 'id',
-        'valueField' => function ($article) {
-            return $article->author->get('label');
-        }
-    ]);
+            'keyField' => 'id',
+            'valueField' => function ($article) {
+                return $article->auteur->get('libelle');
+            }
+        ])
+        ->contain('Auteurs');
 
-Vous pouvez aussi récupérer le label dans la liste directement en utilisant. ::
 
-    // Dans AuthorsTable::initialize():
-    $this->setDisplayField('label'); // Va utiliser Author::_getLabel()
-    // Dans votre finders/controller:
-    $query = $authors->find('list'); // Va utiliser AuthorsTable::getDisplayField()
+Vous pouvez aussi récupérer le libellé directement dans la liste en utilisant. ::
 
-Trouver des Données Threaded
-============================
+    // Dans AuteursTable::initialize():
+    $this->setDisplayField('libelle'); // Va utiliser Auteur::_getLibelle()
+    // Dans vos finders/controller:
+    $query = $auteurs->find('list'); // Va utiliser AuteursTable::getDisplayField()
 
-Le finder ``find('threaded')`` retourne les entities imbriquées qui sont
-threaded ensemble à travers un champ clé. Par défaut, ce champ est
+Trouver des Données Filées
+==========================
+
+Le finder ``find('threaded')`` retourne des entities imbriquées qui sont filées
+ensemble grâce à un champ servant de clé. Par défaut, ce champ est
 ``parent_id``. Ce finder vous permet d'accéder aux données stockées dans une
-table de style 'liste adjacente'. Toutes les entities qui matchent un
+table de style 'liste adjacente'. Toutes les entities qui correspondent à un
 ``parent_id`` donné sont placées sous l'attribut ``children``::
 
     // Dans un controller ou dans une méthode table.
@@ -371,26 +370,26 @@ table de style 'liste adjacente'. Toutes les entities qui matchent un
     echo $results[0]->children[0]->comment;
 
 Les clés ``parentField`` et ``keyField`` peuvent être utilisées pour définir
-les champs sur lesquels le threading va être.
+les champs qui vont servir au filage.
 
 .. tip::
-    Si vous devez gérer des données en arbre plus compliquées, pensez à
-    utiliser :doc:`/orm/behaviors/tree` à la place.
+    Si vous devez gérer des données en arbre plus compliquées, utiliser de
+    préférence le :doc:`/orm/behaviors/tree`.
 
 .. _custom-find-methods:
 
 Méthodes Finder Personnalisées
 ==============================
 
-Les exemples ci-dessus montrent la façon d'utiliser les finders intégrés
-``all`` et ``list``. Cependant, il est possible et recommandé d'intégrer
-vos propres méthodes finder. Les méthodes finder sont idéales pour faire
-des packages de requêtes utilisées couramment, vous permettant de faire
-abstraction de détails de a requête en une méthode facile à utiliser. Les
-méthodes finder sont définies en créant les méthodes en suivant la convention
-``findFoo`` où ``Foo`` est le nom du finder que vous souhaitez créer. Par
-exemple si nous voulons ajouter un finder à notre table articles pour trouver
-des articles publiés, nous ferions ce qui suit::
+Les exemples ci-dessus montrent comment utiliser les finders intégrés ``all``
+et ``list``. Cependant, il est possible et recommandé d'implémenter vos propres
+méthodes finder. Les méthodes finder sont idéales pour rassembler des requêtes
+utilisées couramment, ce qui vous permet de fournir une abstraction facile à
+utiliser pour de nombreux détails de la requête. Les méthodes finder sont
+définies en créant des méthodes nomméed par convention ``findFoo``, où ``Foo``
+est le nom que vous souhaitez donner à votre finder. Par exemple, si nous
+voulons ajouter à notre table d'articles un finder servant à rechercher parmi
+les articles d'un certain auteur, nous ferions ceci::
 
     use Cake\ORM\Query;
     use Cake\ORM\Table;
@@ -398,67 +397,50 @@ des articles publiés, nous ferions ce qui suit::
     class ArticlesTable extends Table
     {
 
-        public function findPublished(Query $query, array $options)
+        public function findEcritPar(Query $query, array $options)
         {
-            $query->where([
-                'Articles.published' => true,
-                'Articles.moderated' => true
-            ]);
-            return $query;
+            $user = $options['user'];
+            return $query->where(['auteur_id' => $user->id]);
         }
 
     }
 
-    // Dans un controller ou dans une méthode table.
-    // Prior to 3.6 use TableRegistry::get('Articles')
-    $articles = TableRegistry::getTableLocator()->get('Articles');
-    $query = $articles->find('published');
+    $query = $articles->find('ecritPar', ['user' => $userEntity]);
 
-Les méthodes finder peuvent modifier la requête comme ceci, ou utiliser
-``$options`` pour personnaliser l'opération finder avec la logique
-d'application concernée. Vous pouvez aussi 'stack' les finders, vous
-permettant de faire des requêtes complexes sans efforts. En supposant que
-vous avez à la fois les finders 'published' et 'recent', vous pouvez faire
-ce qui suit::
+Les méthodes finder peuvent modifier la requête comme il se doit, ou utiliser
+l'argument ``$options`` pour personnaliser l'opération finder selon la logique
+souhaitée. Vous pouvez aussi 'empiler' les finders, ce qui permet d'exprimer
+sans effort des requêtes complexes. En supposant que vous ayez à la fois des
+finders 'published' et 'recent', vous pourriez très bien faire ceci::
 
-    // Dans un controller ou dans une méthode de table.
-    // Prior to 3.6 use TableRegistry::get('Articles')
-    $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find('published')->find('recent');
 
-Alors que les exemples pour l'instant ont montré les méthodes finder sur les
-classes table, les méthodes finder peuvent aussi être définies sur les
-:doc:`/orm/behaviors`.
+Bien que tous les exemples que nous avons cités jusqu'ici montrent des finders
+qui s'appliquent sur des tables, il est aussi possible de définir des méthodes
+finder sur des :doc:`/orm/behaviors`.
 
 Si vous devez modifier les résultats après qu'ils ont été récupérés, vous
-pouvez utiliser une fonction :ref:`map-reduce` pour modifier les résultats.
-Les fonctionnalités de map reduce remplacent le callback 'afterFind' qu'on
-avait dans les versions précédentes de CakePHP.
+pouvez utiliser une fonction :ref:`map-reduce`. Les fonctionnalités de map
+reduce remplacent le callback 'afterFind' présent dans les précédentes versions
+de CakePHP.
 
 .. _dynamic-finders:
 
 Finders Dynamiques
 ==================
 
-L'ORM de CakePHP fournit des méthodes de finder construites dynamiquement qui
-vous permettent d'exprimer des requêtes simples sans aucun code supplémentaire.
-Par exemple si vous vouliez trouver un utilisateur selon son username, vous
-pourriez faire::
+L'ORM de CakePHP fournit des finders construits dynamiquement, qui vous
+permettent d'exprimer des requêtes simples sans écrire de code particulier.
+Par exemple, admettons que vous recherchiez un utilisateur à partir de son
+*username*. Vous pourriez procéder ainsi::
 
     // Dans un controller
     // Les deux appels suivants sont équivalents.
     $query = $this->Users->findByUsername('joebob');
     $query = $this->Users->findAllByUsername('joebob');
 
-    // Dans une méthode de table
-    // Prior to 3.6 use TableRegistry::get('Users')
-    $users = TableRegistry::getTableLocator()->get('Users');
-    // Les deux appels suivants sont équivalents.
-    $query = $users->findByUsername('joebob');
-    $query = $users->findAllByUsername('joebob');
-
-Lors de l'utilisation de finders dynamiques, vous pouvez faire des contraintes
-sur plusieurs champs::
+Les finders dynamiques permettent même de filtrer sur plusieurs champs à la
+fois::
 
     $query = $users->findAllByUsernameAndApproved('joebob', 1);
 
@@ -466,50 +448,52 @@ Vous pouvez aussi créer des conditions ``OR``::
 
     $query = $users->findAllByUsernameOrEmail('joebob', 'joe@example.com');
 
-Alors que vous pouvez utiliser des conditions OR ou AND, vous ne pouvez pas
-combiner les deux dans un finder unique dynamique. Les autres options de requête
-comme ``contain`` ne sont aussi pas supportées avec les finders dynamiques. Vous
-devrez utiliser :ref:`custom-find-methods` pour encapsuler plus de requêtes
-complexes. Dernier point, vous pouvez aussi combiner les finders dynamiques
-avec des finders personnalisés::
+Vous pouvez utiliser des conditions OR ou AND, mais vous ne pouvez pas combiner
+les deux dans un même finder dynamique. Les autres options de requête comme
+``contain`` ne sont pas non plus supportées par les finders dynamiques. Vous
+devrez utiliser des :ref:`custom-find-methods` pour encapsuler des requêtes plus
+complexes. Pour finir, vous pouvez aussi combiner les finders dynamiques avec
+des finders personnalisés::
 
     $query = $users->findTrollsByUsername('bro');
 
-Ce qui est au-dessus se traduirait dans ce qui suit::
+Ce qui se traduirait ainsi::
 
     $users->find('trolls', [
         'conditions' => ['username' => 'bro']
     ]);
 
-Une fois que vous avez un objet query à partir d'un finder dynamique, vous
-devrez appeler ``first()`` si vous souhaitez le premier résultat.
+Une fois que vous avez un objet query créé à partir d'un finder dynamique, vous
+devrez appeler ``first()`` si vous souhaitez récupérer le premier résultat.
 
 .. note::
 
-    Alors que les finders dynamiques facilitent la gestion des requêtes, ils
-    entraînent des coûts de performance supplémentaires.
+    Bien que les finders dynamiques facilitent la gestion des requêtes, ils
+    introduisent de petites contraintes. Vous ne pouvez pas appeler des méthodes
+    ``findBy`` à partir d'un objet Query. Si vous voulez enchaîner des finders,
+    le finder dynamique doit donc être appelé en premier.
 
 Récupérer les Données Associées
 ===============================
 
-Quand vous voulez récupérer des données associées, ou filtrer selon les données
-associées, il y a deux façons:
+Pour récupérer des données associées, ou filtrer selon les données associées, il
+y a deux façons de procéder:
 
-- utiliser les fonctions query de l'ORM de CakePHP comme ``contain()`` et
-  ``matching()``
-- utiliser les fonctions de jointures comme ``innerJoin()``, ``leftJoin()``, et
-  ``rightJoin()``
+- utiliser des fonctions de requêtage de l'ORM de CakePHP telles que
+  ``contain()`` et ``matching()``
+- utiliser des fonctions de jointures telles que ``innerJoin()``,
+  ``leftJoin()``, et ``rightJoin()``.
 
-Vous pouvez utiliser ``contain()`` quand vous voulez charger le model primaire
-et ses données associées. Alors que ``contain()`` va vous laisser appliquer
-des conditions supplémentaires aux associations chargées, vous ne pouvez pas
-donner des contraintes au model primaire selon les associations. Pour plus de
+Vous devriez utiliser ``contain()`` quand vous voulez charger le modèle primaire
+et ses données associées. Bien que ``contain()`` vous permette d'appliquer des
+conditions supplémentaires sur les associations chargées, vous ne pouvez pas
+filtrer le modèle primaire en fonction des données associées. Pour plus de
 détails sur ``contain()``, consultez :ref:`eager-loading-associations`.
 
-Vous pouvez utiliser ``matching()`` quand vous souhaitez donner des contraintes
-au model primaire selon les associations. Par exemple, vous voulez charger tous
-les articles qui ont un tag spécifique. Pour plus de détails sur ``matching()``,
-consultez :ref:`filtering-by-associated-data`.
+Vous devriez utiliser ``matching()`` quand vous souhaitez filtrer le modèle
+primaire en fonction des données associées. Par exemple, quand vous voulez
+charger tous les articles auxquels est associé un tag spécifique. Pour plus de
+détails sur ``matching()``, consultez :ref:`filtering-by-associated-data`.
 
 Si vous préférez utiliser les fonctions de jointure, vous pouvez consulter
 :ref:`adding-joins` pour plus d'informations.
@@ -521,190 +505,204 @@ Eager Loading des Associations Via Contain
 
 Par défaut, CakePHP ne charge **aucune** donnée associée lors de l'utilisation
 de ``find()``. Vous devez faire un 'contain' ou charger en eager chaque
-association que vous souhaitez charger dans vos résultats.
+association que vous souhaitez voir figurer dans vos résultats.
 
 .. start-contain
 
-Chaque Eager loading évite plusieurs problèmes potentiels de chargement
-lors du lazy loading dans un ORM. Les requêtes générées par le eager loading
-peuvent augmenter l'impact des jointures, permettant de faire des
-requêtes plus efficaces. Dans CakePHP vous définissez des associations chargées
-en eager en utilisant la méthode 'contain'::
+L'eager loading aide à éviter la plupart des problèmes potentiels de performance
+qui entourent le lazy loading dans un ORM. Les requêtes générées par eager
+loading peuvent davantage tirer parti des jointures, ce qui permet de créer des
+requêtes plus efficaces. Dans CakePHP, vous utilisez la méthode 'contain' pour
+indiquer quelles associations doivent être chargées en eager::
 
     // Dans un controller ou une méthode de table.
 
     // En option du find()
-    $query = $articles->find('all', ['contain' => ['Authors', 'Comments']]);
+    $query = $articles->find('all', ['contain' => ['Auteurs', 'Commentaires']]);
 
     // En méthode sur un objet query
     $query = $articles->find('all');
-    $query->contain(['Authors', 'Comments']);
+    $query->contain(['Auteurs', 'Commentaires']);
 
-Ce qui est au-dessus va charger les auteurs et commentaires liés pour chaque
-article de l'ensemble de résultats. Vous pouvez charger les associations
-imbriquées en utilisant les tableaux imbriqués pour définir les
-associations à charger::
+Ceci va charger les auteurs et commentaires liés à chaque article du *result
+set*. Vous pouvez charger des associations imbriquées en utilisant les tableaux
+imbriqués pour définir les associations à charger::
 
     $query = $articles->find()->contain([
-        'Authors' => ['Addresses'], 'Comments' => ['Authors']
+        'Auteurs' => ['Addresses'], 'Commentaires' => ['Auteurs']
     ]);
 
-D'une autre façon, vous pouvez exprimer des associations imbriquées en utilisant
-la notation par point::
+Au choix, vous pouvez aussi exprimer des associations imbriquées en utilisant la
+notation par points::
 
     $query = $articles->find()->contain([
-        'Authors.Addresses',
-        'Comments.Authors'
+        'Auteurs.Addresses',
+        'Commentaires.Auteurs'
     ]);
 
 Vous pouvez charger les associations en eager aussi profondément que vous le
 souhaitez::
 
-    $query = $products->find()->contain([
-        'Shops.Cities.Countries',
-        'Shops.Managers'
+    $query = $produits->find()->contain([
+        'Magasins.Villes.Pays',
+        'Magasins.Managers'
     ]);
 
 Vous pouvez sélectionner des champs de toutes les associations en utilisant
 plusieurs appels à ``contain()``::
 
     $query = $this->find()->select([
-        'Realestates.id',
-        'Realestates.title',
-        'Realestates.description'
+        'Immeubles.id',
+        'Immeubles.titre',
+        'Immeubles.description'
     ])
     ->contain([
-        'RealestateAttributes' => [
-            'Attributes' => [
+        'ImmeublesAttributs' => [
+            'Attributs' => [
                 'fields' => [
-                    // Les champs alias dans contain() doivent
-                    // inclure le préfixe du modèle à mapper correctement.
-                    'Attributes__name' => 'attr_name'
+                    // Les champs dépendant d'un alias doivent inclure le préfixe
+                    // du modèle dans contain() pour être mappés correctement.
+                    'Attributs__nom' => 'attr_nom'
                 ]
             ]
         ]
     ])
     ->contain([
-        'RealestateAttributes' => [
+        'ImmeublesAttributs' => [
             'fields' => [
-                'RealestateAttributes.realestate_id',
-                'RealestateAttributes.value'
+                'ImmeublesAttributs.immeuble_id',
+                'ImmeublesAttributs.valeur'
             ]
         ]
     ])
     ->where($condition);
 
-Si vous avez besoin de remettre les contain sur une requête, vous pouvez
+Si vous avez besoin de réinitialiser les *contain* sur une requête, vous pouvez
 définir le second argument à ``true``::
 
     $query = $articles->find();
-    $query->contain(['Authors', 'Comments'], true);
+    $query->contain(['Auteurs', 'Commentaires'], true);
+ 
+.. note::
+
+    Les noms d'association dans les appels à ``contain()`` doivent respecter la
+    casse (majuscules/minuscules) avec lequelle votre association a été définie,
+    et non pas selon le nom de la propriété utilisée pour accéder aux données
+    associées depuis l'entity. Par exemple, si vous avez déclaré une association
+    par ``belongsTo('Users')``, alors vous devez utiliser ``contain('Users')``
+    et pas ``contain('users')`` ni ``contain('user')``.
 
 Passer des Conditions à Contain
 -------------------------------
 
 Avec l'utilisation de ``contain()``, vous pouvez restreindre les données
-retournées par les associations et les filtrer par conditions::
+retournées par les associations et les filtrer par conditions. Pour spécifier
+des conditions, passez une fonction anonyme qui reçoit en premier argument la
+query, de type ``\Cake\ORM\Query``::
 
     // Dans un controller ou une méthode de table.
-
-    $query = $articles->find()->contain('Comments', function ($q) {
-       return $q
-            ->select(['body', 'author_id'])
-            ->where(['Comments.approved' => true]);
+    $query = $articles->find()->contain('Commentaires', function (Query $q) {
+        return $q
+            ->select(['contenu', 'auteur_id'])
+            ->where(['Commentaires.approuve' => true]);
     });
 
 Cela fonctionne aussi pour la pagination au niveau du Controller::
 
     $this->paginate['contain'] = [
-        'Comments' => function (\Cake\ORM\Query $query) {
-            return $query->select(['body', 'author_id'])
-            ->where(['Comments.approved' => true]);
+        'Commentaires' => function (Query $query) {
+            return $query->select(['contenu', 'auteur_id'])
+            ->where(['Commentaires.approuve' => true]);
         }
     ];
 
-.. note::
+.. warning::
 
-    Quand vous limitez les champs qui sont récupérés d'une association, vous
-    **devez** vous assurer que les colonnes de clé étrangère soient
-    sélectionnées. Ne pas sélectionner les champs de clé étrangère va entraîner
-    la non présence des données associées dans le résultat final.
+    Si vous constatez qu'il manque des entités associées, vérifiez que les
+    champs de clés étrangères sont bien sélectionnés dans la requête. Sans les
+    clés étrangères, l'ORM ne peut pas retrouver les lignes correspondantes.
 
-Il est aussi possible de restreindre les associations imbriquées profondément
-en utilisant la notation par point::
+Il est aussi possible de restreindre les associations imbriquées en utilisant la
+notation par point::
 
     $query = $articles->find()->contain([
-        'Comments',
-        'Authors.Profiles' => function ($q) {
-            return $q->where(['Profiles.is_published' => true]);
+        'Commentaires',
+        'Auteurs.Profils' => function (Query $q) {
+            return $q->where(['Profils.is_published' => true]);
         }
     ]);
 
-Dans l'exemple ci-dessus, vous obtiendrez les auteurs même s'ils n'ont pas
+Dans cet exemple, vous obtiendrez les auteurs même s'ils n'ont pas
 de profil publié. Pour ne récupérer que les auteurs avec un profil publié,
 utilisez :ref:`matching() <filtering-by-associated-data>`.
 
-Si vous avez des méthodes de finder personnalisées dans votre table associée,
+Si vous avez des finders personnalisés dans votre table associée,
 vous pouvez les utiliser à l'intérieur de ``contain()``::
 
     // Récupère tous les articles, mais récupère seulement les commentaires qui
     // sont approuvés et populaires.
-    $query = $articles->find()->contain('Comments', function ($q) {
-        return $q->find('approved')->find('popular');
+    $query = $articles->find()->contain('Commentaires', function ($q) {
+        return $q->find('approuve')->find('populaire');
     });
 
 .. note::
 
     Pour les associations ``BelongsTo`` et ``HasOne``, seules les clauses
-    ``where`` et ``select`` sont utilisées lors du chargement des
-    enregistrements associés. Pour le reste des types d'association, vous pouvez
-    utiliser chaque clause que l'objet query fournit.
+    ``where`` et ``select`` sont utilisées lors du chargement par ``contain()``.
+    Avec ``HasMany`` et ``BelongsToMany``, toutes les clauses sont valides,
+    telles que ``order()``.
 
-Si vous devez prendre le contrôle total d'une requête qui est générée, vous
-pouvez appeler ``contain()`` pour ne pas ajouter les contraintes ``foreignKey``
-à la requête générée. Dans ce cas, vous devez utiliser un tableau en passant
-``foreignKey`` et ``queryBuilder``::
+Vous pouvez contrôler plus que les simples clauses utilisées par ``contain()``.
+Si vous passez un tableau avec l'association, vous pouvez surcharger
+``foreignKey``, ``joinType`` et ``strategy``. Reportez-vous à
+:doc:`/orm/associations` pour plus de détails sur la valeur par défaut et les
+options de chaque type d'association.
+
+Vous pouvez passer ``false`` comme nouvelle valeur de ``foreignKey`` pour
+désactiver complètement les contraintes liées aux clés étrangères.
+Utilisez l'option ``queryBuilder`` pour personnaliser la requête quand vous
+passez un tableau::
 
     $query = $articles->find()->contain([
-        'Authors' => [
+        'Auteurs' => [
             'foreignKey' => false,
-            'queryBuilder' => function ($q) {
-                return $q->where(...); // Full conditions for filtering
+            'queryBuilder' => function (Query $q) {
+                return $q->where(...); // Conditions complètes pour le filtrage
             }
         ]
     ]);
 
 Si vous avez limité les champs que vous chargez avec ``select()`` mais que
-vous souhaitez aussi charger les champs enlevés des associations avec contain,
+vous souhaitez aussi charger les champs des associations avec contain,
 vous pouvez passer l'objet association à ``select()``::
 
-    // Sélectionne id & title de articles, mais tous les champs enlevés pour Users.
+    // Sélectionne id & titre de articles, mais aussi tous les champs de Users.
     $query = $articles->find()
-        ->select(['id', 'title'])
+        ->select(['id', 'titre'])
         ->select($articles->Users)
         ->contain(['Users']);
 
-D'une autre façon, si vous pouvez faire des associations multiples, vous
-pouvez utiliser ``enableAutoFields()``::
+Autre possibilité, si vous avez des associations multiples, vous pouvez utiliser
+``enableAutoFields()``::
 
-    // Sélectionne id & title de articles, mais tous les champs enlevés de
-    // Users, Comments et Tags.
-    $query->select(['id', 'title'])
-        ->contain(['Comments', 'Tags'])
-        ->enableAutoFields(true) // Avant 3.4.0 utilisez autoFields(true)
-        ->contain(['Users' => function($q) {
+    // Sélectionne id & titre de articles, mais tous les champs de
+    // Users, Commentaires et Tags.
+    $query->select(['id', 'titre'])
+        ->contain(['Commentaires', 'Tags'])
+        ->enableAutoFields(true)
+        ->contain(['Users' => function(Query $q) {
             return $q->autoFields(true);
         }]);
 
-Ordonner les Associations Contain
----------------------------------
+Trier les Associations Contain
+------------------------------
 
 Quand vous chargez des associations HasMany et BelongsToMany, vous pouvez
-utiliser l'option ``sort`` pour ordonner les données dans ces associations::
+utiliser l'option ``sort`` pour trier les données dans ces associations::
 
     $query->contain([
-        'Comments' => [
-            'sort' => ['Comments.created' => 'DESC']
+        'Commentaires' => [
+            'sort' => ['Commentaires.created' => 'DESC']
         ]
     ]);
 
@@ -717,24 +715,24 @@ Filtrer par les Données Associées Via Matching et Joins
 
 .. start-filtering
 
-Un cas de requête couramment fait avec les associations est de trouver les
-enregistrements qui 'matchent' les données associées spécifiques. Par exemple
-si vous avez 'Articles belongsToMany Tags', vous aurez probablement envie de
-trouver les Articles qui ont le tag CakePHP. C'est extrêmement simple
-à faire avec l'ORM de CakePHP::
+Un cas de requête couramment utilisé avec les associations consiste à trouver
+les enregistrements qui correspondent à certaines données associées. Par exemple
+si vous avez une association 'Articles belongsToMany Tags', vous voudrez
+probablement trouver les Articles qui portent le tag *CakePHP*. C'est
+extrêmement simple à faire avec l'ORM de CakePHP::
 
-    // Dans un controller ou table de méthode.
+    // Dans un controller ou une méthode de table.
 
     $query = $articles->find();
     $query->matching('Tags', function ($q) {
-        return $q->where(['Tags.name' => 'CakePHP']);
+        return $q->where(['Tags.nom' => 'CakePHP']);
     });
 
 Vous pouvez aussi appliquer cette stratégie aux associations HasMany. Par
-exemple si 'Authors HasMany Articles', vous pouvez trouver tous les auteurs
-avec les articles récemment publiés en utilisant ce qui suit::
+exemple si 'Auteurs HasMany Articles', vous pouvez trouver tous les auteurs
+ayant publié un article récemment en écrivant ceci::
 
-    $query = $authors->find();
+    $query = $auteurs->find();
     $query->matching('Articles', function ($q) {
         return $q->where(['Articles.created >=' => new DateTime('-10 days')]);
     });
@@ -742,35 +740,35 @@ avec les articles récemment publiés en utilisant ce qui suit::
 La syntaxe de ``contain()``, qui doit déjà vous être familière, permet aussi de
 filtrer des associations imbriquées::
 
-    // Dans un controller ou une table de méthode.
-    $query = $products->find()->matching(
-        'Shops.Cities.Countries', function ($q) {
-            return $q->where(['Countries.name' => 'Japan']);
+    // Dans un controller ou une méthode de table.
+    $query = $produits->find()->matching(
+        'Magasins.Villes.Pays', function ($q) {
+            return $q->where(['Pays.nom' => 'Japon']);
         }
     );
 
-    // Récupère les articles uniques qui étaient commentés par 'markstory'
-    // en utilisant la variable passée
-    // Les chemins avec points doivent être utilisés plutôt que les appels
-    // imbriqués de matching()
+    // Récupère les articles qui ont été commentés par 'markstory',
+    // en passant une variable.
+    // Utiliser la notation par points plutôt que des appels imbriqués à matching()
     $username = 'markstory';
-    $query = $articles->find()->matching('Comments.Users', function ($q) use ($username) {
+    $query = $articles->find()->matching('Commentaires.Users', function ($q) use ($username) {
         return $q->where(['username' => $username]);
     });
 
 .. note::
 
-    Comme cette fonction va créer un ``INNER JOIN``, vous pouvez appeler
-    ``distinct`` sur le find de la requête puisque vous aurez des lignes
-    dupliquées si les conditions ne les excluent pas déjà. Ceci peut être le
-    cas, par exemple, quand les mêmes utilisateurs commentent plus d'une fois
-    un article unique.
+    Dans la mesure où cette fonction va créer un ``INNER JOIN``, il serait
+    judicieux d'utiliser ``distinct`` dans la requête. Sinon, vous risquez
+    d'obtenir des doublons si les conditions posées ne l'excluent pas par
+    principe. Dans notre exemple, cela peut être le cas si un utilisateur
+    commente plusieurs fois le même article.
 
-Les données des associations qui sont 'matchés' (appairés) seront disponibles
+Les données des associations qui correspondent aux conditions (données
+*matchées*) seront disponibles
 dans l'attribut ``_matchingData`` des entities. Si vous utilisez à la fois
-match et contain sur la même association, vous pouvez vous attendre à recevoir
-à la fois la propriété ``_matchingData`` et la propriété standard d'association
-dans vos résultats.
+``match`` et ``contain`` sur la même association, vous pouvez vous attendre à
+avoir à la fois la propriété ``_matchingData`` et la propriété standard
+d'association dans vos résultats.
 
 Utiliser innerJoinWith
 ----------------------
@@ -779,13 +777,13 @@ Utiliser la fonction ``matching()``, comme nous l'avons vu précédemment, va
 créer un ``INNER JOIN`` avec l'association spécifiée et va aussi charger les
 champs dans un ensemble de résultats.
 
-Il peut arriver que vous vouliez utiliser ``matching()`` mais que vous n'êtes
-pas intéressé par le chargement des champs dans un ensemble de résultats. Dans
-ce cas, vous pouvez utiliser ``innerJoinWith()``::
+Il peut arriver que vous veuillez utiliser ``matching()`` mais que vous n'êtes
+pas intéressé par le chargement des champs de l'association. Dans ce cas, vous
+pouvez utiliser ``innerJoinWith()``::
 
     $query = $articles->find();
     $query->innerJoinWith('Tags', function ($q) {
-        return $q->where(['Tags.name' => 'CakePHP']);
+        return $q->where(['Tags.nom' => 'CakePHP']);
     });
 
 La méthode ``innerJoinWith()`` fonctionne de la même manière que ``matching()``,
@@ -793,14 +791,44 @@ ce qui signifie que vous pouvez utiliser la notation par points pour faire des
 jointures pour les associations imbriquées profondément::
 
     $query = $products->find()->innerJoinWith(
-        'Shops.Cities.Countries', function ($q) {
-            return $q->where(['Countries.name' => 'Japan']);
+        'Magasins.Villes.Pays', function ($q) {
+            return $q->where(['Pays.nom' => 'Japon']);
         }
     );
 
-De même, la seule différence est qu'aucune colonne supplémentaire ne sera
-ajoutée à l'ensemble de résultats et aucune propriété ``_matchingData`` ne sera
-définie.
+Si vous voulez à la fois poser des conditions sur certains champs de
+l'association et charger d'autres champs de cette même association, vous pouvez
+parfaitement combiner ``innerJoinWith()`` et ``contain()``.
+L'exemple ci-dessous filtre les Articles qui ont des Tags spécifiques et charge
+ces Tags::
+ 
+    $filter = ['Tags.nom' => 'CakePHP'];
+    $query = $articles->find()
+        ->distinct($articles->getPrimaryKey())
+        ->contain('Tags', function (Query $q) use ($filter) {
+            return $q->where($filter);
+        })
+        ->innerJoinWith('Tags', function (Query $q) use ($filter) {
+            return $q->where($filter);
+        });
+
+.. note::
+    Si vous utilisez ``innerJoinWith()`` et que vous voulez sélectionner des
+    champs de cette association avec ``select()``, vous devez utiliser un alias
+    pour les noms des champs::
+
+        $query
+            ->select(['nom_pays' => 'Pays.nom'])
+            ->innerJoinWith('Pays');
+ 
+    Sinon, vous verrez les données dans ``_matchingData``, comme cela a été
+    décrit ci-dessous à propos de ``matching()``. C'est un angle mort de 
+    ``matching()``, qui ne sait pas que vous avez sélectionné des champs.
+
+.. warning::
+    Vous ne devez pas combiner ``innerJoinWith()`` and ``matching()`` pour la
+    même association. Cela produirait de multiple requêtes ``INNER JOIN`` et ne
+    réaliserait pas ce que vous en attendez.
 
 Utiliser notMatching
 --------------------
@@ -814,146 +842,129 @@ l'association spécifiée::
     $query = $articlesTable
         ->find()
         ->notMatching('Tags', function ($q) {
-            return $q->where(['Tags.name' => 'boring']);
+            return $q->where(['Tags.nom' => 'ennuyeux']);
         });
 
-L'exemple ci-dessus va trouver tous les articles qui n'étaient pas taggés avec
-le mot ``boring``. Vous pouvez aussi utiliser cette méthode avec les
+L'exemple ci-dessus va trouver tous les articles qui n'ont pas été taggés avec
+le mot ``ennuyeux``. Vous pouvez aussi utiliser cette méthode avec les
 associations HasMany. Vous pouvez, par exemple, trouver tous les auteurs qui
-n'ont aucun article dans les 10 derniers jours::
+n'ont publié aucun article dans les 10 derniers jours::
 
-    $query = $authorsTable
+    $query = $auteursTable
         ->find()
         ->notMatching('Articles', function ($q) {
             return $q->where(['Articles.created >=' => new \DateTime('-10 days')]);
         });
 
 Il est aussi possible d'utiliser cette méthode pour filtrer les enregistrements
-qui ne matchent pas les associations profondes. Par exemple, vous pouvez
+qui ne matchent pas des associations imbriquées. Par exemple, vous pouvez
 trouver les articles qui n'ont pas été commentés par un utilisateur précis::
 
     $query = $articlesTable
         ->find()
-        ->notMatching('Comments.Users', function ($q) {
+        ->notMatching('Commentaires.Users', function ($q) {
             return $q->where(['username' => 'jose']);
         });
 
-Puisque les articles avec aucun commentaire satisfont aussi la condition
-du dessus, vous pouvez combiner ``matching()`` et ``notMatching()`` dans la
-même requête. L'exemple suivant va trouver les articles ayant au moins un
+Puisque les articles n'ayant absolument aucun commentaire satisfont aussi cette
+condition, vous aurez intérêt à combiner ``matching()`` et ``notMatching()``
+dans cette requête. L'exemple suivant recherchera les articles ayant au moins un
 commentaire, mais non commentés par un utilisateur précis::
 
     $query = $articlesTable
         ->find()
-        ->notMatching('Comments.Users', function ($q) {
+        ->notMatching('Commentaires.Users', function ($q) {
             return $q->where(['username' => 'jose']);
         })
-        ->matching('Comments');
+        ->matching('Commentaires');
 
 .. note::
 
     Comme ``notMatching()`` va créer un ``LEFT JOIN``, vous pouvez envisager
-    d'appeler ``distinct`` sur la requête find puisque sinon vous allez avoir
-    des lignes dupliquées.
+    d'appeler ``distinct`` sur la requête pour éviter d'obtenir des lignes
+    dupliquées.
 
 Gardez à l'esprit que le contraire de la fonction ``matching()``,
-``notMatching()`` ne va pas ajouter toutes les données à la propriété
-``_matchingData`` dans les résultats.
+``notMatching()``, ne va pas ajouter de données à la propriété ``_matchingData``
+dans les résultats.
 
 Utiliser leftJoinWith
 ---------------------
 
-Dans certaines situations, vous aurez à calculer un résultat selon une
-association, sans avoir à charger tous les enregistrements. Par
-exemple, si vous voulez charger le nombre total de commentaires qu'un article
-a, ainsi que toutes les données de l'article, vous pouvez utiliser la fonction
+Dans certaines situations, vous aurez à calculer un résultat à partir d'une
+association, sans avoir à charger tous ses enregistrements. Par
+exemple, si vous voulez charger le nombre total de commentaires d'un article, en
+parallèle des données de l'article, vous pouvez utiliser la fonction
 ``leftJoinWith()``::
 
     $query = $articlesTable->find();
-    $query->select(['total_comments' => $query->func()->count('Comments.id')])
-        ->leftJoinWith('Comments')
+    $query->select(['total_commentaires' => $query->func()->count('Commentaires.id')])
+        ->leftJoinWith('Commentaires')
         ->group(['Articles.id'])
-        ->enableAutoFields(true); // Avant 3.4.0 utilisez autoFields(true)
+        ->enableAutoFields(true);
 
-Le résultat de la requête ci-dessus va contenir les données de l'article et
-la propriété ``total_comments`` pour chacun d'eux.
+Le résultat de cette requête contiendra les données de l'article et la propriété
+``total_comments`` pour chacun d'eux.
 
-``leftJoinWith()`` peut aussi être utilisée avec des associations profondes.
-C'est utile par exemple pour rapporter le nombre d'articles taggés par l'auteur
-avec un certain mot::
+``leftJoinWith()`` peut aussi être utilisée avec des associations imbriquées.
+C'est utile par exemple pour rechercher, pour chaque auteur, le nombre
+d'articles taggés avec un certain mot::
 
-    $query = $authorsTable
+    $query = $auteursTable
         ->find()
         ->select(['total_articles' => $query->func()->count('Articles.id')])
         ->leftJoinWith('Articles.Tags', function ($q) {
-            return $q->where(['Tags.name' => 'awesome']);
+            return $q->where(['Tags.nom' => 'redoutable']);
         })
-        ->group(['Authors.id'])
-        ->enableAutoFields(true); // Avant 3.4.0 utilisez autoFields(true)
+        ->group(['Auteurs.id'])
+        ->enableAutoFields(true);
 
-Cette fonction ne va charger aucune colonne des associations spécifiées dans
-l'ensemble de résultats.
+Cette fonction ne va charger aucune colonne des associations spécifiées dans les
+résultats.
 
 .. end-filtering
 
 Changer les Stratégies de Récupération
 ======================================
 
-Comme vous le savez peut-être déjà, les associations ``belongsTo`` et ``hasOne``
-sont chargées en utilisant un ``JOIN`` dans la requête du finder principal.
-Bien que ceci améliore la requête et la vitesse de récupération des données et
-permet de créer des conditions plus parlantes lors de la récupération des
-données, cela peut devenir un problème quand vous devez appliquer certaines
-clauses à la requête finder pour l'association, comme ``order()`` ou
-``limit()``.
+Comme cela a été dit, vous pouvez personnaliser la stratégie (*strategy*)
+utilisée par une association dans un ``contain()``.
 
-Par exemple, si vous souhaitez récupérer le premier commentaire d'un article
-en association::
-
-   $articles->hasOne('FirstComment', [
-        'className' => 'Comments',
-        'foreignKey' => 'article_id'
-   ]);
-
-Afin de récupérer correctement les données de cette association, nous devrons
-dire à la requête d'utiliser la stratégie ``select``, puisque nous voulons
-trier selon une colonne en particulier::
+Si vous observez les options des :doc:`associations </orm/associations>`
+``BelongsTo`` et ``HasOne``, vous constaterez que la stratégie par défaut 'join'
+et le type de jointure (``joinType``) 'INNER' peuvent être remplacés par
+'select'::
 
     $query = $articles->find()->contain([
-        'FirstComment' => [
-                'strategy' => 'select',
-                'queryBuilder' => function ($q) {
-                    return $q->order(['FirstComment.created' =>'ASC'])->limit(1);
-                }
+        'Commentaires' => [
+            'strategy' => 'select',
         ]
     ]);
 
-Changer la stratégie de façon dynamique de cette façon va seulement l'appliquer
-pour une requête spécifique. Si vous souhaitez rendre le changement de stratégie
-permanent, vous pouvez faire::
+Cela peut être utile lorsque vous avez besoin de conditions qui ne font pas bon
+ménage avec une jointure. Cela ouvre aussi la possibilité de requêter des tables
+entre lesquelles vous n'avez pas l'autorisation de faire des jointures, par
+exemple des tables se trouvant dans deux bases de données différentes.
 
-    $articles->FirstComment->setStrategy('select');
-
-    // Avant 3.4.0
-    $articles->FirstComment->strategy('select');
-
-Utiliser la stratégie ``select`` est aussi une bonne façon de faire des
-associations avec des tables d'une autre base de données, puisqu'il ne serait
-pas possible de récupérer des enregistrements en utilisant ``joins``.
+Habituellement, vous définisser la stratégie d'une association quand vous la
+définissez, dans la méthode ``Table::initialize()``, mais vous pouvez changer
+manuellement la stratégie de façon permanente::
+ 
+    $articles->Commentaires->setStrategy('select');
 
 Récupération Avec la Stratégie de Sous-Requête
 ----------------------------------------------
 
-Avec la taille de vos tables qui grandit, la récupération des associations
-peut devenir lente, spécialement si vous faîtes des grandes requêtes en une
-fois. Un bon moyen d'optimiser le chargement des associations ``hasMany`` et
+Quand vos tables grandissent en taille, la récupération des associations
+peut ralentir sensiblement, en particulier si vous faites de grandes requêtes en
+une fois. Un bon moyen d'optimiser le chargement des associations ``hasMany`` et
 ``belongsToMany`` est d'utiliser la stratégie ``subquery``::
 
     $query = $articles->find()->contain([
-        'Comments' => [
+        'Commentaires' => [
                 'strategy' => 'subquery',
                 'queryBuilder' => function ($q) {
-                    return $q->where(['Comments.approved' => true]);
+                    return $q->where(['Commentaires.approuve' => true]);
                 }
         ]
     ]);
@@ -961,90 +972,78 @@ fois. Un bon moyen d'optimiser le chargement des associations ``hasMany`` et
 Le résultat va rester le même que pour la stratégie par défaut, mais
 ceci peut grandement améliorer la requête et son temps de récupération dans
 certaines bases de données, en particulier cela va permettre de récupérer des
-grandes portions de données en même temps, dans des bases de données qui
-limitent le nombre de paramètres liés par requête, comme le **Serveur Microsoft
-SQL**.
-
-Vous pouvez aussi rendre la stratégie pour les associations permanente en
-faisant::
-
-    $articles->Comments->setStrategy('subquery');
-
-    // Avant 3.4.0
-    $articles->Comments->strategy('subquery');
+grandes portions de données en même temps dans les bases de données qui
+limitent le nombre de paramètres liés par requête, comme **Microsoft SQL
+Server**.
 
 Lazy loading des Associations
 =============================
 
-Bien que CakePHP propose le chargement en eager de vos associations, il y a des
-cas où vous devrez charger en lazy les associations. Vous devez vous référer
-aux sections :ref:`lazy-load-associations` et
+CakePHP propose le chargement de vos associations en eager. Cependant il y a des
+cas où vous aurez besoin de charger les associations en lazy. Consultez les
+sections :ref:`lazy-load-associations` et
 :ref:`loading-additional-associations` pour plus d'informations.
 
-Travailler avec des Ensembles de Résultat
-=========================================
+Travailler sur les Résultats (Result Sets)
+===========================================
 
-Une fois qu'une requête est exécutée avec ``all()``, vous récupèrerez une
-instance de :php:class:`Cake\\ORM\\ResultSet`. Cet objet permet de manipuler les
-données résultantes de vos requêtes. Comme les objets Query, les ensembles de
-résultats sont une :doc:`Collection </core-libraries/collections>` et vous
-pouvez utiliser toute méthode de collection sur des objets ResultSet.
+Une fois qu'une requête est exécutée avec ``all()``, vous récupérez une
+instance de :php:class:`Cake\\ORM\\ResultSet`. Cet objet propose des outils
+puissants pour manipuler les données renvoyées par vos requêtes. Comme les
+objets Query, un ResultSet est une
+:doc:`Collection </core-libraries/collections>` et vous
+pouvez donc appeler sur celui-ci n'importe quelle méthode propre aux
+collections.
 
-Les objets ResultSet vont charger lazily les lignes à partir de la requête
-préparée sous-jacente.
-Par défaut, les résultats seront mis en mémoire vous permettant
-d'itérer un ensemble de résultats plusieurs fois, ou de mettre en cache et
-d'itérer les résultats. Si vous devez travailler sur un ensemble de données qui
-ne rentre pas dans la mémoire, vous pouvez désactiver la mise en mémoire sur la
-requête pour faire un stream des résultats::
+Les objets ResultSet vont charger les lignes paresseusement (*lazily*) à partir
+de la requête préparée sous-jacente. Par défaut, les résultats seront mis en
+mémoire tampon, vous permettant ainsi de parcourir les résultats plusieurs fois,
+ou de mettre les résultats en cache et d'itérer dessus. Si vous travaillez sur
+un ensemble de données trop large pour tenir en mémoire, vous pouvez désactiver
+la mise en mémoire tampon depuis la requête pour travailler sur les résultats à
+la volée::
 
-    $query->enableBufferedResults(false);
+    $query->disableBufferedResults();
 
-    // Avant 3.4.0
-    $query->bufferResults(false);
+Stopper la mise en mémoire tampon appelle quelques mises en garde:
 
-Stopper la mise en mémoire tampon nécessite quelques mises en garde:
-
-#. Vous ne pourrez plus itérer un ensemble de résultats plus d'une fois.
-#. Vous ne pourrez plus aussi itérer et mettre en cache les résultats.
-#. La mise en mémoire tampon ne peut pas être désactivé pour les requêtes qui
+#. Vous ne pourrez itérer les résultats qu'une seule fois.
+#. Vous ne pourrez pas non plus itérer et mettre en cache les résultats.
+#. La mise en mémoire tampon ne peut pas être désactivée pour les requêtes qui
    chargent en eager les associations hasMany ou belongsToMany, puisque ces
    types d'association nécessitent le chargement en eager de tous les résultats
-   pour que les requêtes dépendantes puissent être générées.
+   afin de générer les requêtes dépendantes.
 
 .. warning::
 
-    Les résultats de streaming alloueront toujours l'espace mémoire nécessaire
-    pour les résultats complets lorsque vous utilisez PostgreSQL et SQL Server.
-    Ceci est dû à des limitations dans PDO.
+    Traiter les résultats à la volée continuera d'allouer l'espace mémoire
+    nécessaire pour la totalité des résultats lorsque vous utilisez PostgreSQL
+    et SQL Server. Ceci est dû à des limitations dans PDO.
 
-Les ensembles de résultat vous permettent de mettre en cache/serializer ou
-d'encoder en JSON les résultats pour les résultats d'une API::
+Les ResultSets vous permettent de mettre en cache, de sérialiser ou d'encoder en
+JSON les résultats::
 
     // Dans un controller ou une méthode de table.
     $results = $query->all();
 
-    // Serializé
+    // Serialisé
     $serialized = serialize($results);
 
     // Json
     $json = json_encode($results);
 
-Les sérialisations et encodage en JSON des ensembles de résultats fonctionne
-comme vous pouvez vous attendre. Les données sérialisées peuvent être
-désérializées en un ensemble de résultats de travail. Convertir en JSON
-garde les configurations de champ caché & virtuel sur tous les objets
-entity dans un ensemble de résultat.
+La sérialisation des ResultSets et l'encodage en JSON fonctionnent comme vous
+pouvez vous y attendre. Les données sérialisées peuvent être désérialisées en un
+ResultSet fonctionnel. La conversion en JSON respecte la configuration des
+champs cachés et des champs virtuels dans tous les objets entity inclus dans le
+ResultSet.
 
-Les ensembles de résultats sont un
-objet 'Collection' et supportent les mêmes méthodes que les
-:doc:`objets collection </core-libraries/collections>`. Par exemple, vous
+Les ResultSets sont des objets 'Collection' et supportent les mêmes méthodes que
+les :doc:`objets collection </core-libraries/collections>`. Par exemple, vous
 pouvez extraire une liste des tags uniques sur une collection d'articles en
 exécutant::
 
     // Dans un controller ou une méthode de table.
-    // Prior to 3.6 use TableRegistry::get('Articles')
-    $articles = TableRegistry::getTableLocator()->get('Articles');
     $query = $articles->find()->contain(['Tags']);
 
     $reducer = function ($output, $value) {
@@ -1058,8 +1057,8 @@ exécutant::
         ->extract('tags.name')
         ->reduce($reducer, []);
 
-Ci-dessous quelques autres exemples des méthodes de collection utilisées
-avec des ensembles de données::
+Ci-dessous quelques autres exemples de méthodes de collection utilisées avec des
+ResultSets::
 
     // Filtre les lignes sur une propriété calculée
     $filtered = $results->filter(function ($row) {
@@ -1067,21 +1066,20 @@ avec des ensembles de données::
     });
 
     // Crée un tableau associatif depuis les propriétés du résultat
-    // Prior to 3.6 use TableRegistry::get('Articles')
-    $articles = TableRegistry::getTableLocator()->get('Articles');
-    $results = $articles->find()->contain(['Authors'])->all();
+    $results = $articles->find()->contain(['Auteurs'])->all();
 
-    $authorList = $results->combine('id', 'author.name');
+    $auteursList = $results->combine('id', 'auteur.nom');
 
 Le chapitre :doc:`/core-libraries/collections` comporte plus de détails sur
-ce qui peut être fait avec les ensembles de résultat en utilisant les
-fonctionnalités des collections.
+ce qu'on peut faire avec les fonctionnalités des collections sur des ResultSets.
+La section :ref:`format-results` montre comment ajouter des champs calculés, ou
+remplacer le ResutSet.
 
 Récupérer le Premier & Dernier enregistrement à partir d'un ResultSet
 ---------------------------------------------------------------------
 
 Vous pouvez utiliser les méthodes ``first()`` et ``last()`` pour récupérer
-les enregistrements respectifs à partir d'un ensemble de résultats::
+respectivement le premier et le dernier enregistrement d'un ResultSet::
 
     $result = $articles->find('all')->all();
 
@@ -1089,8 +1087,8 @@ les enregistrements respectifs à partir d'un ensemble de résultats::
     $row = $result->first();
     $row = $result->last();
 
-Récupérer un Index arbitraire à partir d'un ResultSet
------------------------------------------------------
+Récupérer une Ligne Spécifique d'un ResultSet
+---------------------------------------------
 
 Vous pouvez utiliser ``skip()`` et ``first()`` pour récupérer un enregistrement
 arbitraire à partir d'un ensemble de résultats::
@@ -1100,12 +1098,12 @@ arbitraire à partir d'un ensemble de résultats::
     // Récupère le 5ème enregistrement
     $row = $result->skip(4)->first();
 
-Vérifier si une Requête Query ou un ResultSet est vide
-------------------------------------------------------
+Vérifier si une Requête ou un ResultSet est vide
+------------------------------------------------
 
 Vous pouvez utiliser la méthode ``isEmpty()`` sur un objet Query ou ResultSet
-pour voir s'il contient au moins une colonne. Appeler ``isEmpty()`` sur un
-objet Query va évaluer la requête::
+pour savoir s'il contient au moins une ligne. Appeler ``isEmpty()`` sur un
+objet Query va exécuter la requête::
 
     // Vérifie une requête.
     $query->isEmpty();
@@ -1116,19 +1114,19 @@ objet Query va évaluer la requête::
 
 .. _loading-additional-associations:
 
-Chargement d'Associations Additionnelles
+Charger des Associations Supplémentaires
 ----------------------------------------
 
-Une fois que vous avez créé un ensemble de résultats, vous pourriez vouloir
-charger en eager des associations additionnelles. C'est le moment idéal pour charger
-des données. Vous pouvez charger des associations additionnelles en utilisant
-``loadInto()``::
+Une fois que vous avez créé un ResultSet, vous pourriez vouloir charger en eager
+des associations supplémentaires. C'est le moment idéal pour charger
+paresseusement des données en eager. Vous pouvez charger des associations
+supplémentaires en utilisant ``loadInto()``::
 
     $articles = $this->Articles->find()->all();
-    $withMore = $this->Articles->loadInto($articles, ['Comments', 'Users']);
+    $withMore = $this->Articles->loadInto($articles, ['Commentaires', 'Users']);
 
 Vous pouvez charger en eager des données additionnelles dans une entity unique
-ou une collection d'entites.
+ou une collection d'entities.
 
 .. _map-reduce:
 
@@ -1136,119 +1134,119 @@ Modifier les Résultats avec Map/Reduce
 ======================================
 
 La plupart du temps, les opérations ``find`` nécessitent un traitement
-postérieur des données qui se trouvent dans la base de données. Alors que les
-méthodes ``getter`` des ``entities`` peuvent s'occuper de la plupart de la
-génération de propriété virtuelle ou un formatage de données spéciales, parfois
-vous devez changer la structure des données d'une façon plus fondamentale.
+après-coup des données de la base de données. Les accesseurs (*getters*) des
+entities peuvent s'occuper de générer la plupart des propriétés virtuelles ou
+des formats de données particuliers ; néanmoins vous serez parfois amené à
+changer la structure des données de façon plus radicale.
 
-Pour ces cas, l'objet ``Query`` offre la méthode ``mapReduce()``, qui est une
-façon de traiter les résultats une fois qu'ils ont été récupérés dans la
+Pour ces situations, l'objet ``Query`` propose la méthode ``mapReduce()``, qui
+est une façon de traiter les résultats après qu'ils ont été récupérés dans la
 base de données.
 
-Un exemple habituel de changement de structure de données est le groupement de
-résultats basé sur certaines conditions. Pour cette tâche, nous
-pouvons utiliser la fonction ``mapReduce()``. Nous avons besoin de deux
-fonctions appelables ``$mapper`` et ``$reducer``.
-La callable ``$mapper`` reçoit le résultat courant de la base de données en
-premier argument, la clé d'itération en second paramètre et finalement elle
-reçoit une instance de la routine ``MapReduce`` qu'elle lance::
+Un exemple classique de changement de structure de données est le regroupement
+des résultats selon certaines conditions. Nous pouvons utiliser la fonction
+``mapReduce()`` pour cette tâche. Nous avons besoin de deux
+fonctions appelées ``$mapper`` et ``$reducer``.
+La fonction ``$mapper`` reçoit en premier argument un résultat de la base de
+données, en second argument la clé d'itération et en troisième elle reçoit une
+instance de la routine ``MapReduce`` en train d'être éxecutée::
 
     $mapper = function ($article, $key, $mapReduce) {
-        $status = 'published';
-        if ($article->isDraft() || $article->isInReview()) {
-            $status = 'unpublished';
+        $status = 'publié';
+        if ($article->estBrouillon() || $article->estEnRevision()) {
+            $status = 'non publié';
         }
         $mapReduce->emitIntermediate($article, $status);
     };
 
-Dans l'exemple ci-dessus, ``$mapper`` calcule le statut d'un article, soit
-publié (published) soit non publié (unpublished), ensuite il appelle
-``emitIntermediate()`` sur l'instance ``MapReduce``. Cette méthode stocke
-l'article dans la liste des articles avec pour label soit publié (published)
-ou non publié (unpublished).
+Dans cet exemple, ``$mapper`` calcule le statut d'un article, soit publié soit
+non publié. Ensuite il appelle ``emitIntermediate()`` sur l'instance
+``MapReduce``. Cette méthode insère l'article dans la liste des articles soit
+sous l'étiquette 'publié', soit sous l'étiquette 'non publié'.
 
-La prochaine étape dans le processus de map-reduce  est de consolider les
-résultats finaux. Pour chaque statut créé dans le mapper, la fonction
-``$reducer`` va être appelée donc vous pouvez faire des traitements
-supplémentaires. Cette fonction va recevoir la liste des articles dans un
-"bucket" particulier en premier paramètre, le nom du "bucket" dont il a
-besoin pour faire le traitement en second paramètre, et encore une fois, comme
-dans la fonction ``mapper()``, l'instance de la routine ``MapReduce`` en
-troisième paramètre. Dans notre exemple, nous n'avons pas fait de traitement
-supplémentaire, donc nous avons juste ``emit()`` les résultats finaux::
+La prochaine étape dans le processus de map-reduce est la consolidation des
+résultats finaux. La fonction ``$reducer`` sera appelée sur chaque statut créé
+dans le mapper, de manière à ce que vous puissiez faire des traitements
+supplémentaires. Cette fonction va recevoir la liste des articles d'un certain
+"tas" en premier paramètre, le nom du tas à traiter en second paramètre, et à
+nouveau, comme pour la fonction ``mapper()``, l'instance de la routine
+``MapReduce`` en troisième paramètre. Dans notre exemple, nous n'avons pas
+besoin de retraiter les listes d'articles une fois qu'elles sont constituées,
+donc nous nous contentons d'émettre (*emit*) les résultats finaux::
 
     $reducer = function ($articles, $status, $mapReduce) {
         $mapReduce->emit($articles, $status);
     };
 
-Finalement, nous pouvons mettre ces deux fonctions ensemble pour faire le
-groupement::
+Pour finir, nous pouvons passer ces deux fonctions pour exécuter le
+regroupement::
 
-    $articlesByStatus = $articles->find()
-        ->where(['author_id' => 1])
-        ->mapReduce($mapper, $reducer);
+    $articlesParStatut = $articles->find()
+        ->where(['auteur_id' => 1])
+        ->mapReduce($mapper, $reducer)
+        ->all();
 
-    foreach ($articlesByStatus as $status => $articles) {
-        echo sprintf("The are %d %s articles", count($articles), $status);
+    foreach ($articlesParStatut as $statut => $articles) {
+        echo sprintf("Il y a %d articles avec le statut %s", count($articles), $statut);
     }
 
-Ce qui est au-dessus va afficher les lignes suivantes::
+Ce qui va afficher la sortie suivante::
 
-    There are 4 published articles
-    There are 5 unpublished articles
+    Il y a 4 articles avec le statut publié
+    Il y a 5 articles avec le statut non publié
 
-Bien sûr, ceci est un exemple simple qui pourrait être solutionné d'une autre
+Bien sûr, ceci est un exemple simple qui pourrait être résolu d'une autre
 façon sans l'aide d'un traitement map-reduce. Maintenant, regardons un autre
 exemple dans lequel la fonction reducer sera nécessaire pour faire quelque
 chose de plus que d'émettre les résultats.
 
-Calculer les mots mentionnés le plus souvent, où les articles contiennent
-l'information sur CakePHP, comme d'habitude nous avons besoin d'une fonction
+Pour calculer les mots mentionnés le plus souvent dans les articles contenant
+des informations sur CakePHP, comme d'habitude nous avons besoin d'une fonction
 mapper::
 
     $mapper = function ($article, $key, $mapReduce) {
-        if (stripos($article['body'], 'cakephp') === false) {
+        if (stripos($article['contenu'], 'cakephp') === false) {
             return;
         }
 
-        $words = array_map('strtolower', explode(' ', $article['body']));
-        foreach ($words as $word) {
-            $mapReduce->emitIntermediate($article['id'], $word);
+        $mots = array_map('strtolower', explode(' ', $article['contenu']));
+        foreach ($mots as $mot) {
+            $mapReduce->emitIntermediate($article['id'], $mot);
         }
     };
 
 Elle vérifie d'abord si le mot "cakephp" est dans le corps de l'article, et
 ensuite coupe le corps en mots individuels. Chaque mot va créer son propre
-``bucket`` où chaque id d'article sera stocké. Maintenant réduisons nos
-résultats pour extraire seulement le compte::
+``tas``, où chaque id d'article sera stocké. Maintenant réduisons nos
+résultats pour extraire seulement le décompte du nombre de mots::
 
-    $reducer = function ($occurrences, $word, $mapReduce) {
-        $mapReduce->emit(count($occurrences), $word);
+    $reducer = function ($occurrences, $mot, $mapReduce) {
+        $mapReduce->emit(count($occurrences), $mot);
     }
 
-Finalement, nous mettons tout ensemble::
+Pour finir, nous mettons tout ensemble::
 
-    $wordCount = $articles->find()
-        ->where(['published' => true])
-        ->andWhere(['published_date >=' => new DateTime('2014-01-01')])
-        ->enableHydrate(false) // Avant 3.4.0 utilisez hydrate(false)
+    $nbMots = $articles->find()
+        ->where(['publie' => true])
+        ->andWhere(['publication_date >=' => new DateTime('2014-01-01')])
+        ->disableHydration()
         ->mapReduce($mapper, $reducer)
-        ->toArray();
+        ->all();
 
-Ceci pourrait retourner un tableau très grand si nous ne nettoyons pas les mots
-interdits, mais il pourrait ressembler à ceci::
+Ceci pourrait retourner un tableau très grand si nous ne purgeons pas les petits
+mots, mais cela pourrait ressembler à ceci::
 
     [
         'cakephp' => 100,
-        'awesome' => 39,
-        'impressive' => 57,
-        'outstanding' => 10,
-        'mind-blowing' => 83
+        'génial' => 39,
+        'impressionnant' => 57,
+        'remarquable' => 10,
+        'hallucinant' => 83
     ]
 
 Un dernier exemple et vous serez un expert de map-reduce. Imaginez que vous
-avez une table de ``friends`` et que vous souhaitiez trouver les "fake friends"
-dans notre base de données ou, autrement dit, les gens qui ne se suivent pas
+ayez une table ``amis`` et que vous souhaitiez trouver les "faux amis"
+dans notre base de données ou, autrement dit, des gens qui ne se suivent pas
 mutuellement. Commençons avec notre fonction ``mapper()``::
 
     $mapper = function ($rel, $key, $mr) {
@@ -1272,31 +1270,31 @@ La clé de premier niveau étant un utilisateur, les nombres positifs indiquent
 que l'utilisateur suit d'autres utilisateurs et les nombres négatifs qu'il est
 suivi par d'autres utilisateurs.
 
-Maintenant, il est temps de la réduire. Pour chaque appel au reducer, il va recevoir
-une liste de followers par utilisateur::
+Maintenant, il est temps de la réduire. Pour chaque appel au reducer, il va
+recevoir une liste de followers par utilisateur::
 
-    $reducer = function ($friends, $user, $mr) {
-        $fakeFriends = [];
+    $reducer = function ($amis, $user, $mr) {
+        $fauxAmis = [];
 
-        foreach ($friends as $friend) {
-            if ($friend > 0 && !in_array(-$friend, $friends)) {
-                $fakeFriends[] = $friend;
+        foreach ($amis as $ami) {
+            if ($ami > 0 && !in_array(-$ami, $amis)) {
+                $fauxAmis[] = $ami;
             }
         }
 
-        if ($fakeFriends) {
-            $mr->emit($fakeFriends, $user);
+        if ($fauxAmis) {
+            $mr->emit($fauxAmis, $user);
         }
     };
 
 Et nous fournissons nos fonctions à la requête::
 
     $fakeFriends = $friends->find()
-        ->enableHydrate(false) // Avant 3.4.0 utilisez hydrate(false)
+        ->disableHydration()
         ->mapReduce($mapper, $reducer)
-        ->toArray();
+        ->all();
 
-Ceci retournerait un tableau similaire à ceci::
+Ceci retournerait un tableau ressemblant à::
 
     [
         1 => [2, 4],
@@ -1304,8 +1302,8 @@ Ceci retournerait un tableau similaire à ceci::
         ...
     ]
 
-Les tableaux résultants signifient, par exemple, que l'utilisateur avec l'id
-``1`` suit les utilisateurs ``2`` and ``4``, mais ceux-ci ne suivent pas
+Ce tableau final signifie, par exemple, que l'utilisateur avec l'id
+``1`` suit les utilisateurs ``2`` et ``4``, mais ceux-ci ne suivent pas
 ``1`` de leur côté.
 
 Stacking Multiple Operations
@@ -1315,21 +1313,21 @@ L'utilisation de `mapReduce` dans une requête ne va pas l'exécuter
 immédiatement. L'opération va être enregistrée pour être lancée dès que
 l'on tentera de récupérer le premier résultat.
 Ceci vous permet de continuer à chainer les méthodes et les filtres
-à la requête même après avoir ajouté une routine map-reduce::
+sur la requête même après avoir ajouté une routine map-reduce::
 
     $query = $articles->find()
-        ->where(['published' => true])
+        ->where(['publie' => true])
         ->mapReduce($mapper, $reducer);
 
     // Plus loin dans votre app:
     $query->where(['created >=' => new DateTime('1 day ago')]);
 
 C'est particulièrement utile pour construire des méthodes finder personnalisées
- comme décrit dans la section :ref:`custom-find-methods`::
+comme décrit dans la section :ref:`custom-find-methods`::
 
-    public function findPublished(Query $query, array $options)
+    public function findPublie(Query $query, array $options)
     {
-        return $query->where(['published' => true]);
+        return $query->where(['publie' => true]);
     }
 
     public function findRecent(Query $query, array $options)
@@ -1337,40 +1335,40 @@ C'est particulièrement utile pour construire des méthodes finder personnalisé
         return $query->where(['created >=' => new DateTime('1 day ago')]);
     }
 
-    public function findCommonWords(Query $query, array $options)
+    public function findMotsCourants(Query $query, array $options)
     {
-        // Same as in the common words example in the previous section
+        // Comme dans l'exemple précédent sur la fréquence des mots
         $mapper = ...;
         $reducer = ...;
         return $query->mapReduce($mapper, $reducer);
     }
 
-    $commonWords = $articles
-        ->find('commonWords')
-        ->find('published')
+    $motsCourant = $articles
+        ->find('motsCourants')
+        ->find('publie')
         ->find('recent');
 
-En plus, il est aussi possible d'empiler plus d'une opération ``mapReduce``
-pour une requête unique. Par exemple, si nous souhaitons avoir les mots les
+De plus, il est aussi possible d'empiler plusieurs opérations ``mapReduce``
+pour une même requête. Par exemple, si nous souhaitons avoir les mots les
 plus couramment utilisés pour les articles, mais ensuite les filtrer pour
-seulement retourner les mots qui étaient mentionnés plus de 20 fois tout au long
-des articles::
+retourner uniquement les mots qui étaient mentionnés plus de 20 fois tout au
+long des articles::
 
-    $mapper = function ($count, $word, $mr) {
-        if ($count > 20) {
-            $mr->emit($count, $word);
+    $mapper = function ($nb, $mot, $mr) {
+        if ($nb > 20) {
+            $mr->emit($nb, $mot);
         }
     };
 
-    $articles->find('commonWords')->mapReduce($mapper);
+    $articles->find('motsCourants')->mapReduce($mapper)->all();
 
 Retirer Toutes les Opérations Map-reduce Empilées
 -------------------------------------------------
 
-Dans les mêmes circonstances vous voulez modifier un objet ``Query`` pour
-que les opérations ``mapReduce`` ne soient pas exécutées du tout. Ceci peut
-être fait en appelant la méthode avec les deux paramètres à null et le troisième
-paramètre (overwrite) à ``true``::
+Dans certaines circonstances vous pourriez vouloir modifier un objet ``Query``
+pour que les opérations ``mapReduce`` prévues ne soient pas exécutées du tout.
+Vous pouvez le faire en appelant la méthode avec les deux paramètres à null et
+le troisième paramètre (overwrite) à ``true``::
 
     $query->mapReduce(null, null, true);
 

--- a/fr/orm/retrieving-data-and-resultsets.rst
+++ b/fr/orm/retrieving-data-and-resultsets.rst
@@ -49,7 +49,7 @@ Vous pouvez faire ceci en utilisant ``get()``::
 
     // Récupère un article unique, et les commentaires liés
     $article = $articles->get($id, [
-        'contain' => ['Commentaires']
+        'contain' => ['Comments']
     ]);
 
 Si l'opération get ne trouve aucun résultat, une
@@ -141,7 +141,7 @@ convertissez en tableau, ou quand la méthode ``all()`` est appelée::
     // Dans un controller ou dans une méthode de table.
     $query = $articles->find('all')
         ->where(['Articles.created >' => new DateTime('-10 days')])
-        ->contain(['Commentaires', 'Auteurs'])
+        ->contain(['Comments', 'Authors'])
         ->limit(10);
 
 Vous pouvez aussi fournir à ``find()`` plusieurs options couramment utilisées.
@@ -150,7 +150,7 @@ Cela peut être utile pour les tests puisqu'il y a peu de méthodes à mocker::
     // Dans un controller ou dans une méthode de table
     $query = $articles->find('all', [
         'conditions' => ['Articles.created >' => new DateTime('-10 days')],
-        'contain' => ['Auteurs', 'Commentaires'],
+        'contain' => ['Authors', 'Comments'],
         'limit' => 10
     ]);
 
@@ -256,7 +256,7 @@ pour configurer le champ à afficher::
 
         public function initialize(array $config): void
         {
-            $this->setDisplayField('libelle');
+            $this->setDisplayField('label');
         }
     }
 
@@ -267,7 +267,7 @@ comme clé et comme valeur respectivement avec les options ``keyField`` et
     // Dans un controller ou dans une méthode de table.
     $query = $articles->find('list', [
         'keyField' => 'slug',
-        'valueField' => 'libelle'
+        'valueField' => 'label'
     ]);
     $data = $query->toArray();
 
@@ -284,8 +284,8 @@ valeurs en sous-groupes, ou que vous voulez construire des elements
     // Dans un controller ou dans une méthode de table.
     $query = $articles->find('list', [
         'keyField' => 'slug',
-        'valueField' => 'libelle',
-        'groupField' => 'auteur_id'
+        'valueField' => 'label',
+        'groupField' => 'author_id'
     ]);
     $data = $query->toArray();
 
@@ -305,8 +305,8 @@ Vous pouvez aussi créer une liste de données à partir d'associations pouvant
 
     $query = $articles->find('list', [
         'keyField' => 'id',
-        'valueField' => 'auteur.nom'
-    ])->contain(['Auteurs']);
+        'valueField' => 'author.name'
+    ])->contain(['Authors']);
 
 Les expressions ``keyField``, ``valueField``, et ``groupField`` font référence
 au chemin des attributs dans les entités, et non sur des colonnes de la base de
@@ -319,33 +319,33 @@ Personnaliser la Sortie Clé-Valeur
 Pour finir, il est possible d'utiliser les closures pour accéder aux méthodes de
 mutation des entities dans vos finds list. ::
 
-    // Dans votre Entity Auteurs, créez un champ virtuel
+    // Dans votre Entity Authors, créez un champ virtuel
     // à utiliser en tant que champ à afficher:
     protected function _getLibelle()
     {
-        return $this->_fields['prenom'] . ' ' . $this->_fields['nom']
+        return $this->_fields['first_name'] . ' ' . $this->_fields['last_name']
           . ' / ' . __('User ID %s', $this->_fields['user_id']);
     }
 
-Cet exemple montre l'utilisation de la méthode accesseur ``_getLibellel()``
-dans l'entity Auteur. ::
+Cet exemple montre l'utilisation de la méthode accesseur ``_getLabel()``
+dans l'entity Author. ::
 
     // Dans vos finders/controller:
     $query = $articles->find('list', [
             'keyField' => 'id',
             'valueField' => function ($article) {
-                return $article->auteur->get('libelle');
+                return $article->author->get('label');
             }
         ])
-        ->contain('Auteurs');
+        ->contain('Authors');
 
 
 Vous pouvez aussi récupérer le libellé directement dans la liste en utilisant. ::
 
-    // Dans AuteursTable::initialize():
-    $this->setDisplayField('libelle'); // Va utiliser Auteur::_getLibelle()
+    // Dans AuthorsTable::initialize():
+    $this->setDisplayField('label'); // Va utiliser Author::_getLabel()
     // Dans vos finders/controller:
-    $query = $auteurs->find('list'); // Va utiliser AuteursTable::getDisplayField()
+    $query = $authors->find('list'); // Va utiliser AuthorsTable::getDisplayField()
 
 Trouver des Données Filées
 ==========================
@@ -400,7 +400,7 @@ les articles d'un certain auteur, nous ferions ceci::
         public function findEcritPar(Query $query, array $options)
         {
             $user = $options['user'];
-            return $query->where(['auteur_id' => $user->id]);
+            return $query->where(['author_id' => $user->id]);
         }
 
     }
@@ -518,60 +518,60 @@ indiquer quelles associations doivent être chargées en eager::
     // Dans un controller ou une méthode de table.
 
     // En option du find()
-    $query = $articles->find('all', ['contain' => ['Auteurs', 'Commentaires']]);
+    $query = $articles->find('all', ['contain' => ['Authors', 'Comments']]);
 
     // En méthode sur un objet query
     $query = $articles->find('all');
-    $query->contain(['Auteurs', 'Commentaires']);
+    $query->contain(['Authors', 'Comments']);
 
 Ceci va charger les auteurs et commentaires liés à chaque article du *result
 set*. Vous pouvez charger des associations imbriquées en utilisant les tableaux
 imbriqués pour définir les associations à charger::
 
     $query = $articles->find()->contain([
-        'Auteurs' => ['Addresses'], 'Commentaires' => ['Auteurs']
+        'Authors' => ['Addresses'], 'Comments' => ['Authors']
     ]);
 
 Au choix, vous pouvez aussi exprimer des associations imbriquées en utilisant la
 notation par points::
 
     $query = $articles->find()->contain([
-        'Auteurs.Addresses',
-        'Commentaires.Auteurs'
+        'Authors.Addresses',
+        'Comments.Authors'
     ]);
 
 Vous pouvez charger les associations en eager aussi profondément que vous le
 souhaitez::
 
     $query = $produits->find()->contain([
-        'Magasins.Villes.Pays',
-        'Magasins.Managers'
+        'Shops.Cities.Countries',
+        'Shops.Managers'
     ]);
 
 Vous pouvez sélectionner des champs de toutes les associations en utilisant
 plusieurs appels à ``contain()``::
 
     $query = $this->find()->select([
-        'Immeubles.id',
-        'Immeubles.titre',
-        'Immeubles.description'
+        'Realestates.id',
+        'Realestates.title',
+        'Realestates.description'
     ])
     ->contain([
-        'ImmeublesAttributs' => [
-            'Attributs' => [
+        'RealestatesAttributes' => [
+            'Attributes' => [
                 'fields' => [
                     // Les champs dépendant d'un alias doivent inclure le préfixe
                     // du modèle dans contain() pour être mappés correctement.
-                    'Attributs__nom' => 'attr_nom'
+                    'Attributes__name' => 'attr_name'
                 ]
             ]
         ]
     ])
     ->contain([
-        'ImmeublesAttributs' => [
+        'RealestatesAttributes' => [
             'fields' => [
-                'ImmeublesAttributs.immeuble_id',
-                'ImmeublesAttributs.valeur'
+                'RealestatesAttributes.realestate_id',
+                'RealestatesAttributes.value'
             ]
         ]
     ])
@@ -581,7 +581,7 @@ Si vous avez besoin de réinitialiser les *contain* sur une requête, vous pouve
 définir le second argument à ``true``::
 
     $query = $articles->find();
-    $query->contain(['Auteurs', 'Commentaires'], true);
+    $query->contain(['Authors', 'Comments'], true);
  
 .. note::
 
@@ -601,18 +601,18 @@ des conditions, passez une fonction anonyme qui reçoit en premier argument la
 query, de type ``\Cake\ORM\Query``::
 
     // Dans un controller ou une méthode de table.
-    $query = $articles->find()->contain('Commentaires', function (Query $q) {
+    $query = $articles->find()->contain('Comments', function (Query $q) {
         return $q
-            ->select(['contenu', 'auteur_id'])
-            ->where(['Commentaires.approuve' => true]);
+            ->select(['contenu', 'author_id'])
+            ->where(['Comments.approved' => true]);
     });
 
 Cela fonctionne aussi pour la pagination au niveau du Controller::
 
     $this->paginate['contain'] = [
-        'Commentaires' => function (Query $query) {
-            return $query->select(['contenu', 'auteur_id'])
-            ->where(['Commentaires.approuve' => true]);
+        'Comments' => function (Query $query) {
+            return $query->select(['body', 'author_id'])
+            ->where(['Comments.approved' => true]);
         }
     ];
 
@@ -626,9 +626,9 @@ Il est aussi possible de restreindre les associations imbriquées en utilisant l
 notation par point::
 
     $query = $articles->find()->contain([
-        'Commentaires',
-        'Auteurs.Profils' => function (Query $q) {
-            return $q->where(['Profils.is_published' => true]);
+        'Comments',
+        'Authors.Profiles' => function (Query $q) {
+            return $q->where(['Profiles.is_published' => true]);
         }
     ]);
 
@@ -641,8 +641,8 @@ vous pouvez les utiliser à l'intérieur de ``contain()``::
 
     // Récupère tous les articles, mais récupère seulement les commentaires qui
     // sont approuvés et populaires.
-    $query = $articles->find()->contain('Commentaires', function ($q) {
-        return $q->find('approuve')->find('populaire');
+    $query = $articles->find()->contain('Comments', function ($q) {
+        return $q->find('approved')->find('popular');
     });
 
 .. note::
@@ -664,7 +664,7 @@ Utilisez l'option ``queryBuilder`` pour personnaliser la requête quand vous
 passez un tableau::
 
     $query = $articles->find()->contain([
-        'Auteurs' => [
+        'Authors' => [
             'foreignKey' => false,
             'queryBuilder' => function (Query $q) {
                 return $q->where(...); // Conditions complètes pour le filtrage
@@ -676,19 +676,19 @@ Si vous avez limité les champs que vous chargez avec ``select()`` mais que
 vous souhaitez aussi charger les champs des associations avec contain,
 vous pouvez passer l'objet association à ``select()``::
 
-    // Sélectionne id & titre de articles, mais aussi tous les champs de Users.
+    // Sélectionne id & title de articles, mais aussi tous les champs de Users.
     $query = $articles->find()
-        ->select(['id', 'titre'])
+        ->select(['id', 'title'])
         ->select($articles->Users)
         ->contain(['Users']);
 
 Autre possibilité, si vous avez des associations multiples, vous pouvez utiliser
 ``enableAutoFields()``::
 
-    // Sélectionne id & titre de articles, mais tous les champs de
-    // Users, Commentaires et Tags.
-    $query->select(['id', 'titre'])
-        ->contain(['Commentaires', 'Tags'])
+    // Sélectionne id & title de articles, mais tous les champs de
+    // Users, Comments et Tags.
+    $query->select(['id', 'title'])
+        ->contain(['Comments', 'Tags'])
         ->enableAutoFields(true)
         ->contain(['Users' => function(Query $q) {
             return $q->autoFields(true);
@@ -701,8 +701,8 @@ Quand vous chargez des associations HasMany et BelongsToMany, vous pouvez
 utiliser l'option ``sort`` pour trier les données dans ces associations::
 
     $query->contain([
-        'Commentaires' => [
-            'sort' => ['Commentaires.created' => 'DESC']
+        'Comments' => [
+            'sort' => ['Comments.created' => 'DESC']
         ]
     ]);
 
@@ -725,14 +725,14 @@ extrêmement simple à faire avec l'ORM de CakePHP::
 
     $query = $articles->find();
     $query->matching('Tags', function ($q) {
-        return $q->where(['Tags.nom' => 'CakePHP']);
+        return $q->where(['Tags.name' => 'CakePHP']);
     });
 
 Vous pouvez aussi appliquer cette stratégie aux associations HasMany. Par
-exemple si 'Auteurs HasMany Articles', vous pouvez trouver tous les auteurs
+exemple si 'Authors HasMany Articles', vous pouvez trouver tous les auteurs
 ayant publié un article récemment en écrivant ceci::
 
-    $query = $auteurs->find();
+    $query = $authors->find();
     $query->matching('Articles', function ($q) {
         return $q->where(['Articles.created >=' => new DateTime('-10 days')]);
     });
@@ -742,8 +742,8 @@ filtrer des associations imbriquées::
 
     // Dans un controller ou une méthode de table.
     $query = $produits->find()->matching(
-        'Magasins.Villes.Pays', function ($q) {
-            return $q->where(['Pays.nom' => 'Japon']);
+        'Shops.Cities.Countries', function ($q) {
+            return $q->where(['Countries.name' => 'Japon']);
         }
     );
 
@@ -751,7 +751,7 @@ filtrer des associations imbriquées::
     // en passant une variable.
     // Utiliser la notation par points plutôt que des appels imbriqués à matching()
     $username = 'markstory';
-    $query = $articles->find()->matching('Commentaires.Users', function ($q) use ($username) {
+    $query = $articles->find()->matching('Comments.Users', function ($q) use ($username) {
         return $q->where(['username' => $username]);
     });
 
@@ -783,7 +783,7 @@ pouvez utiliser ``innerJoinWith()``::
 
     $query = $articles->find();
     $query->innerJoinWith('Tags', function ($q) {
-        return $q->where(['Tags.nom' => 'CakePHP']);
+        return $q->where(['Tags.name' => 'CakePHP']);
     });
 
 La méthode ``innerJoinWith()`` fonctionne de la même manière que ``matching()``,
@@ -791,8 +791,8 @@ ce qui signifie que vous pouvez utiliser la notation par points pour faire des
 jointures pour les associations imbriquées profondément::
 
     $query = $products->find()->innerJoinWith(
-        'Magasins.Villes.Pays', function ($q) {
-            return $q->where(['Pays.nom' => 'Japon']);
+        'Shops.Cities.Countries', function ($q) {
+            return $q->where(['Countries.name' => 'Japon']);
         }
     );
 
@@ -802,7 +802,7 @@ parfaitement combiner ``innerJoinWith()`` et ``contain()``.
 L'exemple ci-dessous filtre les Articles qui ont des Tags spécifiques et charge
 ces Tags::
  
-    $filter = ['Tags.nom' => 'CakePHP'];
+    $filter = ['Tags.name' => 'CakePHP'];
     $query = $articles->find()
         ->distinct($articles->getPrimaryKey())
         ->contain('Tags', function (Query $q) use ($filter) {
@@ -818,8 +818,8 @@ ces Tags::
     pour les noms des champs::
 
         $query
-            ->select(['nom_pays' => 'Pays.nom'])
-            ->innerJoinWith('Pays');
+            ->select(['country_name' => 'Countries.name'])
+            ->innerJoinWith('Countries');
  
     Sinon, vous verrez les données dans ``_matchingData``, comme cela a été
     décrit ci-dessous à propos de ``matching()``. C'est un angle mort de 
@@ -842,7 +842,7 @@ l'association spécifiée::
     $query = $articlesTable
         ->find()
         ->notMatching('Tags', function ($q) {
-            return $q->where(['Tags.nom' => 'ennuyeux']);
+            return $q->where(['Tags.name' => 'ennuyeux']);
         });
 
 L'exemple ci-dessus va trouver tous les articles qui n'ont pas été taggés avec
@@ -850,7 +850,7 @@ le mot ``ennuyeux``. Vous pouvez aussi utiliser cette méthode avec les
 associations HasMany. Vous pouvez, par exemple, trouver tous les auteurs qui
 n'ont publié aucun article dans les 10 derniers jours::
 
-    $query = $auteursTable
+    $query = $authorsTable
         ->find()
         ->notMatching('Articles', function ($q) {
             return $q->where(['Articles.created >=' => new \DateTime('-10 days')]);
@@ -862,7 +862,7 @@ trouver les articles qui n'ont pas été commentés par un utilisateur précis::
 
     $query = $articlesTable
         ->find()
-        ->notMatching('Commentaires.Users', function ($q) {
+        ->notMatching('Comments.Users', function ($q) {
             return $q->where(['username' => 'jose']);
         });
 
@@ -873,10 +873,10 @@ commentaire, mais non commentés par un utilisateur précis::
 
     $query = $articlesTable
         ->find()
-        ->notMatching('Commentaires.Users', function ($q) {
+        ->notMatching('Comments.Users', function ($q) {
             return $q->where(['username' => 'jose']);
         })
-        ->matching('Commentaires');
+        ->matching('Comments');
 
 .. note::
 
@@ -898,8 +898,8 @@ parallèle des données de l'article, vous pouvez utiliser la fonction
 ``leftJoinWith()``::
 
     $query = $articlesTable->find();
-    $query->select(['total_commentaires' => $query->func()->count('Commentaires.id')])
-        ->leftJoinWith('Commentaires')
+    $query->select(['total_comments' => $query->func()->count('Comments.id')])
+        ->leftJoinWith('Comments')
         ->group(['Articles.id'])
         ->enableAutoFields(true);
 
@@ -910,13 +910,13 @@ Le résultat de cette requête contiendra les données de l'article et la propri
 C'est utile par exemple pour rechercher, pour chaque auteur, le nombre
 d'articles taggés avec un certain mot::
 
-    $query = $auteursTable
+    $query = $authorsTable
         ->find()
         ->select(['total_articles' => $query->func()->count('Articles.id')])
         ->leftJoinWith('Articles.Tags', function ($q) {
-            return $q->where(['Tags.nom' => 'redoutable']);
+            return $q->where(['Tags.name' => 'redoutable']);
         })
-        ->group(['Auteurs.id'])
+        ->group(['Authors.id'])
         ->enableAutoFields(true);
 
 Cette fonction ne va charger aucune colonne des associations spécifiées dans les
@@ -936,7 +936,7 @@ et le type de jointure (``joinType``) 'INNER' peuvent être remplacés par
 'select'::
 
     $query = $articles->find()->contain([
-        'Commentaires' => [
+        'Comments' => [
             'strategy' => 'select',
         ]
     ]);
@@ -950,7 +950,7 @@ Habituellement, vous définisser la stratégie d'une association quand vous la
 définissez, dans la méthode ``Table::initialize()``, mais vous pouvez changer
 manuellement la stratégie de façon permanente::
  
-    $articles->Commentaires->setStrategy('select');
+    $articles->Comments->setStrategy('select');
 
 Récupération Avec la Stratégie de Sous-Requête
 ----------------------------------------------
@@ -961,10 +961,10 @@ une fois. Un bon moyen d'optimiser le chargement des associations ``hasMany`` et
 ``belongsToMany`` est d'utiliser la stratégie ``subquery``::
 
     $query = $articles->find()->contain([
-        'Commentaires' => [
+        'Comments' => [
                 'strategy' => 'subquery',
                 'queryBuilder' => function ($q) {
-                    return $q->where(['Commentaires.approuve' => true]);
+                    return $q->where(['Comments.approved' => true]);
                 }
         ]
     ]);
@@ -1066,9 +1066,9 @@ ResultSets::
     });
 
     // Crée un tableau associatif depuis les propriétés du résultat
-    $results = $articles->find()->contain(['Auteurs'])->all();
+    $results = $articles->find()->contain(['Authors'])->all();
 
-    $auteursList = $results->combine('id', 'auteur.nom');
+    $authorsList = $results->combine('id', 'author.name');
 
 Le chapitre :doc:`/core-libraries/collections` comporte plus de détails sur
 ce qu'on peut faire avec les fonctionnalités des collections sur des ResultSets.
@@ -1123,7 +1123,7 @@ paresseusement des données en eager. Vous pouvez charger des associations
 supplémentaires en utilisant ``loadInto()``::
 
     $articles = $this->Articles->find()->all();
-    $withMore = $this->Articles->loadInto($articles, ['Commentaires', 'Users']);
+    $withMore = $this->Articles->loadInto($articles, ['Comments', 'Users']);
 
 Vous pouvez charger en eager des données additionnelles dans une entity unique
 ou une collection d'entities.
@@ -1152,9 +1152,9 @@ données, en second argument la clé d'itération et en troisième elle reçoit 
 instance de la routine ``MapReduce`` en train d'être éxecutée::
 
     $mapper = function ($article, $key, $mapReduce) {
-        $status = 'publié';
-        if ($article->estBrouillon() || $article->estEnRevision()) {
-            $status = 'non publié';
+        $status = 'published';
+        if ($article->isDraft() || $article->isInReview()) {
+            $status = 'unpublished';
         }
         $mapReduce->emitIntermediate($article, $status);
     };
@@ -1181,19 +1181,19 @@ donc nous nous contentons d'émettre (*emit*) les résultats finaux::
 Pour finir, nous pouvons passer ces deux fonctions pour exécuter le
 regroupement::
 
-    $articlesParStatut = $articles->find()
-        ->where(['auteur_id' => 1])
+    $articlesByStatus = $articles->find()
+        ->where(['author_id' => 1])
         ->mapReduce($mapper, $reducer)
         ->all();
 
-    foreach ($articlesParStatut as $statut => $articles) {
-        echo sprintf("Il y a %d articles avec le statut %s", count($articles), $statut);
+    foreach ($articlesByStatus as $status => $articles) {
+        echo sprintf("Il y a %d articles avec le statut %s", count($articles), $status);
     }
 
 Ce qui va afficher la sortie suivante::
 
-    Il y a 4 articles avec le statut publié
-    Il y a 5 articles avec le statut non publié
+    Il y a 4 articles avec le statut published
+    Il y a 5 articles avec le statut unpublished
 
 Bien sûr, ceci est un exemple simple qui pourrait être résolu d'une autre
 façon sans l'aide d'un traitement map-reduce. Maintenant, regardons un autre
@@ -1205,13 +1205,13 @@ des informations sur CakePHP, comme d'habitude nous avons besoin d'une fonction
 mapper::
 
     $mapper = function ($article, $key, $mapReduce) {
-        if (stripos($article['contenu'], 'cakephp') === false) {
+        if (stripos($article['body'], 'cakephp') === false) {
             return;
         }
 
-        $mots = array_map('strtolower', explode(' ', $article['contenu']));
-        foreach ($mots as $mot) {
-            $mapReduce->emitIntermediate($article['id'], $mot);
+        $words = array_map('strtolower', explode(' ', $article['body']));
+        foreach ($words as $word) {
+            $mapReduce->emitIntermediate($article['id'], $word);
         }
     };
 
@@ -1220,14 +1220,14 @@ ensuite coupe le corps en mots individuels. Chaque mot va créer son propre
 ``tas``, où chaque id d'article sera stocké. Maintenant réduisons nos
 résultats pour extraire seulement le décompte du nombre de mots::
 
-    $reducer = function ($occurrences, $mot, $mapReduce) {
-        $mapReduce->emit(count($occurrences), $mot);
+    $reducer = function ($occurrences, $word, $mapReduce) {
+        $mapReduce->emit(count($occurrences), $word);
     }
 
 Pour finir, nous mettons tout ensemble::
 
     $nbMots = $articles->find()
-        ->where(['publie' => true])
+        ->where(['published' => true])
         ->andWhere(['publication_date >=' => new DateTime('2014-01-01')])
         ->disableHydration()
         ->mapReduce($mapper, $reducer)
@@ -1273,17 +1273,17 @@ suivi par d'autres utilisateurs.
 Maintenant, il est temps de la réduire. Pour chaque appel au reducer, il va
 recevoir une liste de followers par utilisateur::
 
-    $reducer = function ($amis, $user, $mr) {
-        $fauxAmis = [];
+    $reducer = function ($friends, $user, $mr) {
+        $fakeFriends = [];
 
-        foreach ($amis as $ami) {
-            if ($ami > 0 && !in_array(-$ami, $amis)) {
-                $fauxAmis[] = $ami;
+        foreach ($friends as $friend) {
+            if ($friend > 0 && !in_array(-$friend, $friends)) {
+                $fakeFriends[] = $friend;
             }
         }
 
-        if ($fauxAmis) {
-            $mr->emit($fauxAmis, $user);
+        if ($fakeFriends) {
+            $mr->emit($fakeFriends, $user);
         }
     };
 
@@ -1306,7 +1306,7 @@ Ce tableau final signifie, par exemple, que l'utilisateur avec l'id
 ``1`` suit les utilisateurs ``2`` et ``4``, mais ceux-ci ne suivent pas
 ``1`` de leur côté.
 
-Stacking Multiple Operations
+Empiler Plusieurs Opérations
 ----------------------------
 
 L'utilisation de `mapReduce` dans une requête ne va pas l'exécuter
@@ -1316,7 +1316,7 @@ Ceci vous permet de continuer à chainer les méthodes et les filtres
 sur la requête même après avoir ajouté une routine map-reduce::
 
     $query = $articles->find()
-        ->where(['publie' => true])
+        ->where(['published' => true])
         ->mapReduce($mapper, $reducer);
 
     // Plus loin dans votre app:
@@ -1325,9 +1325,9 @@ sur la requête même après avoir ajouté une routine map-reduce::
 C'est particulièrement utile pour construire des méthodes finder personnalisées
 comme décrit dans la section :ref:`custom-find-methods`::
 
-    public function findPublie(Query $query, array $options)
+    public function findPublished(Query $query, array $options)
     {
-        return $query->where(['publie' => true]);
+        return $query->where(['published' => true]);
     }
 
     public function findRecent(Query $query, array $options)
@@ -1335,7 +1335,7 @@ comme décrit dans la section :ref:`custom-find-methods`::
         return $query->where(['created >=' => new DateTime('1 day ago')]);
     }
 
-    public function findMotsCourants(Query $query, array $options)
+    public function findCommonWords(Query $query, array $options)
     {
         // Comme dans l'exemple précédent sur la fréquence des mots
         $mapper = ...;
@@ -1344,8 +1344,8 @@ comme décrit dans la section :ref:`custom-find-methods`::
     }
 
     $motsCourant = $articles
-        ->find('motsCourants')
-        ->find('publie')
+        ->find('commonWords')
+        ->find('published')
         ->find('recent');
 
 De plus, il est aussi possible d'empiler plusieurs opérations ``mapReduce``
@@ -1354,13 +1354,13 @@ plus couramment utilisés pour les articles, mais ensuite les filtrer pour
 retourner uniquement les mots qui étaient mentionnés plus de 20 fois tout au
 long des articles::
 
-    $mapper = function ($nb, $mot, $mr) {
-        if ($nb > 20) {
-            $mr->emit($nb, $mot);
+    $mapper = function ($count, $word, $mr) {
+        if ($count > 20) {
+            $mr->emit($count, $word);
         }
     };
 
-    $articles->find('motsCourants')->mapReduce($mapper)->all();
+    $articles->find('commonWords')->mapReduce($mapper)->all();
 
 Retirer Toutes les Opérations Map-reduce Empilées
 -------------------------------------------------


### PR DESCRIPTION
After a while, this is a french update of some articles and recent changes.

* Completion of the 4.4 migration guide
* Full update of `entities` and `retrieving-data-and-resultsets` articles
* Introduce french translation of console-command-description section
* Introduce check-http-cache article and fix related toctree

In addition, I fixed a wrong description in the **english** `retrieving-data-and-resultsets` article.