### PR TITLE
4.x - Fix HTTP client trait namespace and method directives.

### DIFF
--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -469,8 +469,9 @@ instead. You can force select a transport adapter using a constructor option::
 Testing
 =======
 
-.. php:trait:: Cake\Http\TestSuite\HttpClientTrait
+.. php:namespace:: Cake\Http\TestSuite
 
+.. php:trait:: HttpClientTrait
 
 In tests you will often want to create mock responses to external APIs. You can
 use the ``HttpClientTrait`` to define responses to the requests your application
@@ -503,7 +504,7 @@ There are methods to mock the most commonly used HTTP methods::
     $this->mockClientPut(...);
     $this->mockClientDelete(...);
 
-... php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
+.. php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
 
 As seen above you can use the ``newClientResponse()`` method to create responses
 for the requests your application will make. The headers need to be a list of

--- a/fr/core-libraries/httpclient.rst
+++ b/fr/core-libraries/httpclient.rst
@@ -492,7 +492,9 @@ option du constructeur::
 Tests
 =====
 
-.. php:trait:: Cake\Http\TestSuite\HttpClientTrait
+.. php:namespace:: Cake\Http\TestSuite
+
+.. php:trait:: HttpClientTrait
 
 Dans les tests, vous voudrez souvent créer des réponses de mocks vers des API
 externes. Vous pouvez utiliser ``HttpClientTrait`` pour définir des réponses aux
@@ -525,7 +527,7 @@ Il existe des méthodes pour mocker les méthodes HTTP les plus courantes::
     $this->mockClientPut(...);
     $this->mockClientDelete(...);
 
-... php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
+.. php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
 
 Comme vu précédemment, vous pouvez utiliser la méthode ``newClientResponse()``
 pour créer des réponses pour les requêtes que fera votre application. Les

--- a/ja/core-libraries/httpclient.rst
+++ b/ja/core-libraries/httpclient.rst
@@ -486,13 +486,15 @@ instead. You can force select a transport adapter using a constructor option::
 Testing
 =======
 
-.. php:trait:: Cake\TestSuite\HttpClientTrait
+.. php:namespace:: Cake\Http\TestSuite
+
+.. php:trait:: HttpClientTrait
 
 In tests you will often want to create mock responses to external APIs. You can
 use the ``HttpClientTrait`` to define responses to the requests your application
 is making::
 
-    use Cake\TestSuite\HttpClientTrait;
+    use Cake\Http\TestSuite\HttpClientTrait;
     use Cake\TestSuite\TestCase;
 
     class CartControllerTests extends TestCase
@@ -519,7 +521,7 @@ There are methods to mock the most commonly used HTTP methods::
     $this->mockClientPut(...);
     $this->mockClientDelete(...);
 
-... php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
+.. php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
 
 As seen above you can use the ``newClientResponse()`` method to create responses
 for the requests your application will make. The headers need to be a list of


### PR DESCRIPTION
Turns out that `php:trait` neither picks up the namespace from qualified, nor from fully qualified names, a `php:namespace` directive seems to be always required to set/switch the context.