### PR TITLE
5.x - add enum type migration guide and database basics documentation

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -162,3 +162,4 @@ Database
 --------
 
 - ``Query::all()`` was added which runs result decorator callbacks and returns a result set for select queries.
+- ``EnumType`` was added to allow mapping between backed enums and a string or integer column.

--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -162,4 +162,4 @@ Database
 --------
 
 - ``Query::all()`` was added which runs result decorator callbacks and returns a result set for select queries.
-- ``EnumType`` was added to allow mapping between backed enums and a string or integer column.
+- ``EnumType`` was added to allow mapping between PHP backed enums and a string or integer column.

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -431,8 +431,7 @@ Enum Type
 .. php:class:: EnumType
 
 Maps a `BackedEnum <https://www.php.net/manual/en/language.enumerations.backed.php>`_ to a string or integer column.
-To use this type you need to specify which column is associated to which BackedEnum inside the table class.
-::
+To use this type you need to specify which column is associated to which BackedEnum inside the table class::
 
     use \Cake\Database\Type\EnumType;
     use \App\Model\Enum\ArticleStatus;
@@ -443,8 +442,7 @@ To use this type you need to specify which column is associated to which BackedE
         $this->getSchema()->setColumnType('status', EnumType::from(ArticleStatus::class));
     }
 
-Where ``ArticleStatus`` contains something like:
-::
+Where ``ArticleStatus`` contains something like::
 
     namespace App\Model\Enum;
 

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -367,6 +367,8 @@ time
     Maps to a ``TIME`` type in all databases.
 json
     Maps to a ``JSON`` type if it's available, otherwise it maps to ``TEXT``.
+enum
+    See :ref:`enum-type`.
 
 These types are used in both the schema reflection features that CakePHP
 provides, and schema generation features CakePHP uses when using test fixtures.
@@ -420,6 +422,37 @@ Can be used to map datetime columns that contain time zones such as
 
     // Overwrite the default datetime type with a more precise one.
     TypeFactory::map('datetime', DateTimeTimezoneType::class);
+
+.. _enum-type:
+
+Enum Type
+---------
+
+.. php:class:: EnumType
+
+Maps a `BackedEnum <https://www.php.net/manual/en/language.enumerations.backed.php>`_ to a string or integer column.
+To use this type you need to specify which column is associated to which BackedEnum inside the table class.
+::
+
+    use \Cake\Database\Type\EnumType;
+    use \App\Model\Enum\ArticleStatus;
+
+    // in src/Model/Table/ArticlesTable.php
+    public function initialize(array $config): void
+    {
+        $this->getSchema()->setColumnType('status', EnumType::from(ArticleStatus::class));
+    }
+
+Where ``ArticleStatus`` contains something like:
+::
+
+    namespace App\Model\Enum;
+
+    enum ArticleStatus: string
+    {
+        case PUBLISHED = 'Y';
+        case UNPUBLISHED = 'N';
+    }
 
 .. _adding-custom-database-types:
 


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/16705

I guess we should add the [string => integer coercion](https://github.com/cakephp/cakephp/pull/16744) feature when it is in but feel free to add it as desired.