### PR TITLE
Prefix routes need not precede fallback routes.

### DIFF
--- a/en/development/routing.rst
+++ b/en/development/routing.rst
@@ -688,10 +688,6 @@ how to build this link using the HTML helper::
         ['prefix' => false, 'controller' => 'Articles', 'action' => 'view', 5]
     );
 
-.. note::
-
-    You should connect prefix routes *before* you connect fallback routes.
-
 .. index:: plugin routing
 
 Creating Links to Prefix Routes


### PR DESCRIPTION
Reverts 994ea95c114d21b819c0dbe6dfbe9441dbd707bb.

It had to be at the time, but was fixed the next day. https://github.com/cakephp/cakephp/commit/12c5f5bb72dc4d55161ccb242b918ef90b26788a