### PR TITLE
5.x requirements

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -2,7 +2,7 @@
 ###################
 
 CakePHP 5.0 contains breaking changes, and is not backwards compatible with 4.x
-releases. Before attempting to upgrade to 5.0, first upgrade to 4.3 and resolve
+releases. Before attempting to upgrade to 5.0, first upgrade to 4.5 and resolve
 all deprecation warnings.
 
 Refer to the :doc:`/appendices/5-0-upgrade-guide` for step by step instructions
@@ -12,7 +12,7 @@ Deprecated Features Removed
 ===========================
 
 All methods, properties and functionality that were emitting deprecation warnings
-as of 4.3 have been removed.
+as of 4.5 have been removed.
 
 Deprecations
 ============

--- a/en/appendices/5-0-upgrade-guide.rst
+++ b/en/appendices/5-0-upgrade-guide.rst
@@ -20,13 +20,13 @@ Once your application is running on latest CakePHP 4.x, enable deprecation warni
 
 Now that you can see all the warnings, make sure these are fixed before proceding with the upgrade.
 
-Upgrade to PHP 8.0
+Upgrade to PHP 8.1
 ==================
 
-If you are not running on **PHP 8.0 or higher**, you will need to upgrade PHP before updating CakePHP.
+If you are not running on **PHP 8.1 or higher**, you will need to upgrade PHP before updating CakePHP.
 
 .. note::
-    CakePHP 5.0 requires **a minimum of PHP 8.0**.
+    CakePHP 5.0 requires **a minimum of PHP 8.1**.
 
 .. _upgrade-tool-use:
 


### PR DESCRIPTION
- Cake 4.5 will be out before Cake 5, so people will need to update to that version before upgrading to 5
- We already decided in the past that Cake 5 will require PHP 8.1