### PR TITLE
4.x - Add section that explains how to dynamically create routes in tests.

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -736,6 +736,46 @@ This method will build an instance of your ``Application`` and call the
 ``routes()`` method on it. If your ``Application`` class requires specialized
 constructor parameters you can provide those to ``loadRoutes($constructorArgs)``.
 
+Creating Routes in Tests
+------------------------
+
+Sometimes it may be be necessary to dynamically add routes in tests, for example
+when developing plugins, or applications that are extensible.
+
+Just like loading existing application routes, this can be done during ``setup()``
+of a test method, and/or in the individual test methods themselves::
+
+    use Cake\Routing\Route\DashedRoute;
+    use Cake\Routing\RouteBuilder;
+    use Cake\Routing\Router;
+    use Cake\TestSuite\TestCase;
+
+    class PluginHelperTest extends TestCase
+    {
+        protected RouteBuilder $routeBuilder;
+
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            $this->routeBuilder = Router::createRouteBuilder('/');
+            $this->routeBuilder->scope('/', function (RouteBuilder $routes) {
+                $routes->setRouteClass(DashedRoute::class);
+                $routes->get(
+                    '/test/view/{id}',
+                    ['controller' => 'Tests', 'action' => 'view']
+                );
+                // ...
+            });
+
+            // ...
+        }
+    }
+
+This will create a new route builder instance that will merge connected routes
+into the same route collection used by all other route builder instances that
+may already exist, or are yet to be created in the environment.
+
 Loading Plugins in Tests
 ------------------------
 

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -781,6 +781,48 @@ méthode ``routes()`` dessus. Si votre classe ``Application`` a besoin de
 paramètres de constructeur spécialisés, vous pouvez les fournir à
 ``loadRoutes($constructorArgs)``.
 
+Création de routes dans les tests
+---------------------------------
+
+Parfois, il peut être nécessaire d'ajouter dynamiquement des routes dans les tests,
+par exemple lors du développement de plugins, ou d'applications qui sont extensibles.
+
+Tout comme le chargement de routes d'applications existantes, ceci peut être fait
+pendant ``setup()`` d'une méthode de test, et/ou dans les méthodes de test individuelles
+elles-mêmes::
+
+    use Cake\Routing\Route\DashedRoute;
+    use Cake\Routing\RouteBuilder;
+    use Cake\Routing\Router;
+    use Cake\TestSuite\TestCase;
+
+    class PluginHelperTest extends TestCase
+    {
+        protected RouteBuilder $routeBuilder;
+
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            $this->routeBuilder = Router::createRouteBuilder('/');
+            $this->routeBuilder->scope('/', function (RouteBuilder $routes) {
+                $routes->setRouteClass(DashedRoute::class);
+                $routes->get(
+                    '/test/view/{id}',
+                    ['controller' => 'Tests', 'action' => 'view']
+                );
+                // ...
+            });
+
+            // ...
+        }
+    }
+
+Ceci créera une nouvelle instance de route builder qui fusionnera les routes connectées
+dans la même collection de routes utilisée par toutes les autres instances de route
+builder qui qui peuvent déjà exister, ou qui doivent encore être créées dans
+l'environnement.
+
 Charger des Plugins dans les Tests
 ----------------------------------
 

--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -675,6 +675,46 @@ CakePHPコアまたはプラグインからフィクスチャをロードする�
 このメソッドは、 ``Application`` インスタンスの作成と、そのインスタンスでの ``routes()`` メソッドの呼び出しを行ないます。
 この ``Application`` インスタンスのコンストラクタには、 ``loadRoutes($constructorArgs)`` としてパラメータを渡すことができます。
 
+テストにおけるルーティングの作成
+--------------------------------
+
+プラグインや拡張性のあるアプリケーションを開発する場合など、 テスト内で動的にルートを追加することが必要になることがあります。
+例えば、プラグインや拡張性のあるアプリケーションを開発する場合などです。
+
+既存のアプリケーションのルートを読み込むのと同じように、これはテストメソッドの ``setup()`` の中で行うことができます。
+で、あるいは個々のテストメソッド自身で行うことができます。::
+
+    use Cake\Routing\Route\DashedRoute;
+    use Cake\Routing\RouteBuilder;
+    use Cake\Routing\Router;
+    use Cake\TestSuite\TestCase;
+
+    class PluginHelperTest extends TestCase
+    {
+        protected RouteBuilder $routeBuilder;
+
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            $this->routeBuilder = Router::createRouteBuilder('/');
+            $this->routeBuilder->scope('/', function (RouteBuilder $routes) {
+                $routes->setRouteClass(DashedRoute::class);
+                $routes->get(
+                    '/test/view/{id}',
+                    ['controller' => 'Tests', 'action' => 'view']
+                );
+                // ...
+            });
+
+            // ...
+        }
+    }
+
+これは新しいルートビルダのインスタンスを作成し、接続されたルートをマージします。
+を、他のすべてのルートビルダーインスタンスで使われる同じルートコレクションにマージします。
+接続されたルートを、その環境に存在する、あるいはまだ作成されていない他のすべてのルートビルダーインスタンスで使用される同じルートコレクションにマージします。
+
 プラグインをロード
 ------------------------
 


### PR DESCRIPTION
Now that the `connect()`, `scope()`, `plugin()` and `prefix()` methods on `Router` are deprecated, and it's not immediately obvious anymore from the app's `routes.php` file on what to connect routes, as the routes builder instance is being somewhat "magically" injected, it might warrant having a short explanation on how to dynamically create routes in tests.

Translations are courtesy of deepl.