### PR TITLE
3.x Create Project for Tutorials with CakePHP 3.10 correctly 

### DIFF
--- a/en/tutorials-and-examples/blog/blog.rst
+++ b/en/tutorials-and-examples/blog/blog.rst
@@ -39,11 +39,11 @@ installation directory to install the CakePHP application skeleton
 in the directory that you wish to use it with. For this example we will be using
 "blog" but feel free to change it to something else.::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^3.8 blog
+    php composer.phar create-project --prefer-dist cakephp/app blog "^3.10"
 
 In case you've already got composer installed globally, you may instead type::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^3.8 blog
+    composer self-update && composer create-project --prefer-dist cakephp/app blog "^3.10"
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/blog/blog.rst
+++ b/en/tutorials-and-examples/blog/blog.rst
@@ -39,11 +39,11 @@ installation directory to install the CakePHP application skeleton
 in the directory that you wish to use it with. For this example we will be using
 "blog" but feel free to change it to something else.::
 
-    php composer.phar create-project --prefer-dist cakephp/app blog "^3.10"
+    php composer.phar create-project --prefer-dist cakephp/app:"^3.10" blog
 
 In case you've already got composer installed globally, you may instead type::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app blog "^3.10"
+    composer self-update && composer create-project --prefer-dist cakephp/app:"^3.10" blog
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -44,14 +44,14 @@ Then simply type the following line in your terminal from your
 installation directory to install the CakePHP application skeleton
 in the **bookmarker** directory::
 
-    php composer.phar create-project --prefer-dist cakephp/app bookmarker "^3.10"
+    php composer.phar create-project --prefer-dist cakephp/app:"^3.10" bookmarker
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
 your terminal from your installation directory (ie.
 C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app bookmarker "^3.10"
+    composer self-update && composer create-project --prefer-dist cakephp/app:"^3.10" bookmarker
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -44,14 +44,14 @@ Then simply type the following line in your terminal from your
 installation directory to install the CakePHP application skeleton
 in the **bookmarker** directory::
 
-    php composer.phar create-project --prefer-dist cakephp/app:^3.8 bookmarker
+    php composer.phar create-project --prefer-dist cakephp/app bookmarker "^3.10"
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
 your terminal from your installation directory (ie.
 C:\\wamp\\www\\dev\\cakephp3)::
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^3.8 bookmarker
+    composer self-update && composer create-project --prefer-dist cakephp/app bookmarker "^3.10"
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/cms/installation.rst
+++ b/en/tutorials-and-examples/cms/installation.rst
@@ -46,7 +46,7 @@ in the **cms** directory of the current working directory:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app:^3.8 cms
+    php composer.phar create-project --prefer-dist cakephp/app cms "^3.10"
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
@@ -55,7 +55,7 @@ C:\\wamp\\www\\dev\\cakephp3):
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app:^3.8 cms
+    composer self-update && composer create-project --prefer-dist cakephp/app cms "^3.10"
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and

--- a/en/tutorials-and-examples/cms/installation.rst
+++ b/en/tutorials-and-examples/cms/installation.rst
@@ -46,7 +46,7 @@ in the **cms** directory of the current working directory:
 
 .. code-block:: bash
 
-    php composer.phar create-project --prefer-dist cakephp/app cms "^3.10"
+    php composer.phar create-project --prefer-dist cakephp/app:"^3.10" cms
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in
@@ -55,7 +55,7 @@ C:\\wamp\\www\\dev\\cakephp3):
 
 .. code-block:: bash
 
-    composer self-update && composer create-project --prefer-dist cakephp/app cms "^3.10"
+    composer self-update && composer create-project --prefer-dist cakephp/app:"^3.10" cms
 
 The advantage to using Composer is that it will automatically complete some
 important set up tasks, such as setting the correct file permissions and


### PR DESCRIPTION
When I tried to just replace ``3.8`` with ``3.10``, it installed CakePHP App ``3.10.0``, which installed CakePHP ``4.2.10`` instead of ``3.10.x`` as a dependency.

````
>composer create-project --prefer-dist cakephp/app:^3.10 cms2
Creating a "cakephp/app:3.10" project at "./cms2"
Installing cakephp/app (3.10.0)
  - Downloading cakephp/app (3.10.0)
  - Installing cakephp/app (3.10.0): Extracting archive
Created project in C:\xampp\htdocs\cms2
Loading composer repositories with package information
Updating dependencies
Lock file operations: 91 installs, 0 updates, 0 removals
  - Locking brick/varexporter (0.3.7)
  - Locking cakephp/bake (2.5.2)
  - Locking cakephp/cakephp (4.2.10)
````

The correct syntax of ``create-project`` is:

````
>composer create-project --prefer-dist --help
Description:
  Creates new project from a package into given directory

Usage:
  create-project [options] [--] [<package> [<directory> [<version>]]]
````
  
https://getcomposer.org/doc/03-cli.md#create-project
