### PR TITLE
3.x Name PHP & CakePHP uniformly in uppercase

### DIFF
--- a/en/appendices/3-0-migration-guide.rst
+++ b/en/appendices/3-0-migration-guide.rst
@@ -303,7 +303,7 @@ Log
   forwarded to the log engines' ``write()`` method in order to provide better
   context to the engines.
 * Log engines are now required to implement ``Psr\Log\LogInterface`` instead of
-  Cake's own ``LogInterface``. In general, if you extended :php:class:`Cake\\Log\\Engine\\BaseEngine`
+  CakePHP's own ``LogInterface``. In general, if you extended :php:class:`Cake\\Log\\Engine\\BaseEngine`
   you just need to rename the ``write()`` method to ``log()``.
 * :php:meth:`Cake\\Log\\Engine\\FileLog` now writes files in ``ROOT/logs`` instead of ``ROOT/tmp/logs``.
 

--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -174,7 +174,7 @@ Asset.timestamp
 Asset.cacheTime
     Sets the asset cache time. This determines the http header ``Cache-Control``'s
     ``max-age``, and the http header's ``Expire``'s time for assets.
-    This can take anything that you version of php's `strtotime function
+    This can take anything that you version of PHP's `strtotime function
     <https://php.net/manual/en/function.strtotime.php>`_ can take.
     The default is ``+1 day``.
 


### PR DESCRIPTION
All other instances are alreadywritten this way.