### PR TITLE
4.x Name PHP & CakePHP uniformly in uppercase

### DIFF
--- a/en/development/configuration.rst
+++ b/en/development/configuration.rst
@@ -164,7 +164,7 @@ Asset.timestamp
 Asset.cacheTime
     Sets the asset cache time. This determines the http header ``Cache-Control``'s
     ``max-age``, and the http header's ``Expire``'s time for assets.
-    This can take anything that you version of php's `strtotime function
+    This can take anything that you version of PHP's `strtotime function
     <https://php.net/manual/en/function.strtotime.php>`_ can take.
     The default is ``+1 day``.
 

--- a/en/development/rest.rst
+++ b/en/development/rest.rst
@@ -94,7 +94,7 @@ controller might look something like this::
 
 RESTful controllers often use parsed extensions to serve up different views
 based on different kinds of requests. We're defining the content-type based
-views we support in this controller. We're including Cake's ``JsonView``. To
+views we support in this controller. We're including CakePHP's ``JsonView``. To
 learn more about it and Xml based views see :doc:`/views/json-and-xml-views`. By
 using  :php:class:`JsonView` we can define a ``serialize`` option. This option
 is used to define which view variables ``JsonView`` should serialize into JSON.


### PR DESCRIPTION
All other instances are alreadywritten this way.