### PR TITLE
Mention that Validation::compariosn can no longer compare dates

### DIFF
--- a/en/appendices/4-2-migration-guide.rst
+++ b/en/appendices/4-2-migration-guide.rst
@@ -106,6 +106,7 @@ Validation
 
 - ``Validation::time()`` will now reject a string if minutes are missing. Previously,
   this would accept hours-only digits although the api documentation showed minutes were required.
+- ``Validatior::greaterThanField()``, ``Validatior::lessThanField()``, ``Validatior::lessThanOrEqualToField()`` and ``Validatior::greaterThanOrEqualToField()`` will no longer accept dates due to ``Validation::comparison`` now enforcing numeric values. 
 
 
 Breaking Changes


### PR DESCRIPTION
I noticed that various field comparison validation methods e.g.

- ``Validatior::greaterThanField()``,
- ``Validatior::lessThanField()``
- ``Validatior::lessThanOrEqualToField()`` 
- ``Validatior::greaterThanOrEqualToField()``

can no longer validate dates.  This is a result of the underlying ``Validation::comparison`` method being changed in [this PR](https://github.com/cakephp/cakephp/pull/14885 ). I think this should be mentioned in the 4.2 migration guide.