### PR TITLE
REPL is shipped as a plugin since 4.3

### DIFF
--- a/en/console-commands/repl.rst
+++ b/en/console-commands/repl.rst
@@ -1,9 +1,15 @@
 Interactive Console (REPL)
 ##########################
 
-The CakePHP app skeleton comes with a built in REPL(Read Eval Print Loop) to let
-you explore some CakePHP and your application in an interactive console. You can
-start the interactive console using:
+CakePHP offers
+`REPL(Read Eval Print Loop) plugin <https://github.com/cakephp/repl>`__ to let
+you explore some CakePHP and your application in an interactive console.
+
+.. note::
+
+    The plugin was shipped with the CakePHP app skelton before 4.3.
+
+You can start the interactive console using:
 
 .. code-block:: console
 

--- a/en/console-commands/repl.rst
+++ b/en/console-commands/repl.rst
@@ -7,7 +7,7 @@ you explore some CakePHP and your application in an interactive console.
 
 .. note::
 
-    The plugin was shipped with the CakePHP app skelton before 4.3.
+    The plugin was shipped with the CakePHP app skeleton before 4.3.
 
 You can start the interactive console using:
 

--- a/fr/console-commands/repl.rst
+++ b/fr/console-commands/repl.rst
@@ -1,6 +1,10 @@
 Console Interactive (REPL)
 ##########################
 
+.. todo::
+
+    REPL is shipped as a plugin since 4.3. Update the translation.
+
 Le squelette de l'application CakePHP intègre un REPL(Read Eval Print Loop
 = Lire Evaluer Afficher Boucler) qui permet l'exploration de CakePHP et
 de votre application avec une console interactive. Vous pouvez commencer la

--- a/ja/console-commands/repl.rst
+++ b/ja/console-commands/repl.rst
@@ -1,8 +1,13 @@
 インタラクティブ・コンソール (REPL)
 ###################################
 
-CakePHP の app スケルトンは、組み込みの REPL (Read Eval Print Loop) を備えており、
-このことで CakePHP やアプリケーションがインタラクティブ・コンソール内で探索しやすくなります。
+`REPL(Read Eval Print Loop) プラグイン <https://github.com/cakephp/repl>`__ を使う
+ことで CakePHP やアプリケーションがインタラクティブ・コンソール内で探索しやすくなります。
+
+.. note::
+
+    このプラグインは 4.3 以前では CakePHP の app スケルトンに同梱されていました。
+
 以下のようにするとインタラクティブ・コンソールを使い始めることができます。
 
 .. code-block:: console


### PR DESCRIPTION
Document updates for the following pull request on app skelton, which seems to be released as 4.3.0.

"Use repl package and remove mobiledetect" https://github.com/cakephp/app/pull/829

## Translations
- en : written by me
- ja : written by me
- fr : added a TODO comment
- pt : doesn't have translation, so I did nothing
- es : doesn't have translation, so I did nothing