### PR TITLE
Improve AuthenticationMiddleware positioning info

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -130,7 +130,9 @@ Then add the following::
         $middlewareQueue
             // ... other middleware added before
             ->add(new RoutingMiddleware($this))
-            // add Authentication after RoutingMiddleware
+            ->add(new BodyParserMiddleware())
+            // Add the AuthenticationMiddleware. It should be
+            // after routing and body parser.
             ->add(new AuthenticationMiddleware($this));
 
         return $middlewareQueue;

--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -131,8 +131,7 @@ Then add the following::
             // ... other middleware added before
             ->add(new RoutingMiddleware($this))
             ->add(new BodyParserMiddleware())
-            // Add the AuthenticationMiddleware. It should be
-            // after routing and body parser.
+            // Add the AuthenticationMiddleware. It should be after routing and body parser.
             ->add(new AuthenticationMiddleware($this));
 
         return $middlewareQueue;


### PR DESCRIPTION
Mention that the AuthenticationMiddleware shall be placed after the routing and body parser. (Otherwise it breaks JWT token request.)

Fixes #7547 