### PR TITLE
4.x: add notice about missing CORS middleware

### DIFF
--- a/en/controllers/request-response.rst
+++ b/en/controllers/request-response.rst
@@ -1094,6 +1094,12 @@ criteria are met:
 #. The request has an ``Origin`` header.
 #. The request's ``Origin`` value matches one of the allowed Origin values.
 
+.. tip::
+
+    CakePHP has no built-in CORS middleware because dealing with CORS requests
+    is very application specific. We recommend you build your own ``CORSMiddleware``
+    if you need one and adjust the response object as desired.
+
 Common Mistakes with Immutable Responses
 ========================================
 


### PR DESCRIPTION
As mentioned in https://github.com/cakephp/cakephp/issues/16652 creating a generic CORS middleware is basically impossible and therefore we recommend users to create their own CORS middleware if they need one.