### PR TITLE
Resolve tiny typo in example

### DIFF
--- a/en/development/dependency-injection.rst
+++ b/en/development/dependency-injection.rst
@@ -222,7 +222,7 @@ An example ServiceProvider would look like::
 
         public function services(ContainerInterface $container): void
         {
-            $container->add(StripService::class);
+            $container->add(StripeService::class);
             $container->add('configKey', 'some value');
         }
     }


### PR DESCRIPTION
While reading the docs I stumbled upon this.

The example provides `StripeService::class` while later it tries adding a `StripService::class`.

That's not a critical issue, just a small typo.