### PR TITLE
4.5 Add un-deprecation of loadModel() to notes

### DIFF
--- a/en/appendices/4-5-migration-guide.rst
+++ b/en/appendices/4-5-migration-guide.rst
@@ -128,6 +128,16 @@ Database
 - ``SelectQuery::setConnectionRole()``, ``SelectQuery::useReadRole()``, and ``SelectQuery::useWriteRole()``
   were added to let you switch a query to a specific connection role.
 
+Datasource
+----------
+
+- ``ModelAwareTrait::loadModel()`` is no longer deprecated. This method is used
+  extensively in user-land applications and had no real replacement. Usage of
+  dynamic-properties & ``loadModel()`` will continue to emit deprecation errors
+  though.
+- ``ModelAwareTrait::fetchModel()`` was added. This method works similar to
+  ``loadModel()`` but does not set the model as an attribute.
+
 Error
 -----
 

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -413,9 +413,23 @@ the named action::
 Loading Additional Models
 =========================
 
+.. php:method:: fetchModel(string $alias, array $config = [])
+
+The ``fetchModel()`` method is useful to load models or ORM tables that
+are not the controller's default. Models retrieved with this method will not be
+set as properties on your controller::
+
+    // Get an ElasticSearch model
+    $articles = $this->fetchModel('Articles', 'Elastic');
+
+    // Get a webservices model 
+    $github = $this->fetchModel('GitHub', 'Webservice');
+
+.. versionadded:: 4.5.0
+
 .. php:method:: fetchTable(string $alias, array $config = [])
 
-The ``fetchTable()`` function comes handy when you need to use a table that is not
+The ``fetchTable()`` method comes handy when you need to use an ORM table that is not
 the controller's default one::
 
     // In a controller method.
@@ -427,6 +441,7 @@ the controller's default one::
 
 .. versionadded:: 4.3.0
     ``Controller::fetchTable()`` was added. Prior to 4.3 you need to use ``Controller::loadModel()``.
+
 
 Paginating a Model
 ==================


### PR DESCRIPTION
Document `fetchModel()` and the differences it has with loadModel()