### PR TITLE
add extra notice on ICU datetime string formatting

### DIFF
--- a/en/core-libraries/time.rst
+++ b/en/core-libraries/time.rst
@@ -158,6 +158,11 @@ This method sets the default format used when converting an object to json::
 .. note::
     This method must be called statically.
 
+.. note::
+    Be aware that this is not a PHP Datetime string format! You need to use a
+    ICU date formatting string as specified in the following resource:
+    https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax.
+
 .. versionchanged:: 4.1.0
     The ``callable`` parameter type was added.
 
@@ -302,6 +307,11 @@ Likewise, it is possible to alter the default formatting string to be used for
 
 It is recommended to always use the constants instead of directly passing a date
 format string.
+
+.. note::
+    Be aware that this is not a PHP Datetime string format! You need to use a
+    ICU date formatting string as specified in the following resource:
+    https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax.
 
 Formatting Relative Times
 -------------------------


### PR DESCRIPTION
People still mix up ICU datetime strings with PHP datetime strings.
See https://discourse.cakephp.org/t/bug-in-frozendate-settostringformat/10966

This PR adds an extra notice to the `setJsonEncodeFormat` as well as the `setToStringFormat` method documentation which are the main cause of confusion in my opinion.