### PR TITLE
ConsoleIntegrationTestTrait namespace change

### DIFF
--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -299,6 +299,10 @@ To get started testing your console application, create a test case that uses th
 ``exec()`` that is used to execute your command. You can pass the same string
 you would use in the CLI to this method.
 
+.. note::
+
+    For CakePHP 4.4 onwards the ``Cake\Console\TestSuite\ConsoleIntegrationTestTrait`` namespace should be used.
+
 Let's start with a very simple command, located in
 **src/Command/UpdateTableCommand.php**::
 


### PR DESCRIPTION
Add note before the code examples showing the changes to namespace for ConsoleIntegrationTestTrait for 4.4+ Alternatively the examples could be updated with a note for <= 4.3 users about the old namespace in those versions.