### PR TITLE
minor fixes for example code on topic testing

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -804,7 +804,7 @@ Let's say we already have our Articles Table class defined in
         public function findPublished(Query $query, array $options): Query
         {
             $query->where([
-                $this->alias() . '.published' => 1
+                $this->getAlias() . '.published' => 1
             ]);
             return $query;
         }
@@ -852,7 +852,7 @@ now looks like this::
 
         public function testFindPublished(): void
         {
-            $query = $this->Articles->find('published')->all();
+            $query = $this->Articles->find('published')->select(['id', 'title']);
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $result = $query->enableHydration(false)->toArray();
             $expected = [


### PR DESCRIPTION
minor fixes in example code():
1) alias() should be getAlias()
2) all() returns Resultset, so assertion on Query will fail at all
3) fix "Failed asserting that two arrays are equal." (resultset will have more elements than expected array provided for comparison)