### PR TITLE
Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -81,7 +81,7 @@ by using the ``finder`` option::
 The list of options supported by get() are:
 
 -  ``cache`` cache config.
--  ``cacheKey`` cache key.
+-  ``key`` cache key.
 -  ``finder`` custom finder function.
 - ``conditions`` provide conditions for the WHERE clause of your query.
 - ``limit`` Set the number of rows you want.


### PR DESCRIPTION
The option for cache key is `key` as in the examples, not `cacheKey`.