### PR TITLE
Example of PointType is wrong

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -648,7 +648,7 @@ value object and into SQL expressions::
     {
         public function toPHP($value, DriverInterface $d)
         {
-            return Point::parse($value);
+            return null === $value ? null : Point::parse($value);
         }
 
         public function marshal($value)

--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -648,7 +648,7 @@ value object and into SQL expressions::
     {
         public function toPHP($value, DriverInterface $d)
         {
-            return null === $value ? null : Point::parse($value);
+            return $value === null ? null : Point::parse($value);
         }
 
         public function marshal($value)


### PR DESCRIPTION
If not checking for null, it will always show in for example "contain".