### PR TITLE
Updated composer command

### DIFF
--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -14,7 +14,7 @@ Use composer to install the Authentication Plugin:
 
 .. code-block:: console
 
-    composer require "cakephp/authentication:^2.0"
+    composer require "cakephp/authentication:^2.4"
 
 
 Adding Password Hashing


### PR DESCRIPTION
authentication 2.0 won't install with PHP 8/8.1/8.2 because zendframework/zend-diactros requires PHP ^7.1, and is also an abandoned package