### PR TITLE
Add note about fetchTable not adding a controller property to docs & migration guide

### DIFF
--- a/en/appendices/4-3-migration-guide.rst
+++ b/en/appendices/4-3-migration-guide.rst
@@ -86,7 +86,9 @@ ORM
 - ``ModelAwareTrait::loadModel()`` is deprecated. Use the new ``LocatorAwareTrait::fetchTable()`` instead.
   For example, in controllers you can do ``$this->fetchTable()`` to get the default table instance or use
   ``$this->fetchTable('Foos')`` for a non-default table.  You can set the ``LocatorAwareTrait::$defaultTable``
-  property to specify the default table alias for ``fetchTable()``.
+  property to specify the default table alias for ``fetchTable()``. But be aware that
+  ``LocatorAwareTrait::fetchTable()`` does not create a property with the name of the table alias on the
+  calling object, e.g. ``$this->Articles``, as  ``ModelAwareTrait::loadModel()`` does.
 - Query proxying all ``ResultSetInterface`` methods (including ```CollectionInterface```), which forces
   fetching results and calls the proxied method on the results, is now deprecated. An example of the
   deprecated usage is ``$query->combine('id', 'title');``. This should be

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -428,6 +428,11 @@ the controller's default one::
 .. versionadded:: 4.3.0
     ``Controller::fetchTable()`` was added. Prior to 4.3 you need to use ``Controller::loadModel()``.
 
+.. note::
+
+    ``Controller::fetchTable()`` does not create a controller property with the name of the table alias,
+    e.g. ``$this->Articles``, as  ``Controller::loadModel()`` does.
+
 Paginating a Model
 ==================
 


### PR DESCRIPTION
No mention of change in behavior in the migration guide:

https://book.cakephp.org/4/en/appendices/4-3-migration-guide.html#orm

No mention of change in behavior in the actual docs:

https://book.cakephp.org/4/en/controllers.html#loading-additional-models
https://book.cakephp.org/4/en/console-commands/commands.html#using-models-in-commands
https://book.cakephp.org/4/en/console-commands/shells.html#using-models-in-your-shells
https://book.cakephp.org/4/en/views/cells.html#implementing-the-cell
https://book.cakephp.org/4/en/orm/entities.html#creating-entities

