### PR TITLE
Removed single quot because string also contains single quot

### DIFF
--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -227,7 +227,7 @@ If a level is not supplied, :php:const:`LOG_ERR` is used which writes to the
 error log. The default log location is **logs/$level.log**::
 
     // Executing this inside a CakePHP class
-    $this->log('Something didn't work!');
+    $this->log("Something didn't work!");
 
     // Results in this being appended to logs/error.log
     // 2007-11-02 10:22:02 Error: Something didn't work!


### PR DESCRIPTION
There's already single quot inside the string "Something didn't work!". So single quot should not be used contain this string, or escape single quot.