### PR TITLE
5.x: adjust DI example for commands

### DIFF
--- a/en/development/dependency-injection.rst
+++ b/en/development/dependency-injection.rst
@@ -50,13 +50,8 @@ Here is an example of an injected service inside a command::
     // In src/Command/CheckUsersCommand.php
     class CheckUsersCommand extends Command
     {
-        /** @var UsersService */
-        public $users;
-
-        public function __construct(UsersService $users)
+        public function __construct(public UsersService $users)
         {
-            parent::__construct();
-            $this->users = $users;
         }
 
         public function execute(Arguments $args, ConsoleIo $io)


### PR DESCRIPTION
Commands don't have a constructor any more in Cake5
Also we should encourage the use of promoted constructor properties