### PR TITLE
5.x Document required entity fields better

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -299,11 +299,10 @@ ORM
 Required Entity Fields
 ----------------------
 
-Entities have a new opt-in functionality that allows making entities 
-handle properties more strictly. The new behavior is called 'required fields'.
-When enabled, accessing properties that
-are not defined in the entity will raise exceptions. This impacts the following
-usage::
+Entities have a new opt-in functionality that allows making entities handle
+properties more strictly. The new behavior is called 'required fields'. When
+enabled, accessing properties that are not defined in the entity will raise
+exceptions. This impacts the following usage::
 
     $entity->get();
     $entity->has();

--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -296,6 +296,30 @@ Http
 ORM
 ---
 
+Required Entity Fields
+----------------------
+
+Entities have a new opt-in functionality that allows makes entities 
+handle properties more strictly. The new behavior is called 'required fields'.
+When enabled, accessing properties that
+are not defined in the entity will raise exceptions. This impacts the following
+usage::
+
+    $entity->get();
+    $entity->has();
+    $entity->getOriginal();
+    isset($entity->attribute);
+    $entity->attribute;
+
+Fields are considered defined if they pass ``array_key_exists``. This includes
+null values. Because this can be a tedious to enable feature, it was deferred to
+5.0. We'd like any feedback you have on this feature as we're considering making
+this the default behavior in the future.
+
+
+Typed Finder Parameters
+-----------------------
+
 Table finders can now have typed arguments as required instead of an options array.
 For e.g. a finder for fetching posts by category or user::
 

--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -299,7 +299,7 @@ ORM
 Required Entity Fields
 ----------------------
 
-Entities have a new opt-in functionality that allows makes entities 
+Entities have a new opt-in functionality that allows making entities 
 handle properties more strictly. The new behavior is called 'required fields'.
 When enabled, accessing properties that
 are not defined in the entity will raise exceptions. This impacts the following


### PR DESCRIPTION
When looking into missing forwards compatibility for EntityTrait::has() I noticed that this feature wasn't documented as well as it could be.