### PR TITLE
Updated supported database engine versions

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -31,6 +31,12 @@ Global
 - Global functions are now opt-in. If your application uses global function
   aliases be sure to add ``require CAKE . 'functions.php'`` to you application's
   ``config/bootstrap.php``.
+- The supported database engine versions were updated:
+  -  MySQL (5.7 or higher)
+  -  MariaDB (10.1 or higher)
+  -  PostgreSQL (9.6 or higher)
+  -  Microsoft SQL Server (2012 or higher)
+  -  SQLite 3
 
 Auth
 ----

--- a/en/installation.rst
+++ b/en/installation.rst
@@ -27,9 +27,9 @@ CakePHP has a few system requirements:
 While a database engine isn't required, we imagine that most applications will
 utilize one. CakePHP supports a variety of database storage engines:
 
--  MySQL (5.6 or higher)
--  MariaDB (5.6 or higher)
--  PostgreSQL (9.4 or higher)
+-  MySQL (5.7 or higher)
+-  MariaDB (10.1 or higher)
+-  PostgreSQL (9.6 or higher)
 -  Microsoft SQL Server (2012 or higher)
 -  SQLite 3
 

--- a/fr/installation.rst
+++ b/fr/installation.rst
@@ -28,9 +28,9 @@ Techniquement, un moteur de base de données n'est pas nécessaire, mais nous
 imaginons que la plupart des applications vont en utiliser un. CakePHP
 supporte une diversité de moteurs de stockage de données:
 
--  MySQL (5.6 ou supérieur)
--  MariaDB (5.6 ou supérieur)
--  PostgreSQL (9.4 ou supérieur)
+-  MySQL (5.7 ou supérieur)
+-  MariaDB (10.1 ou supérieur)
+-  PostgreSQL (9.6 ou supérieur)
 -  Microsoft SQL Server (2012 ou supérieur)
 -  SQLite 3
 

--- a/ja/installation.rst
+++ b/ja/installation.rst
@@ -34,9 +34,9 @@ CakePHP は nginx や lighttpd や Microsoft IIS のような様々なウェブ�
 これを活用することが想像できます。
 CakePHP は種々のデータベース・ストレージのエンジンをサポートしています：
 
--  MySQL (5.6 以上)
--  MariaDB (5.6 以上)
--  PostgreSQL (9.4 以上)
+-  MySQL (5.7 以上)
+-  MariaDB (10.1 以上)
+-  PostgreSQL (9.6 以上)
 -  Microsoft SQL Server (2012 以上)
 -  SQLite 3
 


### PR DESCRIPTION
MariaDB 10.1 is the start of MySQL 5.7 support.