### PR TITLE
5.x: clarify upgrade docs

### DIFF
--- a/en/appendices/5-0-upgrade-guide.rst
+++ b/en/appendices/5-0-upgrade-guide.rst
@@ -57,17 +57,18 @@ plugin::
 Update CakePHP Dependency
 =========================
 
-After applying rector refactorings, upgrade CakePHP and PHPUnit with the following
-composer commands:
+After applying rector refactorings you need to upgrade CakePHP, its plugins, PHPUnit
+and maybe other dependencies in your ``composer.json``.
+This process heavily depends on your application so we recommend you compare your
+``composer.json`` with what is present in `cakephp/app
+<https://github.com/cakephp/app/blob/5.x/composer.json>`__.
 
-.. code-block:: bash
-
-    php composer.phar require --dev --update-with-dependencies "phpunit/phpunit:^10.1"
-    php composer.phar require --update-with-dependencies "cakephp/cakephp:5.0.*"
+After the version strings are adjusted in your ``composer.json`` execute
+``composer update -W`` and check its output.
 
 Update app files based upon latest app template
 ===============================================
 
-Next, ensure your application has been updated to be based upon the
+Next, ensure the rest of your application has been updated to be based upon the
 latest version of `cakephp/app
 <https://github.com/cakephp/app/blob/5.x/>`__.


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17270

```
composer require --update-with-dependencies "cakephp/cakephp:5.0.*"
```

only works if all other plugin dependencies have been updated in the composer.json
This of course won't happen automatically, and new/inexperienced users who don't know how composer works will get stuck here.

This is my proposal to just reference the current state of cakephp/app's composer.json
If further dependencies are broken, its up to the user (or helpful support chat 😉) to resolve the problem anyway.