### PR TITLE
Update security-headers.rst

### DIFF
--- a/en/security/security-headers.rst
+++ b/en/security/security-headers.rst
@@ -10,7 +10,6 @@ headers to responses:
 * ``X-Content-Type-Options``
 * ``X-Download-Options``
 * ``X-Frame-Options``
-* ``X-Permitted-Cross-Domain-Policies``
 * ``Referrer-Policy``
 
 This middleware is configured using a fluent interface before it is applied to
@@ -20,14 +19,16 @@ your application's middleware stack::
 
     $securityHeaders = new SecurityHeadersMiddleware();
     $securityHeaders
-        ->setCrossDomainPolicy()
         ->setReferrerPolicy()
         ->setXFrameOptions()
-        ->setXssProtection()
         ->noOpen()
         ->noSniff();
 
     $middlewareQueue->add($securityHeaders);
+
+Here's a list of common HTTP headers https://en.wikipedia.org/wiki/List_of_HTTP_header_fields.
+
+And the Mozilla recommended settings https://infosec.mozilla.org/guidelines/web_security.html.
 
 .. meta::
    :title lang=en: Security Header Middleware


### PR DESCRIPTION
Remove outdated options from the example, add references to all headers and Mozilla security recommendations