### PR TITLE
Remove Double Slash From AbstractTransport Class Name

### DIFF
--- a/en/core-libraries/email.rst
+++ b/en/core-libraries/email.rst
@@ -529,7 +529,7 @@ Sending emails without using Mailer
 ===================================
 
 The ``Mailer`` is a higher level abstraction class which acts as a bridge between
-the ``Cake\Mailer\Message``, ``Cake\Mailer\Renderer`` and ``Cake\Mailer\\AbstractTransport``
+the ``Cake\Mailer\Message``, ``Cake\Mailer\Renderer`` and ``Cake\Mailer\AbstractTransport``
 classes to configure emails with a fluent interface.
 
 If you want you can use these classes directly with the ``Mailer`` too.

--- a/fr/core-libraries/email.rst
+++ b/fr/core-libraries/email.rst
@@ -601,7 +601,7 @@ Envoyer des Emails sans utiliser Mailer
 
 Le ``Mailer`` est une classe à haut niveau d'abstraction, qui agit commme un
 pont entre les classes ``Cake\Mailer\Message``, ``Cake\Mailer\Renderer`` et
-``Cake\Mailer\\AbstractTransport`` pour configuer les emails avec une interface
+``Cake\Mailer\AbstractTransport`` pour configuer les emails avec une interface
 fluide.
 
 Si vous voulez, vous pouvez aussi utiliser ces classes directement avec le

--- a/pt/core-libraries/email.rst
+++ b/pt/core-libraries/email.rst
@@ -553,7 +553,7 @@ Enviar Emails sem Usar o Mailer
 ===============================
 
 O ``Mailer`` é uma classe de abstração de nível superior que atua como uma ponte entre as 
-classes ``Cake\Mailer\Message``, ``Cake\Mailer\Renderer`` e ``Cake\Mailer\\AbstractTransport`` 
+classes ``Cake\Mailer\Message``, ``Cake\Mailer\Renderer`` e ``Cake\Mailer\AbstractTransport``
 para facilitar a configuração e entrega do e-mail.
 
 Se você quiser, pode usar essas classes diretamente com o ``Mailer`` também.


### PR DESCRIPTION
This also needs back-ported to 4.x. Should I open a separate PR for that, or is there a different process?