### PR TITLE
Add Space Before In-line Code to Fix Rendering

### DIFF
--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -369,7 +369,7 @@ Prior to CakePHP 4.4.0, you should implement ``logMessage()`` and ``log()``::
     ErrorLoggerInterface was added.
 
 .. versionchanged:: 4.4.0
-    ``ErrorLoggerInterface::logException()`` and``ErrorLoggerInterface::logError()`` were added.
+    ``ErrorLoggerInterface::logException()`` and ``ErrorLoggerInterface::logError()`` were added.
 
 
 Custom Error Rendering


### PR DESCRIPTION
[Current page](https://book.cakephp.org/4/en/development/errors.html#custom-error-logging):
![image](https://github.com/cakephp/docs/assets/3212673/3e9a069e-8c00-477c-af02-c5029dfa2585)
