### PR TITLE
Fix Container Auto-Wiring Link

### DIFF
--- a/en/development/dependency-injection.rst
+++ b/en/development/dependency-injection.rst
@@ -311,4 +311,4 @@ caching::
     );
 
 Read more about auto wiring in the `PHP League Container documentation
-<https://container.thephpleague.com/5.x/auto-wiring/>`_.
+<https://container.thephpleague.com/4.x/auto-wiring/>`_.


### PR DESCRIPTION
The current link returns a 404 status page. Looking at the [CakePHP 4.x documentation](https://book.cakephp.org/5/en/development/dependency-injection.html#auto-wiring) and current version of [composer.json](https://github.com/cakephp/cakephp/blob/5.x/composer.json#L33) it looks like we are using the 4.x version of the container.