### PR TITLE
Remove References to useCommandRunner

### DIFF
--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -335,12 +335,6 @@ moment, but let's just test that our command's description is displayed in ``std
     {
         use ConsoleIntegrationTestTrait;
 
-        public function setUp(): void
-        {
-            parent::setUp();
-            $this->useCommandRunner();
-        }
-
         public function testDescriptionOutput()
         {
             $this->exec('update_table --help');

--- a/fr/console-commands/commands.rst
+++ b/fr/console-commands/commands.rst
@@ -342,12 +342,6 @@ moment, mais testons simplement si la description de notre shell description s'a
     {
         user ConsoleIntegrationTestTrait;
 
-        public function setUp(): void
-        {
-            parent::setUp();
-            $this->useCommandRunner();
-        }
-
         public function testDescriptionOutput()
         {
             $this->exec('update_table --help');
@@ -539,15 +533,6 @@ que nous recevons une réponse négative. Retirez la méthode
 Dans le premier cas de test, nous confirmons la question, et les enregistrements sont mis à jour. Dans le deuxième test, nous
 ne confirmons pas et les enregistrements ne sont pas mis à jour, et nous pouvons vérifier que le message d'erreur a été écrit
 dans ``stderr``.
-
-
-Tester le CommandRunner
------------------------
-
-Pour tester les shells qui sont dispatchés en utilisant la classe
-``CommandRunner``, activez-la dans vos cas de test avec la méthode suivante::
-
-    $this->useCommandRunner();
 
 Méthodes d'Assertion
 --------------------

--- a/ja/console-commands/commands.rst
+++ b/ja/console-commands/commands.rst
@@ -313,12 +313,6 @@ CLI で使用するのと同じ文字列を渡すことができます。
     {
         use ConsoleIntegrationTestTrait;
 
-        public function setUp(): void
-        {
-            parent::setUp();
-            $this->useCommandRunner();
-        }
-
         public function testDescriptionOutput()
         {
             $this->exec('update_table --help');
@@ -507,14 +501,6 @@ CLI で使用するのと同じ文字列を渡すことができます。
 最初のテストケースでは、質問を確認し、レコードが更新されます。
 2番目のテストでは確認していませんし、レコードが更新されていないので、
 エラーメッセージが ``stderr`` に書き込まれていることを確認できます。
-
-CommandRunner のテスト
-----------------------
-
-``CommandRunner`` クラスを使ってディスパッチされたシェルをテストするには、
-次のメソッドを使ってテストケースでそれを有効にしてください。 ::
-
-    $this->useCommandRunner();
 
 アサーションメソッド
 ----------------------


### PR DESCRIPTION
The [5.x migration guide](https://book.cakephp.org/5/en/appendices/5-0-migration-guide.html) mentions that `useCommandRunner` was removed.