### PR TITLE
Fix docs about plugin class name

### DIFF
--- a/en/plugins.rst
+++ b/en/plugins.rst
@@ -176,7 +176,7 @@ classes::
     $plugin->enable('routes');
     $this->addPlugin($plugin);
 
-Plugin objects also know their names and path information::
+Plugin classes also know their names and path information::
 
     $plugin = new ContactManagerPlugin();
 
@@ -290,11 +290,11 @@ autoloader once you've created your plugin:
 
 .. _plugin-objects:
 
-Plugin Objects
+Plugin Classes
 ==============
 
-Plugin Objects allow a plugin author to define set-up logic, define default
-hooks, load routes, middleware and console commands. Plugin objects live in
+Plugin classes allow a plugin author to define set-up logic, define default
+hooks, load routes, middleware and console commands. Plugin classes live in
 **src/{PluginName}Plugin.php**. For our ContactManager plugin, our plugin class could look
 like::
 

--- a/fr/plugins.rst
+++ b/fr/plugins.rst
@@ -142,7 +142,7 @@ Configuration du Plugin
 
 Les plugins proposent plusieurs *hooks* permettant à un plugin de s'injecter
 lui-même aux endroits appropriés de votre application. Les *hooks* sont:
- 
+
 * ``bootstrap`` Utilisé pour charger les fichiers de configuration par défaut
   d'un plugin, définir des constantes et d'autres fonctions globales.
 * ``routes`` Utilisé pour charger les routes pour un plugin. Il est déclenché
@@ -293,7 +293,7 @@ re-générer votre autoloader après avoir créé votre plugin:
 
 .. _plugin-objects:
 
-Plugin Objects
+Plugin Classes
 ==============
 
 Les Objets Plugin permettent à un auteur de plugin de spécifier une logique de


### PR DESCRIPTION
We should use the correct name for it: Class
It only becomes on object on instantiation, which is a language detail not relevant for the documentation purpose
It also is called correctly further down in the document, so this consolidates the naming.