### PR TITLE
Update migration guide - 5.x

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -28,9 +28,6 @@ Global
 - Type declarations were added to all class properties where possible. These also include some fixes for
   incorrect annotations.
 - The ``SECOND``, ``MINUTE``, ``HOUR``, ``DAY``,  ``WEEK``, ``MONTH``, ``YEAR`` constants were removed.
-- Global functions are now opt-in. If your application uses global function
-  aliases be sure to add ``require CAKE . 'functions.php'`` to you application's
-  ``config/bootstrap.php``.
 - Use of ``#[\AllowDynamicProperties]`` removed everywhere. It was used for the following classes:
    - ``Command/Command``
    - ``Console/Shell``


### PR DESCRIPTION
Related to https://github.com/cakephp/app/issues/979

Globals are still opt-out on 5.x