### PR TITLE
Backport 7765 to 4.x

### DIFF
--- a/en/appendices/4-4-migration-guide.rst
+++ b/en/appendices/4-4-migration-guide.rst
@@ -97,7 +97,7 @@ be removed in 5.0.
   ``RequestHandlerComponent``.
 
 The automatic view switching for 'ajax' requests offered by
-``RequestHandlerComponent`` is no longer available. Instead you can either
+``RequestHandlerComponent`` is deprecated. Instead you can either
 handle this in a controller action or ``Controller.beforeRender`` callback
 with::
 

--- a/en/appendices/4-4-migration-guide.rst
+++ b/en/appendices/4-4-migration-guide.rst
@@ -96,6 +96,18 @@ be removed in 5.0.
 - Use :ref:`controller-viewclasses` instead of defining view class mappings in
   ``RequestHandlerComponent``.
 
+The automatic view switching for 'ajax' requests offered by
+``RequestHandlerComponent`` is no longer available. Instead you can either
+handle this in a controller action or ``Controller.beforeRender`` callback
+with::
+
+    // In a controller action, or in beforeRender.
+    if ($this->request->is('ajax')) {
+        $this->viewBuilder()->setClassName('Ajax');
+    }
+
+Alternatively, you can have the HTML view class switch to the ``ajax`` layout as
+required in your controller actions or view templates.
 
 PaginatorComponent
 ------------------

--- a/en/controllers.rst
+++ b/en/controllers.rst
@@ -358,6 +358,22 @@ content-type negotiation is attempted.
     Prior to 4.4 you must use :doc:`/controllers/components/request-handling`
     instead of ``viewClasses()``.
 
+Using AjaxView
+==============
+
+In applications that use hypermedia or AJAX clients, you often need to render
+view contents without the wrapping layout. You can use the ``AjaxView`` that
+is bundled with the application skeleton::
+
+    // In a controller action, or in beforeRender.
+    if ($this->request->is('ajax')) {
+        $this->viewBuilder()->setClassName('Ajax');
+    }
+
+``AjaxView`` will respond as ``text/html`` and use the ``ajax`` layout.
+Generally this layout is minimal or contains client specific markup. This
+replaces usage of ``RequestHandlerComponent`` automatically using the
+``AjaxView``.
 
 Redirecting to Other Pages
 ==========================

--- a/en/views.rst
+++ b/en/views.rst
@@ -117,9 +117,9 @@ Another example, using if/elseif/else. Notice the colons:
      <h3>Hi unknown user</h3>
   <?php endif; ?>
 
-If you'd prefer using a templating language like
-`Twig <https://twig.symfony.com>`_, a subclass of View will bridge your
-templating language and CakePHP.
+If you'd prefer to use a templating language like
+`Twig <https://twig.symfony.com>`_, checkout the `CakePHP Twig Plugin
+<https://github.com/cakephp/twig-view>`__ 
 
 Template files are stored in **templates/**, in a folder named after the
 controller that uses the files, and named after the action it corresponds to.


### PR DESCRIPTION
- Backport the changes from #7765 to 4.x
- I've also updated the migration guide notes for RequestHandlerComponent as the 5.x docs reference them.