### PR TITLE
Consistent aliasing for assocs.

### DIFF
--- a/en/orm/associations.rst
+++ b/en/orm/associations.rst
@@ -186,18 +186,18 @@ If you want to break different addresses into multiple associations, you can do 
     {
         public function initialize(array $config): void
         {
-            $this->hasOne('HomeAddress', [
+            $this->hasOne('HomeAddresses', [
                     'className' => 'Addresses'
                 ])
                 ->setProperty('home_address')
-                ->setConditions(['HomeAddress.label' => 'Home'])
+                ->setConditions(['HomeAddresses.label' => 'Home'])
                 ->setDependent(true);
 
-            $this->hasOne('WorkAddress', [
+            $this->hasOne('WorkAddresses', [
                     'className' => 'Addresses'
                 ])
                 ->setProperty('work_address')
-                ->setConditions(['WorkAddress.label' => 'Work'])
+                ->setConditions(['WorkAddresses.label' => 'Work'])
                 ->setDependent(true);
         }
     }
@@ -205,7 +205,7 @@ If you want to break different addresses into multiple associations, you can do 
 .. note::
 
     If a column is shared by multiple hasOne associations, you must qualify it with the association alias.
-    In the above example, the 'label' column is qualified with the 'HomeAddress' and 'WorkAddress' aliases.
+    In the above example, the 'label' column is qualified with the 'HomeAddresses' and 'WorkAddresses' aliases.
 
 Possible keys for hasOne association arrays include:
 


### PR DESCRIPTION
https://book.cakephp.org/5/en/orm/associations.html#hasone-associations

For beginners it can probably be confusing to see only hasOne() relations in singular, and only sometimes.

If anything, I would have expected belongsTo() to be singular, since there can always be only one ever.
HasOne() could easily become hasMany() by allowing more rows to be allowed, and then requires more massive refactoring.
So from the convention approach, it seems sound to stick here to the default, plural.

What do others think?