### PR TITLE
Use 4.5.x package dependency when upgrading

### DIFF
--- a/en/appendices/4-5-migration-guide.rst
+++ b/en/appendices/4-5-migration-guide.rst
@@ -9,7 +9,7 @@ Upgrading to 4.5.0
 
 You can can use composer to upgrade to CakePHP 4.5.0::
 
-    php composer.phar require --update-with-dependencies "cakephp/cakephp:^4.5"
+    php composer.phar require --update-with-dependencies "cakephp/cakephp:4.5.x"
 
 .. note::
     CakePHP 4.5 requires PHP 7.4 or greater.


### PR DESCRIPTION
If users are upgrading to a minor, they want to upgrade to a specific minor.