### PR TITLE
Add notes for https://github.com/cakephp/cakephp/pull/17340

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -56,6 +56,12 @@ Cache
 - The ``Wincache`` engine was removed. The wincache extension is not supported
   on PHP 8.
 
+Collection
+----------
+
+- `combine()` now throws an exception if the key path or group path doesn't exist or contains a null value.
+  This matches the behavior of `indexBy()` and `groupBy()`.
+
 Console
 -------
 


### PR DESCRIPTION
This change was accidentally merged and released in 5.0.2 so needs to be in the migration notes.