### PR TITLE
remove info about cyclic dependency problem in auto-wiring DIC feature

### DIFF
--- a/en/development/dependency-injection.rst
+++ b/en/development/dependency-injection.rst
@@ -292,14 +292,10 @@ Auto Wiring is turned off by default. To enable it::
     // In src/Application.php
     public function services(ContainerInterface $container): void
     {
-        $container->add(\Cake\Controller\ComponentRegistry::class);
         $container->delegate(
             new \League\Container\ReflectionContainer()
         );
     }
-
-The ``$container->add(\Cake\Controller\ComponentRegistry::class);`` is needed to
-fix a cyclic dependency between ``ComponentRegistry`` and ``Controller``.
 
 While your dependencies will now be resolved automatically, this approach will
 not cache resolutions which can be detrimental to performance. To enable


### PR DESCRIPTION
Not needed anymore with Cake5 due to https://github.com/cakephp/cakephp/pull/16546