### PR TITLE
Update form.rst

### DIFF
--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -1814,12 +1814,12 @@ error messages per field.
 
 Example::
 
-    // If in TicketsTable you have a 'notEmpty' validation rule:
+    // If in TicketsTable you have a 'notEmptyString' validation rule:
     public function validationDefault(Validator $validator): Validator
     {
         $validator
             ->requirePresence('ticket', 'create')
-            ->notEmpty('ticket');
+            ->notEmptyString('ticket');
     }
 
     // And inside templates/Tickets/add.php you have:


### PR DESCRIPTION
The `notEmpty()` validator already deprecated since 3.7.0.  Need to use `notEmptyString()` instead.

Refer [#1](https://github.com/cakephp/cakephp/blob/9cb11c941566cae80a825889a2c007e1860abbd3/src/Validation/Validator.php#L1185-L1193) and [#2](https://github.com/cakephp/cakephp/blob/9cb11c941566cae80a825889a2c007e1860abbd3/src/Validation/Validator.php#L1197-L1201)