### PR TITLE
Update PHPUnit Link

### DIFF
--- a/en/appendices/phpunit10.rst
+++ b/en/appendices/phpunit10.rst
@@ -21,7 +21,7 @@ New event system
 ----------------
 
 PHPUnit 10 removed the old hook system and introduced a new `Event system
-<https://docs.phpunit.de/en/10.0/extending-phpunit.html#extending-the-test-runner>`_
+<https://docs.phpunit.de/en/10.5/extending-phpunit.html#extending-the-test-runner>`_
 which requires the following code in your ``phpunit.xml`` to be adjusted from::
 
   <extensions>

--- a/es/appendices/phpunit10.rst
+++ b/es/appendices/phpunit10.rst
@@ -21,7 +21,7 @@ Nuevo sistema de eventos
 ------------------------
 
 PHPUnit 10 eliminó el antiguo sistema de hook e introdujo un nuevo `Sistema de eventos
-<https://docs.phpunit.de/en/10.0/extending-phpunit.html#extending-the-test-runner>`_
+<https://docs.phpunit.de/en/10.5/extending-phpunit.html#extending-the-test-runner>`_
 Lo que requiere que se ajuste el siguiente código en su ``phpunit.xml`` desde::
 
   <extensions>


### PR DESCRIPTION
`appendices/phpunit10.rst` has a link to PHPUnit 10.0 manual, but they seem to have deleted the 10.0 manual.
They now offer 10.5 version instead, so our link should be updated.

## Translations
- en : updated in this pull request
- es : updated in this pull request
- ja : updated in #7813 
- fr : does not have this file
- pt : does not have this file
