### PR TITLE
Update component testing docs

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -1680,14 +1680,13 @@ correctly by the ``adjust()`` method in our component. We create the file
         public function setUp(): void
         {
             parent::setUp();
-            // Setup our component and fake test controller
+            // Setup our component and provide it a basic controller.
+            // If your component relies on Application features, use AppController.
             $request = new ServerRequest();
             $response = new Response();
-            $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
-                ->setConstructorArgs([$request, $response])
-                ->setMethods(null)
-                ->getMock();
+            $this->controller = new Controller($request);
             $registry = new ComponentRegistry($this->controller);
+
             $this->component = new PagematronComponent($registry);
             $event = new Event('Controller.startup', $this->controller);
             $this->component->startup($event);


### PR DESCRIPTION
PHPUnit has deprecated the mock creation methods we were using in this example. By not using mocks we can test more of the actual functionality.

Fixes cakephp/cakephp#17616