### PR TITLE
Remove docs for subcommands

### DIFF
--- a/en/appendices/5-0-migration-guide.rst
+++ b/en/appendices/5-0-migration-guide.rst
@@ -68,6 +68,9 @@ Console
 - ``BaseCommand::__construct()`` was removed.
 - ``ConsoleIntegrationTestTrait::useCommandRunner()`` was removed since it's no longer needed.
 - ``Shell`` has been removed and should be replaced with `Command <https://book.cakephp.org/5/en/console-commands/commands.html>`__
+- ``ConsoleOptionParser::addSubcommand()`` was removed alongside the removal of
+  ``Shell``. Subcommands should be replaced with ``Command`` classes that
+  implement ``Command::defaultName()`` to define the necessary command name.
 - ``BaseCommand`` now emits ``Command.beforeExecute`` and
   ``Command.afterExecute`` events around the command's ``execute()`` method
   being invoked by the framework.

--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -482,7 +482,7 @@ Update the command class to the following::
         }
     }
 
-Now that we have an interactive subcommand, we can add a test case that tests
+Now that we have an interactive command, we can add a test case that tests
 that we receive the proper response, and one that tests that we receive an
 incorrect response. Remove the ``testUpdateModified`` method and, add the following methods to
 **tests/TestCase/Command/UpdateTableCommandTest.php**::

--- a/en/console-commands/option-parsers.rst
+++ b/en/console-commands/option-parsers.rst
@@ -194,32 +194,12 @@ Building a ConsoleOptionParser from an Array
 
 .. php:method:: buildFromArray($spec)
 
-As previously mentioned, when creating subcommand option parsers, you can define
-the parser spec as an array for that method. This can help make building
-subcommand parsers easier, as everything is an array::
-
-    $parser->addSubcommand('check', [
-        'help' => __('Check the permissions between an ACO and ARO.'),
-        'parser' => [
-            'description' => [
-                __("Use this command to grant ACL permissions. Once executed, the "),
-                __("ARO specified (and its children, if any) will have ALLOW access "),
-                __("to the specified ACO action (and the ACO's children, if any)."),
-            ],
-            'arguments' => [
-                'aro' => ['help' => __('ARO to check.'), 'required' => true],
-                'aco' => ['help' => __('ACO to check.'), 'required' => true],
-                'action' => ['help' => __('Action to check')],
-            ],
-        ],
-    ]);
-
-Inside the parser spec, you can define keys for ``arguments``, ``options``,
-``description`` and ``epilog``. You cannot define ``subcommands`` inside an
-array style builder. The values for arguments, and options, should follow the
-format that :php:func:`Cake\\Console\\ConsoleOptionParser::addArguments()` and
+Option parsers can also be defined as arrays. Within the array, you can define
+keys for ``arguments``, ``options``, ``description`` and ``epilog``.  The values
+for arguments, and options, should follow the format that
+:php:func:`Cake\\Console\\ConsoleOptionParser::addArguments()` and
 :php:func:`Cake\\Console\\ConsoleOptionParser::addOptions()` use. You can also
-use buildFromArray on its own, to build an option parser::
+use ``buildFromArray`` on its own, to build an option parser::
 
     public function getOptionParser()
     {
@@ -287,8 +267,8 @@ returned as XML:
     cake bake --help xml
     cake bake -h xml
 
-The above would return an XML document with the generated help, options,
-arguments and subcommands for the selected shell. A sample XML document would
+The above would return an XML document with the generated help, options, and
+arguments for the selected shell. A sample XML document would
 look like:
 
 .. code-block:: xml


### PR DESCRIPTION
- Remove subcommand references from docs.
- Add to the 5.0 migration guide as subcommands were not explicitly mentioned there previously.

Fixes #7825