### PR TITLE
[4.next] Add blank line before return statements in examples

### DIFF
--- a/en/console-commands/commands.rst
+++ b/en/console-commands/commands.rst
@@ -27,7 +27,7 @@ simple Hello world command. In your application's **src/Command** directory crea
         public function execute(Arguments $args, ConsoleIo $io): int
         {
             $io->out('Hello world.');
-            
+
             return static::CODE_SUCCESS;
         }
     }
@@ -62,6 +62,7 @@ command line::
             $parser->addArgument('name', [
                 'help' => 'What is your name'
             ]);
+
             return $parser;
         }
 
@@ -69,7 +70,7 @@ command line::
         {
             $name = $args->getArgument('name');
             $io->out("Hello {$name}.");
-            
+
             return static::CODE_SUCCESS;
         }
     }
@@ -128,7 +129,7 @@ add a ``yell`` option to our ``HelloCommand``::
             $name = mb_strtoupper($name);
         }
         $io->out("Hello {$name}.");
-        
+
         return static::CODE_SUCCESS;
     }
 
@@ -202,7 +203,7 @@ to terminate execution::
             $io->error('Name must be at least 4 characters long.');
             $this->abort();
         }
-        
+
         return static::CODE_SUCCESS;
     }
 
@@ -215,7 +216,7 @@ You can also use ``abort()`` on the ``$io`` object to emit a message and code::
             // Halt execution, output to stderr, and set exit code to 99
             $io->abort('Name must be at least 4 characters long.', 99);
         }
-        
+
         return static::CODE_SUCCESS;
     }
 
@@ -384,7 +385,7 @@ conventions. Let's continue by adding more logic to our command::
                     'modified' => new FrozenTime()
                 ])
                 ->execute();
-                
+
             return static::CODE_SUCCESS;
         }
     }
@@ -486,7 +487,7 @@ Update the command class to the following::
                     'modified' => new FrozenTime()
                 ])
                 ->execute();
-                
+
             return static::CODE_SUCCESS;
         }
     }

--- a/en/console-commands/shells.rst
+++ b/en/console-commands/shells.rst
@@ -146,12 +146,14 @@ Also, the task name must be added as a sub-command to the Shell's OptionParser::
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
+
         $parser->addSubcommand('sound', [
             // Provide help text for the command list
             'help' => 'Execute The Sound Task.',
             // Link the option parsers together.
             'parser' => $this->Sound->getOptionParser(),
         ]);
+
         return $parser;
     }
 

--- a/en/controllers/components.rst
+++ b/en/controllers/components.rst
@@ -142,6 +142,7 @@ in your controller, you could access it like so::
         {
             if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
+
                 return $this->redirect(['action' => 'index']);
             }
         }
@@ -317,6 +318,7 @@ To redirect from within a component callback method you can use the following::
     public function beforeFilter(EventInterface $event)
     {
         $event->stopPropagation();
+
         return $this->getController()->redirect('/');
     }
 

--- a/en/controllers/components/authentication.rst
+++ b/en/controllers/components/authentication.rst
@@ -228,6 +228,7 @@ working with a login form could look like::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
                 $this->Flash->error(__('Username or password is incorrect'));
@@ -444,6 +445,7 @@ from the normal password hash::
                 $entity->plain_password,
                 env('SERVER_NAME')
             );
+
             return true;
         }
     }
@@ -721,6 +723,7 @@ calling ``$this->Auth->setUser()`` with the user data you want to 'login'::
         $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
+
             return $this->redirect([
                 'controller' => 'Users',
                 'action' => 'home'

--- a/en/core-libraries/events.rst
+++ b/en/core-libraries/events.rst
@@ -61,10 +61,12 @@ has been created. To keep your Orders model clean you could use events::
         {
             if ($this->save($order)) {
                 $this->Cart->remove($order);
+
                 $event = new Event('Order.afterPlace', $this, [
                     'order' => $order
                 ]);
                 $this->getEventManager()->dispatch($event);
+
                 return true;
             }
             return false;
@@ -456,6 +458,7 @@ directly or returning the value in the callback itself::
     {
         // ...
         $alteredData = $event->getData('order') + $moreData;
+
         return $alteredData;
     }
 

--- a/en/core-libraries/hash.rst
+++ b/en/core-libraries/hash.rst
@@ -633,6 +633,7 @@ Attribute Matching Types
         public function noop(array $array)
         {
             // Do stuff to array and return the result
+
             return $array;
         }
 

--- a/en/core-libraries/logging.rst
+++ b/en/core-libraries/logging.rst
@@ -471,6 +471,7 @@ After installing Monolog using composer, configure the logger using the
     Log::setConfig('default', function () {
         $log = new Logger('app');
         $log->pushHandler(new StreamHandler('path/to/your/combined.log'));
+
         return $log;
     });
 
@@ -488,6 +489,7 @@ Use similar methods if you want to configure a different logger for your console
     Log::setConfig('default', function () {
         $log = new Logger('cli');
         $log->pushHandler(new StreamHandler('path/to/your/combined-cli.log'));
+
         return $log;
     });
 

--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -303,6 +303,7 @@ something like::
         public function write($id, $data): bool
         {
             Cache::write($id, $data, $this->cacheKey);
+
             return parent::write($id, $data);
         }
 
@@ -310,6 +311,7 @@ something like::
         public function destroy($id): bool
         {
             Cache::delete($id, $this->cacheKey);
+
             return parent::destroy($id);
         }
 

--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -147,6 +147,7 @@ Our helper looks like::
         public function bar($value)
         {
             $width = round($value / 100, 2) * 100;
+
             return sprintf(
                 '<div class="progress-container">
                     <div class="progress-bar" style="width: %s%%"></div>
@@ -867,6 +868,7 @@ Let's say we already have our Articles Table class defined in
             $query->where([
                 $this->getAlias() . '.published' => 1
             ]);
+
             return $query;
         }
     }
@@ -1337,7 +1339,7 @@ and make sure our web service is returning the proper response::
     class MarkersControllerTest extends IntegrationTestCase
     {
         use IntegrationTestTrait;
-    
+
         public function testGet(): void
         {
             $this->configRequest([
@@ -1921,6 +1923,7 @@ Expanding on the Orders example, say we have the following tables::
                     'order' => $order
                 ]);
                 $this->getEventManager()->dispatch($event);
+
                 return true;
             }
             return false;

--- a/en/installation.rst
+++ b/en/installation.rst
@@ -449,6 +449,7 @@ A sample of the server directive is as follows:
         listen   80;
         listen   [::]:80;
         server_name www.example.com;
+
         return 301 http://example.com$request_uri;
     }
 

--- a/en/orm/behaviors.rst
+++ b/en/orm/behaviors.rst
@@ -189,6 +189,7 @@ To prevent the save from continuing, simply stop event propagation in your callb
         if (...) {
             $event->stopPropagation();
             $event->setResult(false);
+
             return;
         }
         $this->slug($entity);

--- a/en/orm/behaviors/tree.rst
+++ b/en/orm/behaviors/tree.rst
@@ -98,14 +98,14 @@ in a hierarchy, you can stack the 'threaded' finder::
     }
 
 While, if you’re using custom ``parent_id`` you need to pass it in the
-'threaded' finder option (i.e. ``parentField``) . 
+'threaded' finder option (i.e. ``parentField``) .
 
 .. note::
     For more information on 'threaded' finder options see :ref:`Finding Threaded Data logic <finding-threaded-data>`
 
 Getting formatted tree lists
 ----------------------------
- 
+
 Traversing threaded results usually requires recursive functions in, but if you
 only require a result set containing a single field from each level so you can
 display a list, in an HTML select for example, it is better to use the
@@ -246,6 +246,7 @@ as the scope::
 
     $this->behaviors()->Tree->setConfig('scope', function ($query) {
         $country = $this->getConfigureContry(); // A made-up function
+
         return $query->where(['country_name' => $country]);
     });
 
@@ -335,7 +336,7 @@ conditional deletes::
     }
 
 TreeBehavior will reorder the ``lft`` and ``rght`` values of records in the
-table when a node is deleted. 
+table when a node is deleted.
 
 In our example above, the ``lft`` and ``rght`` values of the entities inside
 ``$descendants`` will be inaccurate. You will need to reload existing entity

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -169,7 +169,8 @@ implement the collection interface::
         ->all()
         ->map(function ($row) {
             $row->trimmedTitle = trim($row->title);
-            return $row;
+
+           return $row;
         })
         ->combine('id', 'trimmedTitle') // combine() is another collection method
         ->toArray(); // Also a collections library method
@@ -699,6 +700,7 @@ of people, you could calculate their age with a result formatter::
     $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
+
             return $row;
         });
     });
@@ -720,6 +722,7 @@ expect::
         return $q->formatResults(function (\Cake\Collection\CollectionInterface $authors) {
             return $authors->map(function ($author) {
                 $author['age'] = $author['birth_date']->diff(new \DateTime)->y;
+
                 return $author;
             });
         });
@@ -834,6 +837,7 @@ following::
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->add($orConditions)
                 ->eq('published', true)
@@ -862,6 +866,7 @@ the method chaining::
                 return $or->eq('author_id', 2)
                     ->eq('author_id', 5);
             });
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -873,6 +878,7 @@ You can negate sub-expressions using ``not()``::
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -896,6 +902,7 @@ It is also possible to build expressions using SQL functions::
             $year = $q->func()->year([
                 'created' => 'identifier'
             ]);
+
             return $exp
                 ->gte($year, 2014)
                 ->eq('published', true);
@@ -1224,6 +1231,7 @@ And can be used combined with aggregations too::
                     $query->newExpr(['Stocks.quantity', 'Products.unit_price'])
                         ->setConjunction('*')
             );
+
             return [
                 'Products.name',
                 'stock_quantity' => $stockQuantity,

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -77,7 +77,7 @@ by using the ``finder`` option::
     $article = $articles->get($id, [
         'finder' => 'translations',
     ]);
-    
+
 The list of options supported by get() are:
 
 -  ``cache`` cache config.
@@ -389,6 +389,7 @@ given user, we would do the following::
         public function findOwnedBy(Query $query, array $options)
         {
             $user = $options['user'];
+
             return $query->where(['author_id' => $user->id]);
         }
     }
@@ -1071,8 +1072,8 @@ can load additional associations using ``loadInto()``::
     $articles = $this->Articles->find()->all();
     $withMore = $this->Articles->loadInto($articles, ['Comments', 'Users']);
 
-It is possible to restrict the data returned by the associations and filter them 
-by conditions. To specify conditions, pass an anonymous function that receives 
+It is possible to restrict the data returned by the associations and filter them
+by conditions. To specify conditions, pass an anonymous function that receives
 as the first argument a query object, ``\Cake\ORM\Query``::
 
     $user = $this->Users->get($id);
@@ -1288,6 +1289,7 @@ This is particularly useful for building custom finder methods as described in t
         // Same as in the common words example in the previous section
         $mapper = ...;
         $reducer = ...;
+
         return $query->mapReduce($mapper, $reducer);
     }
 

--- a/en/orm/table-objects.rst
+++ b/en/orm/table-objects.rst
@@ -135,20 +135,20 @@ more detail on how to use the events subsystem::
 
     // In a controller
     $articles->save($article, ['customVariable1' => 'yourValue1']);
-    
+
     // In ArticlesTable.php
     public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $customVariable = $options['customVariable1'];	// 'yourValue1'
-        $options['customVariable2'] = 'yourValue2';	
-    }  
-    
+        $options['customVariable2'] = 'yourValue2';
+    }
+
     public function afterSaveCommit(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $customVariable = $options['customVariable1'];	// 'yourValue1'
         $customVariable = $options['customVariable2'];	// 'yourValue2'
     }
-    
+
 
 Event List
 ----------
@@ -357,6 +357,7 @@ To prevent the save from continuing, simply stop event propagation in your callb
         if (...) {
             $event->stopPropagation();
             $event->setResult(false);
+
             return;
         }
         ...

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -112,6 +112,7 @@ used. An example validator for our articles table would be::
             $validator
                 ->notEmptyString('title', __('You need to provide a title'))
                 ->notEmptyString('body', __('A body is required'));
+
             return $validator;
         }
     }
@@ -173,6 +174,7 @@ construction process into multiple reusable steps::
         $validator = $this->validationDefault($validator);
 
         $validator->add('password', 'length', ['rule' => ['lengthBetween', 8, 100]]);
+
         return $validator;
     }
 
@@ -207,6 +209,7 @@ a validation rule::
                     'message' => __('You need to provide a valid role'),
                     'provider' => 'table',
                 ]);
+
             return $validator;
         }
 
@@ -548,6 +551,7 @@ You may want to re-use custom domain rules. You can do so by creating your own i
             'errorField' => 'name',
             'message' => 'Name must be unique per parent.'
         ]);
+
         return $rules;
     }
 
@@ -571,6 +575,7 @@ those rules into re-usable classes::
         public function __invoke(EntityInterface $entity, array $options)
         {
             // Do work
+
             return false;
         }
     }

--- a/en/security/csrf.rst
+++ b/en/security/csrf.rst
@@ -48,6 +48,7 @@ stack you protect all the actions in application::
         $csrf = new SessionCsrfProtectionMiddleware($options);
 
         $middlewareQueue->add($csrf);
+
         return $middlewareQueue;
     }
 
@@ -83,8 +84,8 @@ The available configuration options are:
   will fail. Defaults to ``false``.
 - ``httponly`` Whether or not the cookie will be set with the HttpOnly flag.
   Defaults to ``false``. Prior to 4.1.0 use the ``httpOnly`` option.
-- ``samesite`` Allows you to declare if your cookie should be restricted to a 
-  first-party or same-site context. Possible values are ``Lax``, ``Strict`` and 
+- ``samesite`` Allows you to declare if your cookie should be restricted to a
+  first-party or same-site context. Possible values are ``Lax``, ``Strict`` and
   ``None``. Defaults to ``null``.
 - ``field`` The form field to check. Defaults to ``_csrfToken``. Changing this
   will also require configuring FormHelper.

--- a/en/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/en/tutorials-and-examples/blog-auth-example/auth.rst
@@ -95,6 +95,7 @@ utilities bundled with CakePHP::
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
+
                     return $this->redirect(['action' => 'add']);
                 }
                 $this->Flash->error(__('Unable to add the user.'));
@@ -359,6 +360,7 @@ Add the logout action to the ``UsersController`` class::
         // regardless of POST or GET, redirect if user is logged in
         if ($result->isValid()) {
             $this->Authentication->logout();
+
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }
     }

--- a/en/tutorials-and-examples/blog/part-three.rst
+++ b/en/tutorials-and-examples/blog/part-three.rst
@@ -351,6 +351,7 @@ it::
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));

--- a/en/tutorials-and-examples/blog/part-two.rst
+++ b/en/tutorials-and-examples/blog/part-two.rst
@@ -296,6 +296,7 @@ First, start by creating an ``add()`` action in the
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));
@@ -459,6 +460,7 @@ like::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to update your article.'));
@@ -549,6 +551,7 @@ Next, let's make a way for users to delete articles. Start with a
         $article = $this->Articles->get($id);
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('The article with id: {0} has been deleted.', h($id)));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/en/tutorials-and-examples/bookmarks/intro.rst
+++ b/en/tutorials-and-examples/bookmarks/intro.rst
@@ -289,6 +289,7 @@ add the following::
         protected function _setPassword($value)
         {
             $hasher = new DefaultPasswordHasher();
+
             return $hasher->hash($value);
         }
     }

--- a/en/tutorials-and-examples/bookmarks/part-two.rst
+++ b/en/tutorials-and-examples/bookmarks/part-two.rst
@@ -63,6 +63,7 @@ not written that code yet. So let's create the login action::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error('Your username or password is incorrect.');
@@ -102,6 +103,7 @@ well. Again, in the ``UsersController``, add the following code::
     public function logout()
     {
         $this->Flash->success('You are now logged out.');
+
         return $this->redirect($this->Auth->logout());
     }
 
@@ -234,6 +236,7 @@ like::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('The bookmark could not be saved. Please, try again.');
@@ -258,6 +261,7 @@ edit form and action. Your ``edit()`` action from
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('The bookmark could not be saved. Please, try again.');
@@ -317,6 +321,7 @@ can add a virtual/computed field to the entity. In
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 

--- a/en/tutorials-and-examples/cms/articles-controller.rst
+++ b/en/tutorials-and-examples/cms/articles-controller.rst
@@ -212,6 +212,7 @@ to be created. Start by creating an ``add()`` action in the
 
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));
@@ -356,6 +357,7 @@ now. Add the following action to your ``ArticlesController``::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to update your article.'));
@@ -488,6 +490,7 @@ Next, let's make a way for users to delete articles. Start with a
         $article = $this->Articles->findBySlug($slug)->firstOrFail();
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('The {0} article has been deleted.', $article->title));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/en/tutorials-and-examples/cms/authentication.rst
+++ b/en/tutorials-and-examples/cms/authentication.rst
@@ -195,7 +195,7 @@ If you visit your site, you'll get an "infinite redirect loop" so let's fix that
 
     If your application serves from both SSL and non-SSL protocols, then you might have problems
     with sessions being lost, in case your application is on non-SSL protocol. You need to enable
-    access by setting session.cookie_secure to false in your config config/app.php or config/app_local.php. 
+    access by setting session.cookie_secure to false in your config config/app.php or config/app_local.php.
     (See :doc:`CakePHP’s defaults on session.cookie_secure </development/sessions>`)
 
 In your ``UsersController``, add the following code::
@@ -289,6 +289,7 @@ Add the logout action to the ``UsersController`` class::
         // regardless of POST or GET, redirect if user is logged in
         if ($result && $result->isValid()) {
             $this->Authentication->logout();
+
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }
     }

--- a/en/tutorials-and-examples/cms/authorization.rst
+++ b/en/tutorials-and-examples/cms/authorization.rst
@@ -201,6 +201,7 @@ logged in user. Replace your add action with the following::
 
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been saved.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to add your article.'));
@@ -228,6 +229,7 @@ Next we'll update the ``edit`` action. Replace the edit method with the followin
             ]);
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to update your article.'));

--- a/en/tutorials-and-examples/cms/tags-and-users.rst
+++ b/en/tutorials-and-examples/cms/tags-and-users.rst
@@ -85,6 +85,7 @@ articles. First, update the ``add`` action to look like::
 
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));
@@ -125,6 +126,7 @@ edit method should now look like::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to update your article.'));
@@ -355,6 +357,7 @@ can add a virtual/computed field to the entity. In
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 

--- a/en/views/helpers/breadcrumbs.rst
+++ b/en/views/helpers/breadcrumbs.rst
@@ -186,6 +186,7 @@ when you want to transform the crumbs and overwrite the list::
     $crumbs = $this->Breadcrumbs->getCrumbs();
     $crumbs = collection($crumbs)->map(function ($crumb) {
         $crumb['options']['class'] = 'breadcrumb-item';
+
         return $crumb;
     })->toArray();
 

--- a/en/views/helpers/form.rst
+++ b/en/views/helpers/form.rst
@@ -661,10 +661,10 @@ as well as HTML attributes. This subsection will cover the options specific to
   As seen above you can set the error message for each validation
   rule you have in your models. In addition you can provide i18n
   messages for your forms.
-  
+
   To disable the HTML entity encoding for error messages only, the ``'escape'``
   sub key can be used::
-  
+
       $this->Form->control('name', [
           'error' => ['escape' => false],
       ]);
@@ -2507,6 +2507,7 @@ could do the following::
             $data += [
                 'name' => '',
             ];
+
             return $this->_templates->format('autocomplete', [
                 'name' => $data['name'],
                 'attrs' => $this->_templates->formatAttributes($data, ['name'])

--- a/es/controllers/components.rst
+++ b/es/controllers/components.rst
@@ -2,14 +2,14 @@ Componentes
 ###########
 
 Los componentes son paquetes de lógica que se comparten entre los controladores.
-CakePHP viene un con fantástico conjunto de componentes básicos que puedes usar 
+CakePHP viene un con fantástico conjunto de componentes básicos que puedes usar
 para ayudar en varias tareas comunes. También puedes crear tus propios componentes.
 Si te encuentras queriendo copiar y pegar cosas entre componentes, deberías considerar
 crear tu propio componente que contenga la funcionalidad. Crear componentes mantiene
 el código del controlador limpio y te permite rehusar código entre los diferentes
 controladores.
 
-Para más información sobre componentes incluidos en CakePHP, consulte el capítulo 
+Para más información sobre componentes incluidos en CakePHP, consulte el capítulo
 de cada componente:
 
 .. toctree::
@@ -28,9 +28,9 @@ de cada componente:
 Configurando componentes
 ========================
 
-Muchos de los componentes principales requieren configuración. Algunos ejemplos 
+Muchos de los componentes principales requieren configuración. Algunos ejemplos
 de componentes que requieren configuración son :doc:`/controllers/components/security`
-y :doc:`/controllers/components/form-protection`. La configuración para estos 
+y :doc:`/controllers/components/form-protection`. La configuración para estos
 componentes, y para los componentes en general, es usualmente hecho a través ``loadComponent()``
 en el método ``initialize()`` del controlador o a través del array ``$components``::
 
@@ -105,7 +105,7 @@ Carga de componentes sobre la marcha
 ------------------------------------
 
 Es posible que no necesites todos tus componentes disponibles en cada acción del
-controlador. En situaciones como estas, puedes cargar un componente en tiempo de 
+controlador. En situaciones como estas, puedes cargar un componente en tiempo de
 ejecución usando el método ``loadComponent()`` en tu controlador::
 
     // En una acción del controlador
@@ -115,7 +115,7 @@ ejecución usando el método ``loadComponent()`` en tu controlador::
 .. note::
 
     Ten en cuenta que los componentes cargados sobre la marcha no perderán devoluciones
-    de llamadas. Si te basas en que las devoluciones de llamada ``beforeFilter`` o 
+    de llamadas. Si te basas en que las devoluciones de llamada ``beforeFilter`` o
     ``startup`` serán llamadas, necesitarás llamarlas manualmente dependiendo de
     cuándo cargas tu componente.
 
@@ -123,7 +123,7 @@ Uso de componentes
 ==================
 
 Una vez que hayas incluido algunos componentes a tu controlador, usarlos es bastante
-simple. Cada componente que uses se exponen como una propiedad en tu controlador. 
+simple. Cada componente que uses se exponen como una propiedad en tu controlador.
 Si cargaste el :php:class:`Cake\\Controller\\Component\\FlashComponent` en tu controlador,
 puedes acceder a él de esta forma::
 
@@ -139,6 +139,7 @@ puedes acceder a él de esta forma::
         {
             if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
+
                 return $this->redirect(['action' => 'index']);
             }
         }
@@ -159,7 +160,7 @@ Supongamos que nuestra aplicación necesita realizar una operación matemática 
 en muchas partes diferentes de la aplicación. Podríamos crear un componente para
 albergar esta lógica compartida para su uso en muchos controladores diferentes.
 
-El primer paso es crear un nuevo archivo de componente y clase. Crea el archivo en 
+El primer paso es crear un nuevo archivo de componente y clase. Crea el archivo en
 **src/Controller/Component/MathComponent.php**. La estructura básica para el componente
 debería verse algo como esto::
 
@@ -184,8 +185,8 @@ Incluyendo tu componente en tus controladores
 ---------------------------------------------
 
 Una vez que nuestro componente está terminado, podemos usarlo en los controladores
-de la aplicación cargándolo durante el método ``initialize()`` del controlador. 
-Una vez cargado, el controlador recibirá un nuevo atributo con el nombre del 
+de la aplicación cargándolo durante el método ``initialize()`` del controlador.
+Una vez cargado, el controlador recibirá un nuevo atributo con el nombre del
 componente, a través del cual podemos acceder a una instancia del mismo::
 
     // En un controlador
@@ -198,7 +199,7 @@ componente, a través del cual podemos acceder a una instancia del mismo::
         $this->loadComponent('Csrf');
     }
 
-Al incluir componentes en un controlador, también puedes declarar un conjunto de 
+Al incluir componentes en un controlador, también puedes declarar un conjunto de
 parámetros que se pasarán al constructor del componente. Estos parámetros pueden
 ser manejados por el componente::
 
@@ -213,7 +214,7 @@ ser manejados por el componente::
         $this->loadComponent('Csrf');
     }
 
-Lo anterior pasaría el array que contiene precision y randomGenerator a ``MathComponent::initialize()`` 
+Lo anterior pasaría el array que contiene precision y randomGenerator a ``MathComponent::initialize()``
 en el parámetro ``$config``.
 
 Usando otros componentes en tu componente
@@ -259,13 +260,13 @@ componentes agregándolos a la propiedad `$components`::
 
 .. note::
 
-    A diferencia de un componente incluido en un controlador, no se activarán 
+    A diferencia de un componente incluido en un controlador, no se activarán
     devoluciones de llamada en el componente de un componente.
 
 Accediendo al controlador de un componente
 ------------------------------------------
 
-Desde dentro de un componente, puedes acceder al controlador actual a través del 
+Desde dentro de un componente, puedes acceder al controlador actual a través del
 registro::
 
     $controller = $this->getController();
@@ -288,7 +289,7 @@ de las solicitudes que les permiten aumentar el ciclo de solicitud.
 
 .. php:method:: beforeRender(EventInterface $event)
 
-    Es llamado después de que el controlador ejecute la lógica de la acción 
+    Es llamado después de que el controlador ejecute la lógica de la acción
     solicitada, pero antes de que el controlador renderize las vistas y el diseño.
 
 .. php:method:: shutdown(EventInterface $event)
@@ -313,6 +314,7 @@ puedes usar lo siguiente::
     public function beforeFilter(EventInterface $event)
     {
         $event->stopPropagation();
+
         return $this->getController()->redirect('/');
     }
 

--- a/es/orm/behaviors/tree.rst
+++ b/es/orm/behaviors/tree.rst
@@ -172,6 +172,7 @@ Opcionalmente, puede ejercer un control más riguroso pasando una clausura como 
 
     $this->behaviors()->Tree->config('scope', function ($query) {
         $country = $this->getConfigureContry(); // A made-up function
+
         return $query->where(['country_name' => $country]);
     });
 

--- a/es/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/es/tutorials-and-examples/blog-auth-example/auth.rst
@@ -87,6 +87,7 @@ También vamos a crear UsersController; el siguiente contenido fue generado usan
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
+
                     return $this->redirect(['action' => 'add']);
                 }
                 $this->Flash->error(__('Unable to add the user.'));
@@ -181,6 +182,7 @@ Ahora necesitamos poder registrar nuevos usuarios, guardar el nombre de usuario 
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error(__('Invalid email or password, try again'));
@@ -270,6 +272,7 @@ También, un pequeño cambio en ArticlesController es necesario para guardar el 
             //$article = $this->Articles->patchEntity($article, $newData);
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been saved.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to add your article.'));

--- a/es/tutorials-and-examples/blog/part-three.rst
+++ b/es/tutorials-and-examples/blog/part-three.rst
@@ -246,6 +246,7 @@ Esto nos permitirá elegir una categoría para un Article al momento de crearlo 
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));

--- a/es/tutorials-and-examples/blog/part-two.rst
+++ b/es/tutorials-and-examples/blog/part-two.rst
@@ -269,6 +269,7 @@ ArticlesController::
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));
@@ -424,6 +425,7 @@ ser la acción ``edit()`` del controlador ``ArticlesController``::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Tu artículo ha sido actualizado.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Tu artículo no se ha podido actualizar.'));
@@ -512,6 +514,7 @@ Vamos a permitir a los usuarios que borren artículos. Empieza con una acción
         $article = $this->Articles->get($id);
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('El artículo con id: {0} ha sido eliminado.', h($id)));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/es/tutorials-and-examples/bookmarks/intro.rst
+++ b/es/tutorials-and-examples/bookmarks/intro.rst
@@ -222,6 +222,7 @@ Añadamos un setter para la contraseña añadiendo el siguiente código en **src
         protected function _setPassword($value)
         {
             $hasher = new DefaultPasswordHasher();
+
             return $hasher->hash($value);
         }
     }

--- a/es/tutorials-and-examples/bookmarks/part-two.rst
+++ b/es/tutorials-and-examples/bookmarks/part-two.rst
@@ -71,6 +71,7 @@ así que hagámoslo ahora::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error('Tu usuario o contraseña es incorrecta.');
@@ -115,6 +116,7 @@ Otra vez en ``UsersController``, añade el siguiente código::
     public function logout()
     {
         $this->Flash->success('Ahora estás deslogueado.');
+
         return $this->redirect($this->Auth->logout());
     }
 
@@ -261,6 +263,7 @@ Con esa parte eliminada actualizaremos la acción ``add()`` de
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('El favorito se ha guardado.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('El favorito podría no haberse guardado. Por favor, inténtalo de nuevo.');
@@ -287,6 +290,7 @@ así::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('El favorito se ha guardado.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('El favorito podría no haberse guardado. Por favor, inténtalo de nuevo.');
@@ -350,6 +354,7 @@ En **src/Model/Entity/Bookmark.php** añade lo siguiente::
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 

--- a/fr/console-commands/commands.rst
+++ b/fr/console-commands/commands.rst
@@ -27,7 +27,7 @@ Hello world toute simple. Dans le répertoire **src/Command** de votre applicati
         public function execute(Arguments $args, ConsoleIo $io): int
         {
             $io->out('Hello world.');
-            
+
             return static::CODE_SUCCESS;
         }
     }
@@ -61,6 +61,7 @@ Notre méthode ``execute()`` n'est pas très intéressente, ajoutons des entrée
             $parser->addArgument('name', [
                 'help' => 'Quel est votre nom'
             ]);
+
             return $parser;
         }
 
@@ -68,7 +69,7 @@ Notre méthode ``execute()`` n'est pas très intéressente, ajoutons des entrée
         {
             $name = $args->getArgument('name');
             $io->out("Hello {$name}.");
-            
+
             return static::CODE_SUCCESS;
         }
     }
@@ -82,7 +83,7 @@ Après avoir sauvegardé ce fichier, vous devriez pouvoir exécuter la commande 
 
     # Affiche
     Hello jillian
- 
+
 Changer le Nom Par Défaut de la Commande
 ========================================
 
@@ -127,7 +128,7 @@ pour définir des arguments. Nous pouvons aussi définir des options. Par exempl
             $name = mb_strtoupper($name);
         }
         $io->out("Hello {$name}.");
-            
+
         return static::CODE_SUCCESS;
     }
 
@@ -216,7 +217,7 @@ message et un code::
             // Arrête l'exécution, affiche vers stderr, et définit le code de sortie à 99
             $io->abort('Le nom doit avoir au moins 4 caractères.', 99);
         }
-        
+
         return static::CODE_SUCCESS;
     }
 
@@ -337,7 +338,7 @@ moment, mais testons simplement si la description de notre shell description s'a
 
     use Cake\TestSuite\ConsoleIntegrationTestTrait;
     use Cake\TestSuite\TestCase;
- 
+
     class UpdateTableCommandTest extends TestCase
     {
         user ConsoleIntegrationTestTrait;

--- a/fr/console-commands/shells.rst
+++ b/fr/console-commands/shells.rst
@@ -146,12 +146,14 @@ Also, the task name must be added as a sub-command to the Shell's OptionParser::
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
+
         $parser->addSubcommand('sound', [
             // Provide help text for the command list
             'help' => 'Execute The Sound Task.',
             // Link the option parsers together.
             'parser' => $this->Sound->getOptionParser(),
         ]);
+
         return $parser;
     }
 

--- a/fr/controllers/components.rst
+++ b/fr/controllers/components.rst
@@ -144,6 +144,7 @@ vous pouvez y accéder comme ceci::
         {
             if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Publication effacée.');
+
                 return $this->redirect(['action' => 'index']);
             }
         }
@@ -324,6 +325,7 @@ Pour rediriger à partir d'une méthode de rappel de composant, vous pouvez util
     public function beforeFilter(EventInterface $event)
     {
         $event->stopPropagation();
+
         return $this->getController()->redirect('/');
     }
 

--- a/fr/controllers/components/authentication.rst
+++ b/fr/controllers/components/authentication.rst
@@ -247,6 +247,7 @@ connexion pourrait ressembler à cela::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
                 $this->Flash->error(__("Nom d'utilisateur ou mot de passe incorrect"));
@@ -476,6 +477,7 @@ colonne séparée du mot de passe standard hashé::
                 $entity->plain_password,
                 env('SERVER_NAME')
             );
+
             return true;
         }
     }
@@ -773,6 +775,7 @@ utilisateur que vous voulez pour la 'connexion'::
         $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
+
             return $this->redirect([
                 'controller' => 'Users',
                 'action' => 'home'

--- a/fr/controllers/middleware.rst
+++ b/fr/controllers/middleware.rst
@@ -88,6 +88,7 @@ pour en attacher ::
         {
             // Attache le gestionnaire d'erreur dans la file du middleware
             $middlewareQueue->add(new ErrorHandlerMiddleware());
+
             return $middlewareQueue;
         }
     }
@@ -140,7 +141,7 @@ appliquer un de leurs middlewares dans la file de middlewares de l'application::
     use Cake\Http\MiddlewareQueue;
     use ContactManager\Middleware\ContactManagerContextMiddleware;
 
- 
+
     class Plugin extends BasePlugin
     {
         public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue

--- a/fr/controllers/request-response.rst
+++ b/fr/controllers/request-response.rst
@@ -712,6 +712,7 @@ Vous pouvez accomplir cela en utilisant :php:meth:`Cake\\Http\\Response::withFil
     {
         $file = $this->Attachments->getFile($id);
         $response = $this->response->withFile($file['path']);
+
         // Renvoie la réponse pour empêcher le contrôleur d'essayer
         // de rendre une vue
         return $response;

--- a/fr/core-libraries/caching.rst
+++ b/fr/core-libraries/caching.rst
@@ -289,6 +289,7 @@ Par exemple::
 
     // Stocke les données en cache
     Cache::write('cloud', $cloud);
+
     return $cloud;
 
 Lire Plusieurs Clés d'un Coup

--- a/fr/core-libraries/events.rst
+++ b/fr/core-libraries/events.rst
@@ -76,6 +76,7 @@ garder votre model Orders propre, vous pouvez utiliser les événements::
                     'order' => $order
                 ]);
                 $this->getEventManager()->dispatch($event);
+
                 return true;
             }
             return false;
@@ -493,6 +494,7 @@ callback elle-même::
     {
         // ...
         $alteredData = $event->getData('order') + $moreData;
+
         return $alteredData;
     }
 

--- a/fr/core-libraries/hash.rst
+++ b/fr/core-libraries/hash.rst
@@ -641,6 +641,7 @@ Les Types d'Attribut Correspondants
         public function noop(array $array)
         {
             // Fait des choses au tableau et retourne les résultats
+
             return $array;
         }
 

--- a/fr/core-libraries/logging.rst
+++ b/fr/core-libraries/logging.rst
@@ -499,6 +499,7 @@ utilisant la méthode ``Log::setConfig()``::
     Log::setConfig('default', function () {
         $log = new Logger('app');
         $log->pushHandler(new StreamHandler('path/to/your/combined.log'));
+
         return $log;
     });
 
@@ -516,6 +517,7 @@ Utilisez des méthodes similaires pour configurer un logger différent pour la c
     Log::setConfig('default', function () {
         $log = new Logger('cli');
         $log->pushHandler(new StreamHandler('path/to/your/combined-cli.log'));
+
         return $log;
     });
 

--- a/fr/development/sessions.rst
+++ b/fr/development/sessions.rst
@@ -287,6 +287,7 @@ devrait ressembler à::
         public function write($id, $data)
         {
             Cache::write($id, $data, $this->cacheKey);
+
             return parent::write($id, $data);
         }
 
@@ -294,6 +295,7 @@ devrait ressembler à::
         public function destroy($id)
         {
             Cache::delete($id, $this->cacheKey);
+
             return parent::destroy($id);
         }
 

--- a/fr/development/testing.rst
+++ b/fr/development/testing.rst
@@ -155,6 +155,7 @@ barre de progression HTML. Notre helper ressemblera à cela::
         public function bar($value)
         {
             $width = round($value / 100, 2) * 100;
+
             return sprintf(
                 '<div class="progress-container">
                     <div class="progress-bar" style="width: %s%%"></div>
@@ -864,6 +865,7 @@ Supposons que nous avons déjà notre table Articles définie dans
             $query->where([
                 $this->alias() . '.published' => 1
             ]);
+
             return $query;
         }
     }
@@ -1326,7 +1328,7 @@ service web. Commençons avec un exemple simple  de controller qui renvoie du
 JSON::
 
     use Cake\View\JsonView;
-    
+
     class MarkersController extends AppController
     {
         public function viewClasses(): array
@@ -1607,7 +1609,7 @@ d'assertions afin de tester les réponses plus simplement. Quelques exemples::
     $this->assertResponseEmpty();
 
     // Vérifie le contenu de la réponse
-    $this->assertResponseEquals('Ouais !'); 
+    $this->assertResponseEquals('Ouais !');
 
     // Vérifie que le contenu de la réponse n'est pas égal à...
     $this->assertResponseNotEquals('Non !');
@@ -1721,7 +1723,7 @@ Mocker les Injections de Dépendances
 Voir :ref:`mocking-services-in-tests` pour savoir comment remplacer des services
 injectés avec le conteneur d'injection de dépendances dans vos tests
 d'intégration.
- 
+
 Mocker les Réponses du Client HTTP
 ==================================
 
@@ -1940,6 +1942,7 @@ suivantes::
                     'order' => $order
                 ]);
                 $this->getEventManager()->dispatch($event);
+
                 return true;
             }
             return false;
@@ -2015,7 +2018,7 @@ globaux::
 
 Testing Email
 =============
- 
+
 Consultez :ref:`email-testing` pour savoir comment tester les emails.
 
 Créer des Suites de Test (Test Suites)

--- a/fr/installation.rst
+++ b/fr/installation.rst
@@ -477,6 +477,7 @@ Un exemple de la directive server est le suivant:
         listen   80;
         listen   [::]:80;
         server_name www.example.com;
+
         return 301 http://example.com$request_uri;
     }
 

--- a/fr/orm/behaviors.rst
+++ b/fr/orm/behaviors.rst
@@ -195,6 +195,7 @@ de l'évènement dans votre callback::
     {
         if (...) {
             $event->stopPropagation();
+
             return;
         }
         $this->slug($entity);

--- a/fr/orm/behaviors/tree.rst
+++ b/fr/orm/behaviors/tree.rst
@@ -243,6 +243,7 @@ closure au scope::
 
     $this->behaviors()->Tree->config('scope', function ($query) {
         $country = $this->getConfigureContry(); // A made-up function
+
         return $query->where(['country_name' => $country]);
     });
 

--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -176,6 +176,7 @@ pouvez aussi le faire avec un objet Query::
         ->order(['title' => 'DESC'])
         ->map(function ($row) { // map() est une méthode de collection, elle exécute la requête
             $row->trimmedTitle = trim($row->title);
+
             return $row;
         })
         ->combine('id', 'trimmedTitle') // combine() est une autre méthode de collection
@@ -215,7 +216,7 @@ activer les :ref:`logs de requête <database-query-logging>`.
 
 Récupérer vos Données
 =====================
-CakePHP permet de construire simplement des requêtes ``SELECT``. La 
+CakePHP permet de construire simplement des requêtes ``SELECT``. La
 méthode ``select()`` vous permet de ne récupérer que les champs qui vous sont
 nécessaires::
 
@@ -730,6 +731,7 @@ formatter*)::
     $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['date_de_naissance']->diff(new \DateTime)->y;
+
             return $row;
         });
     });
@@ -752,6 +754,7 @@ comme vous pouvez vous y attendre::
         return $q->formatResults(function (\Cake\Collection\CollectionInterface $auteurs) {
             return $auteurs->map(function ($auteur) {
                 $auteur['age'] = $auteur['date_de_naissance']->diff(new \DateTime)->y;
+
                 return $auteur;
             });
         });
@@ -870,6 +873,7 @@ nous pouvons faire ceci::
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or(['auteur_id' => 2])
                 ->eq('auteur_id', 5);
+
             return $exp
                 ->add($orConditions)
                 ->eq('published', true)
@@ -898,6 +902,7 @@ chaînage des méthodes::
                 return $or->eq('auteur_id', 2)
                     ->eq('auteur_id', 5);
             });
+
             return $exp
                 ->not($orConditions)
                 ->lte('nombre_de_vues', 10);
@@ -909,6 +914,7 @@ Vous pouvez faire une négation des sous-expressions en utilisant ``not()``::
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -933,6 +939,7 @@ SQL::
             $year = $q->func()->year([
                 'created' => 'identifier'
             ]);
+
             return $exp
                 ->gte($year, 2014)
                 ->eq('published', true);

--- a/fr/orm/retrieving-data-and-resultsets.rst
+++ b/fr/orm/retrieving-data-and-resultsets.rst
@@ -400,6 +400,7 @@ les articles d'un certain auteur, nous ferions ceci::
         public function findEcritPar(Query $query, array $options)
         {
             $user = $options['user'];
+
             return $query->where(['author_id' => $user->id]);
         }
 
@@ -582,7 +583,7 @@ définir le second argument à ``true``::
 
     $query = $articles->find();
     $query->contain(['Authors', 'Comments'], true);
- 
+
 .. note::
 
     Les noms d'association dans les appels à ``contain()`` doivent respecter la
@@ -801,7 +802,7 @@ l'association et charger d'autres champs de cette même association, vous pouvez
 parfaitement combiner ``innerJoinWith()`` et ``contain()``.
 L'exemple ci-dessous filtre les Articles qui ont des Tags spécifiques et charge
 ces Tags::
- 
+
     $filter = ['Tags.name' => 'CakePHP'];
     $query = $articles->find()
         ->distinct($articles->getPrimaryKey())
@@ -820,9 +821,9 @@ ces Tags::
         $query
             ->select(['country_name' => 'Countries.name'])
             ->innerJoinWith('Countries');
- 
+
     Sinon, vous verrez les données dans ``_matchingData``, comme cela a été
-    décrit ci-dessous à propos de ``matching()``. C'est un angle mort de 
+    décrit ci-dessous à propos de ``matching()``. C'est un angle mort de
     ``matching()``, qui ne sait pas que vous avez sélectionné des champs.
 
 .. warning::
@@ -949,7 +950,7 @@ exemple des tables se trouvant dans deux bases de données différentes.
 Habituellement, vous définisser la stratégie d'une association quand vous la
 définissez, dans la méthode ``Table::initialize()``, mais vous pouvez changer
 manuellement la stratégie de façon permanente::
- 
+
     $articles->Comments->setStrategy('select');
 
 Récupération Avec la Stratégie de Sous-Requête
@@ -1340,6 +1341,7 @@ comme décrit dans la section :ref:`custom-find-methods`::
         // Comme dans l'exemple précédent sur la fréquence des mots
         $mapper = ...;
         $reducer = ...;
+
         return $query->mapReduce($mapper, $reducer);
     }
 

--- a/fr/orm/table-objects.rst
+++ b/fr/orm/table-objects.rst
@@ -146,14 +146,14 @@ façon d'utiliser le sous-système d'events::
 
     // Dans un controller
     $articles->save($article, ['variablePerso1' => 'votreValeur1']);
-    
+
     // Dans ArticlesTable.php
     public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $variablePerso = $options['variablePerso1']; // 'votreValeur1'
-        $options['variablePerso2'] = 'votreValeur2';    
-    }  
-    
+        $options['variablePerso2'] = 'votreValeur2';
+    }
+
     public function afterSaveCommit(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $variablePerso = $options['variablePerso1']; // 'votreValeur1'
@@ -375,6 +375,7 @@ de l'event dans votre callback::
         if (...) {
             $event->stopPropagation();
             $event->setResult(false);
+
             return;
         }
         ...

--- a/fr/orm/validation.rst
+++ b/fr/orm/validation.rst
@@ -123,6 +123,7 @@ notre table ``articles``::
             $validator
                 ->notEmptyString('title', __('Vous devez indiquer un titre'))
                 ->notEmptyString('body', __('Un contenu est nécessaire'));
+
             return $validator;
         }
     }
@@ -186,6 +187,7 @@ diviser leur process de construction en petites étapes réutilisables::
         $validator = $this->validationDefault($validator);
 
         $validator->add('password', 'length', ['rule' => ['lengthBetween', 8, 100]]);
+
         return $validator;
     }
 
@@ -220,6 +222,7 @@ l'utiliser comme une règle de validation::
                     'message' => __('Vous devez fournir un rôle valide'),
                     'provider' => 'table',
                 ]);
+
             return $validator;
         }
 
@@ -583,6 +586,7 @@ le faire en créant votre propre règle invokable::
             'errorField' => 'name',
             'message' => 'Doit être unique pour chaque parent.'
         ]);
+
         return $rules;
     }
 
@@ -607,6 +611,7 @@ utile de packager ces règles dans des classes réutilisables::
         public function __invoke(EntityInterface $entity, array $options)
         {
             // Faire le boulot ici
+
             return false;
         }
     }
@@ -727,6 +732,7 @@ pour les transitions de données générées à l'intérieur de l'application::
             'errorField' => 'livraison',
             'message' => 'Pas de frais de port gratuits pour une commande de moins de 100!'
         ]);
+
         return $rules;
     }
 

--- a/fr/security/csrf.rst
+++ b/fr/security/csrf.rst
@@ -50,6 +50,7 @@ de votre Application, vous protégez toutes les actions de l'application::
         $csrf = new SessionCsrfProtectionMiddleware($options);
 
         $middlewareQueue->add($csrf);
+
         return $middlewareQueue;
     }
 

--- a/fr/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/fr/tutorials-and-examples/blog-auth-example/auth.rst
@@ -100,6 +100,7 @@ classe obtenue grâce à l'utilitaire de génération de code fourni par CakePHP
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__("L'utilisateur a été sauvegardé."));
+
                     return $this->redirect(['action' => 'add']);
                 }
                 $this->Flash->error(__("Impossible d'ajouter l\'utilisateur."));
@@ -378,6 +379,7 @@ Ajoutez l'action logout à votre classe ``UsersController``::
         // Qu'on soit en POST ou en GET, rediriger l'utilisateur s'il est déjà connecté
         if ($result->isValid()) {
             $this->Authentication->logout();
+
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }
     }

--- a/fr/tutorials-and-examples/blog/part-three.rst
+++ b/fr/tutorials-and-examples/blog/part-three.rst
@@ -364,6 +364,7 @@ lorsqu'on va le créer ou le modifier::
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Votre article a été enregistré.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__("Impossible d\'ajouter votre article."));

--- a/fr/tutorials-and-examples/blog/part-two.rst
+++ b/fr/tutorials-and-examples/blog/part-two.rst
@@ -314,6 +314,7 @@ Premièrement, commençons par créer une action ``add()`` dans le
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Votre article a été sauvegardé.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Impossible d\'ajouter votre article.'));
@@ -487,6 +488,7 @@ devrait ressembler::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Votre article a été mis à jour.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Impossible de mettre à jour votre article.'));
@@ -580,6 +582,7 @@ Articles (``ArticlesController``)::
         $article = $this->Articles->get($id);
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__("L'article avec l'id: {0} a été supprimé.", h($id)));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/fr/tutorials-and-examples/bookmarks/intro.rst
+++ b/fr/tutorials-and-examples/bookmarks/intro.rst
@@ -272,6 +272,7 @@ dans une de vos entities. Ajoutons un setter pour le mot de passe. Dans
         protected function _setPassword($value)
         {
             $hasher = new DefaultPasswordHasher();
+
             return $hasher->hash($value);
         }
     }

--- a/fr/tutorials-and-examples/bookmarks/part-two.rst
+++ b/fr/tutorials-and-examples/bookmarks/part-two.rst
@@ -69,6 +69,7 @@ nous n'avons pas encore écrit ce code. Créons donc l'action login::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error('Votre username ou mot de passe est incorrect.');
@@ -110,6 +111,7 @@ probablement fournir un moyen de se déconnecter. Encore une fois, dans
     public function logout()
     {
         $this->Flash->success('Vous êtes maintenant déconnecté.');
+
         return $this->redirect($this->Auth->logout());
     }
 
@@ -247,6 +249,7 @@ ressembler à ceci::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('Le bookmark a été sauvegardé.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('Le bookmark ne peut être sauvegardé. Merci de réessayer.');
@@ -272,6 +275,7 @@ ceci::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('Le bookmark a été sauvegardé.');
+
                 return $this->redirect(['action' => 'index']);
             } else {
                 $this->Flash->error('Le bookmark ne peut être sauvegardé. Merci de réessayer.');
@@ -335,6 +339,7 @@ pouvons ajouter un champ virtuel/calculé à l'entity. Dans
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 

--- a/fr/tutorials-and-examples/cms/articles-controller.rst
+++ b/fr/tutorials-and-examples/cms/articles-controller.rst
@@ -217,6 +217,7 @@ la création d'articles. Commencez par créer une action ``add()`` dans le
 
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Votre article a été sauvegardé.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Impossible d\'ajouter votre article.'));
@@ -367,6 +368,7 @@ dans votre ``ArticlesController``::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Votre article a été mis à jour.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Impossible de mettre à jour l\'article.'));
@@ -501,6 +503,7 @@ Commencez par créer une action ``delete()`` dans ``ArticlesController``::
         $article = $this->Articles->findBySlug($slug)->firstOrFail();
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('L\'article {0} a été supprimé.', $article->title));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/fr/tutorials-and-examples/cms/authentication.rst
+++ b/fr/tutorials-and-examples/cms/authentication.rst
@@ -288,6 +288,7 @@ Ajoutez l'action de logout à la classe ``UsersController``::
         // indépendamment de POST ou GET, rediriger si l'utilisateur est connecté
         if ($result && $result->isValid()) {
             $this->Authentication->logout();
+
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }
     }

--- a/fr/tutorials-and-examples/cms/authorization.rst
+++ b/fr/tutorials-and-examples/cms/authorization.rst
@@ -198,6 +198,7 @@ l'utilisateur actuellement authentifié. Remplacez l'action ``add`` par le code 
 
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Votre article a été enregistré avec succès.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Impossible d\'ajouter votre article.'));
@@ -225,6 +226,7 @@ Ensuite nous allons modifier l'action ``edit``. Remplacez la méthode d'édition
             ]);
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Votre article a été sauvegardé.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Impossible de mettre à jour votre article.'));

--- a/fr/tutorials-and-examples/cms/tags-and-users.rst
+++ b/fr/tutorials-and-examples/cms/tags-and-users.rst
@@ -85,6 +85,7 @@ l'action ``add`` pour qu'elle ressemble à ceci::
 
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Votre article a été sauvegardé.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Impossible de sauvegarder l\'article.'));
@@ -127,6 +128,7 @@ maintenant ressembler à ceci::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Votre article a été modifié.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Impossible de mettre à jour votre article.'));
@@ -360,6 +362,7 @@ entity, nous ajoutons un champ virtuel/pré-calculé pour l'entity. Dans
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 

--- a/fr/views/helpers/breadcrumbs.rst
+++ b/fr/views/helpers/breadcrumbs.rst
@@ -194,6 +194,7 @@ complètement réinitialiser la liste::
     $crumbs = $this->Breadcrumbs->getCrumbs();
     $crumbs = collection($crumbs)->map(function ($crumb) {
         $crumb['options']['class'] = 'breadcrumb-item';
+
         return $crumb;
     })->toArray();
 

--- a/fr/views/helpers/form.rst
+++ b/fr/views/helpers/form.rst
@@ -2543,6 +2543,7 @@ vouliez construire un widget Autocomplete, vous pourriez le faire comme ceci::
             $data += [
                 'name' => '',
             ];
+
             return $this->_templates->format('autocomplete', [
                 'name' => $data['name'],
                 'attrs' => $this->_templates->formatAttributes($data, ['name'])

--- a/ja/console-commands/commands.rst
+++ b/ja/console-commands/commands.rst
@@ -62,6 +62,7 @@ CakePHP には、開発のスピードアップと日常的なタスクの自動
             $parser->addArgument('name', [
                 'help' => 'What is your name'
             ]);
+
             return $parser;
         }
 

--- a/ja/console-commands/shells.rst
+++ b/ja/console-commands/shells.rst
@@ -140,12 +140,14 @@ public メソッドのうち頭に _ が付かないものは、コマンドラ�
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
+
         $parser->addSubcommand('sound', [
             // コマンド一覧のヘルプテキストを提供
             'help' => 'Execute The Sound Task.',
             // オプションパーサーを互いにリンク
             'parser' => $this->Sound->getOptionParser(),
         ]);
+
         return $parser;
     }
 

--- a/ja/controllers/components.rst
+++ b/ja/controllers/components.rst
@@ -140,6 +140,7 @@ CakePHP の中に含まれるコンポーネントの詳細については、各
         {
             if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
+
                 return $this->redirect(['action' => 'index']);
             }
         }
@@ -313,6 +314,7 @@ CakePHP の中に含まれるコンポーネントの詳細については、各
     public function beforeFilter(EventInterface $event)
     {
         $event->stopPropagation();
+
         return $this->getController()->redirect('/');
     }
 

--- a/ja/controllers/components/authentication.rst
+++ b/ja/controllers/components/authentication.rst
@@ -221,6 +221,7 @@ SSL 暗号化しないアプリケーションにもふさわしいものです�
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
                 $this->Flash->error(__('Username or password is incorrect'));
@@ -427,6 +428,7 @@ CakePHP のライブラリーを使用してランダムにこれらの API ト�
                 $entity->plain_password,
                 env('SERVER_NAME')
             );
+
             return true;
         }
     }
@@ -697,6 +699,7 @@ CakePHP は、1つのアルゴリズムから別のユーザーのパスワー�
         $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
+
             return $this->redirect([
                 'controller' => 'Users',
                 'action' => 'home'

--- a/ja/controllers/middleware.rst
+++ b/ja/controllers/middleware.rst
@@ -74,6 +74,7 @@ CakePHP はウェブアプリケーションの一般的なタスクを処理す
         {
             // ミドルウェアのキューにエラーハンドラーを結びつけます。
             $middlewareQueue->add(new ErrorHandlerMiddleware());
+
             return $middlewareQueue;
         }
     }
@@ -110,7 +111,7 @@ CakePHP はウェブアプリケーションの一般的なタスクを処理す
 
 
 If your middleware is only applicable to a subset of routes or individual
-controllers you can use :ref:`Route scoped middleware <route-scoped-middleware>`, 
+controllers you can use :ref:`Route scoped middleware <route-scoped-middleware>`,
 or :ref:`Controller middleware <controller-middleware>`.
 
 プラグインからのミドルウェア追加

--- a/ja/core-libraries/events.rst
+++ b/ja/core-libraries/events.rst
@@ -437,6 +437,7 @@ DOM イベントのように、追加のリスナーへ通知されることを�
     {
         // ...
         $alteredData = $event->getData('order') + $moreData;
+
         return $alteredData;
     }
 

--- a/ja/core-libraries/logging.rst
+++ b/ja/core-libraries/logging.rst
@@ -431,6 +431,7 @@ Composer を使って Monolog をインストールしたら、
     Log::setConfig('default', function () {
         $log = new Logger('app');
         $log->pushHandler(new StreamHandler('path/to/your/combined.log'));
+
         return $log;
     });
 
@@ -448,6 +449,7 @@ Composer を使って Monolog をインストールしたら、
     Log::setConfig('default', function () {
         $log = new Logger('cli');
         $log->pushHandler(new StreamHandler('path/to/your/combined-cli.log'));
+
         return $log;
     });
 

--- a/ja/development/errors.rst
+++ b/ja/development/errors.rst
@@ -199,6 +199,7 @@ ExceptionRenderer の変更
         public function missingWidget($error)
         {
             $response = $this->controller->response;
+
             return $response->withStringBody('おっとウィジェットが見つからない！');
         }
     }

--- a/ja/development/sessions.rst
+++ b/ja/development/sessions.rst
@@ -265,6 +265,7 @@ IO をもたらします。
         public function write($id, $data): bool
         {
             Cache::write($id, $data, $this->cacheKey);
+
             return parent::write($id, $data);
         }
 
@@ -272,6 +273,7 @@ IO をもたらします。
         public function destroy($id): bool
         {
             Cache::delete($id, $this->cacheKey);
+
             return parent::destroy($id);
         }
 

--- a/ja/development/testing.rst
+++ b/ja/development/testing.rst
@@ -131,6 +131,7 @@ CakePHP が全般的にそうであるように、テストケースにもいく
         public function bar($value)
         {
             $width = round($value / 100, 2) * 100;
+
             return sprintf(
                 '<div class="progress-container">
                     <div class="progress-bar" style="width: %s%%"></div>
@@ -743,6 +744,7 @@ CakePHPコアまたはプラグインからフィクスチャをロードする�
             $query->where([
                 $this->alias() . '.published' => 1
             ]);
+
             return $query;
         }
     }

--- a/ja/orm/behaviors.rst
+++ b/ja/orm/behaviors.rst
@@ -175,6 +175,7 @@ sluggable behavior を作成してみます。
         if (...) {
             $event->stopPropagation();
             $event->setResult(false);
+
             return;
         }
         $this->slug($entity);

--- a/ja/orm/query-builder.rst
+++ b/ja/orm/query-builder.rst
@@ -168,6 +168,7 @@ Query オブジェクトのメソッドに慣れたら、 :doc:`Collection </cor
         ->map(function ($row) {
         // map() は Collection のメソッドで、クエリーを実行します
             $row->trimmedTitle = trim($row->title);
+
             return $row;
         })
         ->combine('id', 'trimmedTitle') // combine() も Collection のメソッドです
@@ -550,6 +551,7 @@ ORM とオブジェクトの結果セットは強力である一方で、エン�
     $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
+
             return $row;
         });
     });
@@ -679,6 +681,7 @@ Conditions
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->add($orConditions)
                 ->eq('published', true)
@@ -706,6 +709,7 @@ Conditions
                 return $or->eq('author_id', 2)
                     ->eq('author_id', 5);
             });
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -717,6 +721,7 @@ Conditions
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -740,6 +745,7 @@ SQL 関数を使った式を構築することも可能です。 ::
             $year = $q->func()->year([
                 'created' => 'identifier'
             ]);
+
             return $exp
                 ->gte($year, 2014)
                 ->eq('published', true);

--- a/ja/orm/retrieving-data-and-resultsets.rst
+++ b/ja/orm/retrieving-data-and-resultsets.rst
@@ -357,6 +357,7 @@ fineder メソッドは、あなたが作成したい finder の名前が ``Foo`
         public function findOwnedBy(Query $query, array $options)
         {
             $user = $options['user'];
+
             return $query->where(['author_id' => $user->id]);
         }
     }
@@ -1190,6 +1191,7 @@ reducer が呼ばれるごとに、reducer はユーザーごとのフォロワ�
         // 前のセクションで説明した共通の単語の件と同じもの
         $mapper = ...;
         $reducer = ...;
+
         return $query->mapReduce($mapper, $reducer);
     }
 

--- a/ja/orm/validation.rst
+++ b/ja/orm/validation.rst
@@ -113,6 +113,7 @@ CakePHP ではデータの検証には二つの段階があります:
             $validator
                 ->notEmptyString('title', __('タイトルを設定してください'))
                 ->notEmptyString('body', __('本文は必須です'));
+
             return $validator;
         }
     }
@@ -207,6 +208,7 @@ CakePHP ではデータの検証には二つの段階があります:
                     'message' => __('有効な権限を指定する必要があります'),
                     'provider' => 'table',
                 ]);
+
             return $validator;
         }
 

--- a/ja/security/csrf.rst
+++ b/ja/security/csrf.rst
@@ -52,6 +52,7 @@ CSRFプロテクションは、アプリケーション全体、または特定�
         $csrf = new SessionCsrfProtectionMiddleware($options);
 
         $middlewareQueue->add($csrf);
+
         return $middlewareQueue;
     }
 

--- a/ja/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/ja/tutorials-and-examples/blog-auth-example/auth.rst
@@ -81,6 +81,7 @@ CakePHP にバンドルされているコード生成ユーティリティを利
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('The user has been saved.'));
+
                     return $this->redirect(['action' => 'add']);
                 }
                 $this->Flash->error(__('Unable to add the user.'));
@@ -342,6 +343,7 @@ composerを使ってAuthenticationプラグインをインストールします�
         // POSTやGETに関係なく、ユーザーがログインしていればリダイレクトします
         if ($result->isValid()) {
             $this->Authentication->logout();
+
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }
     }

--- a/ja/tutorials-and-examples/blog/part-three.rst
+++ b/ja/tutorials-and-examples/blog/part-three.rst
@@ -347,6 +347,7 @@ Articles コントローラーを編集する
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));

--- a/ja/tutorials-and-examples/blog/part-two.rst
+++ b/ja/tutorials-and-examples/blog/part-two.rst
@@ -280,6 +280,7 @@ Articles テーブルに対して ``get()`` を用いるとき、存在するレ
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('記事が保存されました。'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('記事の保存が出来ませんでした。'));
@@ -436,6 +437,7 @@ CakePHP のバリデーションエンジンは強力で、
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('記事が更新されました。'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('記事の更新が出来ませんでした。'));
@@ -523,6 +525,7 @@ CakePHP は挿入あるいは更新のどちらを生成するかを決定しま
         $article = $this->Articles->get($id);
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('ID：{0}の記事が削除されました。', h($id)));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/ja/tutorials-and-examples/bookmarks/intro.rst
+++ b/ja/tutorials-and-examples/bookmarks/intro.rst
@@ -237,6 +237,7 @@ Scaffold コードの生成
         protected function _setPassword($value)
         {
             $hasher = new DefaultPasswordHasher();
+
             return $hasher->hash($value);
         }
     }

--- a/ja/tutorials-and-examples/bookmarks/part-two.rst
+++ b/ja/tutorials-and-examples/bookmarks/part-two.rst
@@ -61,6 +61,7 @@ AppController に追加しましょう。 ::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error('あなたのユーザー名またはパスワードが不正です。');
@@ -104,6 +105,7 @@ AppController に追加しましょう。 ::
     public function logout()
     {
         $this->Flash->success('ログアウトしました。');
+
         return $this->redirect($this->Auth->logout());
     }
 
@@ -231,6 +233,7 @@ AppController に追加しましょう。 ::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('ブックマークを保存しました。');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('ブックマークは保存できませんでした。もう一度お試しください。');
@@ -254,6 +257,7 @@ AppController に追加しましょう。 ::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('ブックマークを保存しました。');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('ブックマークは保存できませんでした。もう一度お試しください。');
@@ -312,6 +316,7 @@ AppController に追加しましょう。 ::
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 

--- a/ja/tutorials-and-examples/cms/articles-controller.rst
+++ b/ja/tutorials-and-examples/cms/articles-controller.rst
@@ -210,6 +210,7 @@ view テンプレートの作成
 
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));
@@ -342,6 +343,7 @@ edit アクションの追加
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Your article has been updated.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Unable to update your article.'));
@@ -471,6 +473,7 @@ delete アクションの追加
         $article = $this->Articles->findBySlug($slug)->firstOrFail();
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('The {0} article has been deleted.', $article->title));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/ja/tutorials-and-examples/cms/authentication.rst
+++ b/ja/tutorials-and-examples/cms/authentication.rst
@@ -266,6 +266,7 @@ logout アクションを ``UsersController`` に追加します。::
         // POST, GET を問わず、ユーザーがログインしている場合はリダイレクトします
         if ($result && $result->isValid()) {
             $this->Authentication->logout();
+
             return $this->redirect(['controller' => 'Users', 'action' => 'login']);
         }
     }

--- a/ja/tutorials-and-examples/cms/tags-and-users.rst
+++ b/ja/tutorials-and-examples/cms/tags-and-users.rst
@@ -79,6 +79,7 @@ ArticlesTable の ``initialize`` メソッドに以下を追加することで�
 
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));

--- a/ja/views/helpers/breadcrumbs.rst
+++ b/ja/views/helpers/breadcrumbs.rst
@@ -176,6 +176,7 @@ BreadcrumbsHelper は内部で ``StringTemplateTrait`` を使用しています�
     $crumbs = $this->Breadcrumbs->getCrumbs();
     $crumbs = collection($crumbs)->map(function ($crumb) {
         $crumb['options']['class'] = 'breadcrumb-item';
+
         return $crumb;
     })->toArray();
 

--- a/ja/views/helpers/form.rst
+++ b/ja/views/helpers/form.rst
@@ -2544,6 +2544,7 @@ autocomplete ウィジェットを作成したい場合、以下を実行でき�
             $data += [
                 'name' => '',
             ];
+
             return $this->_templates->format('autocomplete', [
                 'name' => $data['name'],
                 'attrs' => $this->_templates->formatAttributes($data, ['name'])

--- a/pt/console-and-shells.rst
+++ b/pt/console-and-shells.rst
@@ -494,7 +494,9 @@ facilmente definir múltiplas opções/argumentos de uma vez::
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
+
         // Configure parser
+
         return $parser;
     }
 
@@ -508,6 +510,7 @@ série de chamadas de métodos::
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
+
         $parser->addArgument('type', [
             'help' => 'Either a full path or type of class.'
         ])->addArgument('className', [
@@ -516,6 +519,7 @@ série de chamadas de métodos::
             'short' => 'm',
             'help' => __('The specific method you want help on.')
         ])->description(__('Lookup doc block comments for classes in CakePHP.'));
+
         return $parser;
     }
 

--- a/pt/controllers/components.rst
+++ b/pt/controllers/components.rst
@@ -1,14 +1,14 @@
 Componentes
 ###########
 
-Componentes são pacotes de lógica compartilhados entre controladores. O CakePHP 
-vem com um conjunto fantástico de componentes principais que você pode usar para 
+Componentes são pacotes de lógica compartilhados entre controladores. O CakePHP
+vem com um conjunto fantástico de componentes principais que você pode usar para
 ajudar em várias tarefas comuns. Você também pode criar seus próprios componentes.
-Se você deseja copiar e colar coisas entre controladores, considere criar seu próprio 
-componente para conter a funcionalidade. A criação de componentes mantém o código do 
+Se você deseja copiar e colar coisas entre controladores, considere criar seu próprio
+componente para conter a funcionalidade. A criação de componentes mantém o código do
 controlador limpo e permite reutilizar o código entre diferentes controladores.
 
-Para mais informações sobre os componentes incluídos no CakePHP, consulte o 
+Para mais informações sobre os componentes incluídos no CakePHP, consulte o
 capítulo para cada componente:
 
 .. toctree::
@@ -25,9 +25,9 @@ capítulo para cada componente:
 Configurando Componentes
 ========================
 
-Muitos dos componentes principais requerem configuração. Alguns exemplos de componentes 
-que requerem configuração são :doc:`/controllers/components/security` e 
-:doc:`/controllers/components/request-handling`. A configuração desses componentes e dos 
+Muitos dos componentes principais requerem configuração. Alguns exemplos de componentes
+que requerem configuração são :doc:`/controllers/components/security` e
+:doc:`/controllers/components/request-handling`. A configuração desses componentes e dos
 componentes em geral é geralmente feita via ``loadComponent()`` no método ``initialize()``
 do seu Controlador ou através do array ``$components``::
 
@@ -45,7 +45,7 @@ do seu Controlador ou através do array ``$components``::
     }
 
 Você pode configurar componentes em tempo de execução usando o método ``setConfig()``.
-Muitas vezes, isso é feito no método ``beforeFilter()`` do seu controlador. O exemplo acima 
+Muitas vezes, isso é feito no método ``beforeFilter()`` do seu controlador. O exemplo acima
 também pode ser expresso como::
 
     public function beforeFilter(EventInterface $event)
@@ -53,7 +53,7 @@ também pode ser expresso como::
         $this->RequestHandler->setConfig('viewClassMap', ['rss' => 'MyRssView']);
     }
 
-Como os auxiliares, os componentes implementam os métodos ``getConfig()`` e 
+Como os auxiliares, os componentes implementam os métodos ``getConfig()`` e
 ``setConfig()`` para ler e gravar dados de configuração::
 
     // Leia os dados de configuração.
@@ -62,14 +62,14 @@ Como os auxiliares, os componentes implementam os métodos ``getConfig()`` e
     // Definir configuração
     $this->Csrf->setConfig('cookieName', 'token');
 
-Assim como os auxiliares, os componentes mesclam automaticamente sua propriedade 
-``$ _defaultConfig`` com a configuração do construtor para criar a propriedade 
+Assim como os auxiliares, os componentes mesclam automaticamente sua propriedade
+``$ _defaultConfig`` com a configuração do construtor para criar a propriedade
 ``$_config`` que pode ser acessada com ``getConfig()`` e ``setConfig()``.
 
 Alias em Componentes
 --------------------
 
-Uma configuração comum a ser usada é a opção ``className``, que permite o alias 
+Uma configuração comum a ser usada é a opção ``className``, que permite o alias
 de componentes. Esse recurso é útil quando você deseja substituir ``$this->Auth``
 ou outra referência de componente comum por uma implementação personalizada::
 
@@ -96,14 +96,14 @@ O exemplo acima seria *alias* ``MyAuthComponent`` para ``$this->Auth`` em seus c
 
 .. note::
 
-    O alias de um componente substitui essa instância em qualquer lugar em que esse componente 
+    O alias de um componente substitui essa instância em qualquer lugar em que esse componente
     seja usado, inclusive dentro de outros componentes.
 
 Carregando Componentes em Tempo Real
 ------------------------------------
 
-Você pode não precisar de todos os seus componentes disponíveis em todas as ações do controlador. 
-Em situações como essa, você pode carregar um componente em tempo de execução usando o método 
+Você pode não precisar de todos os seus componentes disponíveis em todas as ações do controlador.
+Em situações como essa, você pode carregar um componente em tempo de execução usando o método
 ``loadComponent()`` no seu controlador::
 
     // Em um método do controlador
@@ -112,16 +112,16 @@ Em situações como essa, você pode carregar um componente em tempo de execuç�
 
 .. note::
 
-    Lembre-se de que os componentes carregados em tempo real não terão retornos de chamada perdidos. 
-    Se você confiar nos retornos de chamada ``beforeFilter`` ou ``startup`` que estão sendo chamados, 
+    Lembre-se de que os componentes carregados em tempo real não terão retornos de chamada perdidos.
+    Se você confiar nos retornos de chamada ``beforeFilter`` ou ``startup`` que estão sendo chamados,
     pode ser necessário chamá-los manualmente, dependendo de quando você carregar o componente.
 
 Usando Componentes
 ==================
 
-Depois de incluir alguns componentes no seu controlador, usá-los é bastante simples. 
-Cada componente usado é exposto como uma propriedade no seu controlador. Se você 
-carregou a classe :php:class:`Cake\\Controller\\Component\\FlashComponent` no seu 
+Depois de incluir alguns componentes no seu controlador, usá-los é bastante simples.
+Cada componente usado é exposto como uma propriedade no seu controlador. Se você
+carregou a classe :php:class:`Cake\\Controller\\Component\\FlashComponent` no seu
 controlador, é possível acessá-lo da seguinte maneira::
 
     class PostsController extends AppController
@@ -136,14 +136,15 @@ controlador, é possível acessá-lo da seguinte maneira::
         {
             if ($this->Post->delete($this->request->getData('Post.id')) {
                 $this->Flash->success('Post deleted.');
+
                 return $this->redirect(['action' => 'index']);
             }
         }
 
 .. note::
 
-    Como os Modelos e os Componentes são adicionados aos Controladores 
-    como propriedades, eles compartilham o mesmo 'namespace'. Certifique-se 
+    Como os Modelos e os Componentes são adicionados aos Controladores
+    como propriedades, eles compartilham o mesmo 'namespace'. Certifique-se
     de não dar o mesmo nome a um componente de um modelo.
 
 .. _creating-a-component:
@@ -151,12 +152,12 @@ controlador, é possível acessá-lo da seguinte maneira::
 Criando um Componente
 =====================
 
-Suponha que nosso aplicativo precise executar uma operação matemática complexa 
-em muitas partes diferentes do aplicativo. Poderíamos criar um componente para 
+Suponha que nosso aplicativo precise executar uma operação matemática complexa
+em muitas partes diferentes do aplicativo. Poderíamos criar um componente para
 hospedar essa lógica compartilhada para uso em muitos controladores diferentes.
 
-O primeiro passo é criar um novo arquivo e classe de componente. Crie o arquivo em 
-**src/Controller/Component/MathComponent.php**. A estrutura básica do componente 
+O primeiro passo é criar um novo arquivo e classe de componente. Crie o arquivo em
+**src/Controller/Component/MathComponent.php**. A estrutura básica do componente
 será semelhante a isso::
 
     namespace App\Controller\Component;
@@ -173,19 +174,19 @@ será semelhante a isso::
 
 .. note::
 
-    Todos os componentes devem estender :php:class:`Cake\\Controller\\Component`. 
+    Todos os componentes devem estender :php:class:`Cake\\Controller\\Component`.
     Não fazer isso acionará uma exceção.
 
 Incluindo seu Componente em seus Controladores
 ----------------------------------------------
 
-Depois que nosso componente é concluído, podemos usá-lo nos controladores 
-do aplicativo carregando-o durante o método ``initialize()`` do controlador. 
-Uma vez carregado, o controlador receberá um novo atributo com o nome do componente, 
+Depois que nosso componente é concluído, podemos usá-lo nos controladores
+do aplicativo carregando-o durante o método ``initialize()`` do controlador.
+Uma vez carregado, o controlador receberá um novo atributo com o nome do componente,
 através do qual podemos acessar uma instância dele::
 
     // Em um controlador
-    // Disponibilize o novo componente em $this->Math, 
+    // Disponibilize o novo componente em $this->Math,
     // bem como o padrão $this->Csrf
     public function initialize(): void
     {
@@ -194,8 +195,8 @@ através do qual podemos acessar uma instância dele::
         $this->loadComponent('Csrf');
     }
 
-Ao incluir componentes em um controlador, você também pode declarar 
-um conjunto de parâmetros que serão passados para o construtor do componente. 
+Ao incluir componentes em um controlador, você também pode declarar
+um conjunto de parâmetros que serão passados para o construtor do componente.
 Esses parâmetros podem ser manipulados pelo componente::
 
     // Em seu controlador
@@ -209,14 +210,14 @@ Esses parâmetros podem ser manipulados pelo componente::
         $this->loadComponent('Csrf');
     }
 
-O exemplo acima passaria um array contendo precision e randomGenerator 
+O exemplo acima passaria um array contendo precision e randomGenerator
 para ``MathComponent::initialize()`` no parâmetro ``$config``.
 
 Usando Outros Componentes em seu Componente
 -------------------------------------------
 
-Às vezes, um de seus componentes pode precisar usar outro componente. 
-Nesse caso, você pode incluir outros componentes no seu componente 
+Às vezes, um de seus componentes pode precisar usar outro componente.
+Nesse caso, você pode incluir outros componentes no seu componente
 exatamente da mesma maneira que os inclui nos controladores - usando o
 atributo ``$components``::
 
@@ -258,18 +259,18 @@ atributo ``$components``::
 
 .. note::
 
-    Ao contrário de um componente incluído em um controlador, 
+    Ao contrário de um componente incluído em um controlador,
     nenhum retorno de chamada será acionado no componente de um componente.
 
 Acessando o Controlador de um Componente
 ----------------------------------------
 
-De dentro de um componente, você pode acessar o controlador atual através do 
+De dentro de um componente, você pode acessar o controlador atual através do
 registro::
 
     $controller = $this->_registry->getController();
 
-Você pode acessar o controlador em qualquer método de retorno de chamada do objeto de 
+Você pode acessar o controlador em qualquer método de retorno de chamada do objeto de
 evento::
 
     $controller = $event->getSubject();
@@ -277,22 +278,22 @@ evento::
 Callback de Componentes
 =======================
 
-Os componentes também oferecem alguns retornos de chamada do ciclo de vida da solicitação que 
+Os componentes também oferecem alguns retornos de chamada do ciclo de vida da solicitação que
 permitem aumentar o ciclo da solicitação.
 
 .. php:method:: beforeFilter(EventInterface $event)
 
-    É chamado antes do método beforeFilter do controlador, 
+    É chamado antes do método beforeFilter do controlador,
     mas *após* o método initialize() do controlador.
 
 .. php:method:: startup(EventInterface $event)
 
-    É chamado após o método beforeFilter do controlador, 
+    É chamado após o método beforeFilter do controlador,
     mas antes que o controlador execute o manipulador de ações atual.
 
 .. php:method:: beforeRender(EventInterface $event)
 
-    É chamado após o controlador executar a lógica da ação solicitada, 
+    É chamado após o controlador executar a lógica da ação solicitada,
     mas antes de o controlador renderizar visualizações e layout.
 
 .. php:method:: shutdown(EventInterface $event)
@@ -301,10 +302,10 @@ permitem aumentar o ciclo da solicitação.
 
 .. php:method:: beforeRedirect(EventInterface $event, $url, Response $response)
 
-    É chamado quando o método de redirecionamento do controlador é chamado, 
-    mas antes de qualquer ação adicional. Se esse método retornar ``false``, 
-    o controlador não continuará redirecionando a solicitação. Os parâmetros 
-    $url e $response permitem inspecionar e modificar o local ou qualquer outro 
+    É chamado quando o método de redirecionamento do controlador é chamado,
+    mas antes de qualquer ação adicional. Se esse método retornar ``false``,
+    o controlador não continuará redirecionando a solicitação. Os parâmetros
+    $url e $response permitem inspecionar e modificar o local ou qualquer outro
     cabeçalho na resposta.
 
 .. meta::

--- a/pt/controllers/components/authentication.rst
+++ b/pt/controllers/components/authentication.rst
@@ -216,6 +216,7 @@ trabalhar com um formulário de login pode se parecer com::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             } else {
                 $this->Flash->error(__('Username or password is incorrect'));
@@ -432,6 +433,7 @@ a partir do hash da senha normal::
                 $entity->plain_password,
                 env('SERVER_NAME')
             );
+
             return true;
         }
     }
@@ -717,6 +719,7 @@ logo após ele se registrar no seu aplicativo. Você pode fazer isso chamando
         $user = $this->Users->newEntity($this->request->getData());
         if ($this->Users->save($user)) {
             $this->Auth->setUser($user->toArray());
+
             return $this->redirect([
                 'controller' => 'Users',
                 'action' => 'home'

--- a/pt/controllers/middleware.rst
+++ b/pt/controllers/middleware.rst
@@ -1,28 +1,28 @@
 Middleware
 ##########
 
-Os objetos de middleware permitem que você 'embrulhe' seu aplicativo em camadas 
-reutilizáveis e composíveis de manipulação de solicitações ou lógica de criação 
-de respostas. Visualmente, seu aplicativo termina no centro e o middleware é envolvido 
-em volta do aplicativo como uma cebola. Aqui, podemos ver um aplicativo agrupado com os 
+Os objetos de middleware permitem que você 'embrulhe' seu aplicativo em camadas
+reutilizáveis e composíveis de manipulação de solicitações ou lógica de criação
+de respostas. Visualmente, seu aplicativo termina no centro e o middleware é envolvido
+em volta do aplicativo como uma cebola. Aqui, podemos ver um aplicativo agrupado com os
 middlewares Routes, Assets, Exception Handling e CORS.
 
 .. image:: /_static/img/middleware-setup.png
 
-Quando um pedido é tratado pelo seu aplicativo, ele entra no middleware mais externo. 
-Cada middleware pode delegar a solicitação/resposta para a próxima camada ou retornar 
-uma resposta. O retorno de uma resposta impede que as camadas inferiores vejam a solicitação. 
-Um exemplo disso é o plugin AssetMiddleware manipulando uma solicitação de uma imagem de 
+Quando um pedido é tratado pelo seu aplicativo, ele entra no middleware mais externo.
+Cada middleware pode delegar a solicitação/resposta para a próxima camada ou retornar
+uma resposta. O retorno de uma resposta impede que as camadas inferiores vejam a solicitação.
+Um exemplo disso é o plugin AssetMiddleware manipulando uma solicitação de uma imagem de
 durante o desenvolvimento.
 
 .. image:: /_static/img/middleware-request.png
 
-Se nenhum middleware executar uma ação para manipular a solicitação, um controlador 
+Se nenhum middleware executar uma ação para manipular a solicitação, um controlador
 será localizado e terá sua ação invocada ou uma exceção será gerada gerando uma página de erro.
 
-O middleware faz parte da nova pilha HTTP no CakePHP que aproveita as interfaces de solicitação e 
-resposta PSR-7. O CakePHP também suporta o padrão PSR-15 para manipuladores de solicitações de 
-servidor, para que você possa usar qualquer middleware compatível com PSR-15 disponível em 
+O middleware faz parte da nova pilha HTTP no CakePHP que aproveita as interfaces de solicitação e
+resposta PSR-7. O CakePHP também suporta o padrão PSR-15 para manipuladores de solicitações de
+servidor, para que você possa usar qualquer middleware compatível com PSR-15 disponível em
 `The Packagist <https://packagist.org>`_.
 
 Middleware em CakePHP
@@ -30,24 +30,24 @@ Middleware em CakePHP
 
 O CakePHP fornece vários middlewares para lidar com tarefas comuns em aplicativos da web:
 
-* ``Cake\Error\Middleware\ErrorHandlerMiddleware`` intercepta exceções do middleware 
-  empacotado e renderiza uma página de erro usando o manipulador de 
+* ``Cake\Error\Middleware\ErrorHandlerMiddleware`` intercepta exceções do middleware
+  empacotado e renderiza uma página de erro usando o manipulador de
   exceção :doc:`/development/errors`.
-* ``Cake\Routing\AssetMiddleware`` verifica se a solicitação está se referindo a um tema ou 
-  arquivo estático do plug-in, como CSS, JavaScript ou arquivo de imagem armazenado na pasta 
+* ``Cake\Routing\AssetMiddleware`` verifica se a solicitação está se referindo a um tema ou
+  arquivo estático do plug-in, como CSS, JavaScript ou arquivo de imagem armazenado na pasta
   raiz da web de um plug-in ou na pasta correspondente a um Tema.
-* ``Cake\Routing\Middleware\RoutingMiddleware`` usa o ``Router`` para analisar a URL 
+* ``Cake\Routing\Middleware\RoutingMiddleware`` usa o ``Router`` para analisar a URL
   recebida e atribuir parâmetros de roteamento à solicitação.
-* ``Cake\I18n\Middleware\LocaleSelectorMiddleware`` habilita a troca automática de idioma no 
+* ``Cake\I18n\Middleware\LocaleSelectorMiddleware`` habilita a troca automática de idioma no
   cabeçalho ``Accept-Language`` enviado pelo navegador.
-* ``Cake\Http\Middleware\SecurityHeadersMiddleware`` facilita adicionar cabeçalhos relacionados 
+* ``Cake\Http\Middleware\SecurityHeadersMiddleware`` facilita adicionar cabeçalhos relacionados
   à segurança como ``X-Frame-Options`` às respostas.
-* ``Cake\Http\Middleware\EncryptedCookieMiddleware`` oferece a capacidade de manipular cookies 
+* ``Cake\Http\Middleware\EncryptedCookieMiddleware`` oferece a capacidade de manipular cookies
   criptografados, caso você precise manipular cookies com dados ofuscados.
 * ``Cake\Http\Middleware\CsrfProtectionMiddleware`` adiciona proteção CSRF ao seu aplicativo.
-* ``Cake\Http\Middleware\BodyParserMiddleware`` permite decodificar JSON, XML e outros corpos 
+* ``Cake\Http\Middleware\BodyParserMiddleware`` permite decodificar JSON, XML e outros corpos
   de solicitação codificados com base no cabeçalho ``Content-Type``.
-* ``Cake\Http\Middleware\CspMiddleware`` simplifica a adição de cabeçalhos de política de 
+* ``Cake\Http\Middleware\CspMiddleware`` simplifica a adição de cabeçalhos de política de
   segurança de conteúdo ao seu aplicativo.
 
 .. _using-middleware:
@@ -58,8 +58,8 @@ Usando Middleware
 O middleware pode ser aplicado ao seu aplicativo globalmente ou individualmente a
 escopos de roteamento.
 
-Para aplicar o middleware a todas as solicitações, use o método ``middleware`` da sua classe 
-``App\Application``. O método de gancho ``middleware`` do seu aplicativo será chamado no 
+Para aplicar o middleware a todas as solicitações, use o método ``middleware`` da sua classe
+``App\Application``. O método de gancho ``middleware`` do seu aplicativo será chamado no
 início do processo de solicitação; você pode usar o objeto ``MiddlewareQueue`` para anexar o
 middleware::
 
@@ -75,6 +75,7 @@ middleware::
         {
             // Vincule o manipulador de erros à fila do middleware.
             $middlwareQueue->add(new ErrorHandlerMiddleware());
+
             return $middlwareQueue;
         }
     }
@@ -89,7 +90,7 @@ Além de adicionar ao final do ``MiddlewareQueue``, você pode executar várias 
         // O middleware precedido será o primeiro da fila.
         $middlwareQueue->prepend($layer);
 
-        // Insira em um slot específico. Se o slot estiver 
+        // Insira em um slot específico. Se o slot estiver
         // fora dos limites, ele será adicionado ao final.
         $middlwareQueue->insertAt(2, $layer);
 
@@ -109,14 +110,14 @@ Além de adicionar ao final do ``MiddlewareQueue``, você pode executar várias 
             $layer
         );
 
-Além de aplicar o middleware a todo o aplicativo, você pode aplicar o 
-middleware a conjuntos específicos de rotas usando 
+Além de aplicar o middleware a todo o aplicativo, você pode aplicar o
+middleware a conjuntos específicos de rotas usando
 :ref:`Scope Middleware <connecting-scoped-middleware>`.
 
 Adicionando Middleware a partir de Plugins
 ------------------------------------------
 
-Os plug-ins podem usar seu método de gancho ``middleware`` para aplicar qualquer 
+Os plug-ins podem usar seu método de gancho ``middleware`` para aplicar qualquer
 middleware que eles tenham à fila de middleware do aplicativo::
 
     // Em plugins/ContactManager/src/Plugin.php
@@ -139,19 +140,19 @@ middleware que eles tenham à fila de middleware do aplicativo::
 Criando um Middleware
 =====================
 
-O middleware pode ser implementado como funções anônimas (Closures) ou classes que 
-estendem ``Psr\Http\Server\MiddlewareInterface``. Embora os Closures sejam 
-adequados para tarefas menores, eles tornam os testes mais difíceis e podem criar 
-uma classe ``Application`` complicada. As classes de middleware no CakePHP têm 
+O middleware pode ser implementado como funções anônimas (Closures) ou classes que
+estendem ``Psr\Http\Server\MiddlewareInterface``. Embora os Closures sejam
+adequados para tarefas menores, eles tornam os testes mais difíceis e podem criar
+uma classe ``Application`` complicada. As classes de middleware no CakePHP têm
 algumas convenções:
 
-* Os arquivos de classe Middleware devem ser colocados em ** src/Middleware**. Por exemplo: 
+* Os arquivos de classe Middleware devem ser colocados em ** src/Middleware**. Por exemplo:
   **src/Middleware/CorsMiddleware.php**
-* As classes de middleware devem ter o sufixo ``Middleware``. Por exemplo: 
+* As classes de middleware devem ter o sufixo ``Middleware``. Por exemplo:
   ``LinkMiddleware``.
 * O Middleware deve implementar ``Psr\Http\Server\MiddlewareInterface``.
 
-O middleware pode retornar uma resposta chamando ``$handler->handle()`` 
+O middleware pode retornar uma resposta chamando ``$handler->handle()``
 ou criando sua própria resposta. Podemos ver as duas opções em nosso middleware simples::
 
     // Em src/Middleware/TrackingCookieMiddleware.php
@@ -169,9 +170,9 @@ ou criando sua própria resposta. Podemos ver as duas opções em nosso middlewa
         public function process(
             ServerRequestInterface $request,
             RequestHandlerInterface $handler
-        ): ResponseInterface 
+        ): ResponseInterface
         {
-            // Chamar $handler->handle() delega o controle para 
+            // Chamar $handler->handle() delega o controle para
             // o *próximo* middleware na fila do seu aplicativo.
             $response = $handler->handle($request);
 
@@ -188,7 +189,7 @@ ou criando sua própria resposta. Podemos ver as duas opções em nosso middlewa
         }
     }
 
-Agora que criamos um middleware muito simples, vamos anexá-lo ao nosso 
+Agora que criamos um middleware muito simples, vamos anexá-lo ao nosso
 aplicativo::
 
     // Em src/Application.php
@@ -216,10 +217,10 @@ aplicativo::
 Roteamento de Middleware
 ========================
 
-O middleware de roteamento é responsável por aplicar as rotas no seu aplicativo e 
-resolver o: plug-in, o controlador e a ação que uma solicitação está pedindo. 
-Ele pode armazenar em cache a coleção de rotas usada no seu aplicativo para aumentar o 
-tempo de inicialização. Para habilitar o cache de rotas em, forneça o  
+O middleware de roteamento é responsável por aplicar as rotas no seu aplicativo e
+resolver o: plug-in, o controlador e a ação que uma solicitação está pedindo.
+Ele pode armazenar em cache a coleção de rotas usada no seu aplicativo para aumentar o
+tempo de inicialização. Para habilitar o cache de rotas em, forneça o
 :ref:`cache configuration <cache-configuration>` desejado como um parâmetro::
 
     // Em Application.php
@@ -229,7 +230,7 @@ tempo de inicialização. Para habilitar o cache de rotas em, forneça o
         $middlwareQueue->add(new RoutingMiddleware($this, 'routing'));
     }
 
-O exemplo acima usaria o mecanismo de cache ``routing`` para armazenar a coleção 
+O exemplo acima usaria o mecanismo de cache ``routing`` para armazenar a coleção
 de rotas gerada.
 
 .. _security-header-middleware:
@@ -237,8 +238,8 @@ de rotas gerada.
 Middleware de Cabeçalho de Segurança
 ====================================
 
-A camada ``Security Headers Middleware`` facilita a aplicação de cabeçalhos 
-relacionados à segurança em seu aplicativo. Depois de configurado, o middleware 
+A camada ``Security Headers Middleware`` facilita a aplicação de cabeçalhos
+relacionados à segurança em seu aplicativo. Depois de configurado, o middleware
 pode aplicar os seguintes cabeçalhos às respostas:
 
 * ``X-Content-Type-Options``
@@ -247,7 +248,7 @@ pode aplicar os seguintes cabeçalhos às respostas:
 * ``X-Permitted-Cross-Domain-Policies``
 * ``Referrer-Policy``
 
-Esse middleware é configurado usando uma interface simples antes de ser aplicado à 
+Esse middleware é configurado usando uma interface simples antes de ser aplicado à
 pilha de middleware do seu aplicativo::
 
     use Cake\Http\Middleware\SecurityHeadersMiddleware;
@@ -266,14 +267,14 @@ pilha de middleware do seu aplicativo::
 Middleware do Cabeçalho da Política de Segurança de Conteúdo
 ============================================================
 
-O ``CspMiddleware`` facilita a adição de cabeçalhos referente a política de segurança de 
+O ``CspMiddleware`` facilita a adição de cabeçalhos referente a política de segurança de
 conteúdo em seu aplicativo. Antes de usá-lo, você deve instalar o ``paragonie/csp-builder``:
 
 .. code-block::bash
 
     composer require paragonie/csp-builder
 
-Você pode configurar o middleware usando uma matriz ou passando um 
+Você pode configurar o middleware usando uma matriz ou passando um
 objeto ``CSPBuilder`` integrado::
 
     use Cake\Http\Middleware\CspMiddleware;
@@ -296,10 +297,10 @@ objeto ``CSPBuilder`` integrado::
 Middleware de Cookie Criptografado
 ==================================
 
-Se o seu aplicativo possui cookies que contêm dados que você deseja ofuscar e 
-proteger contra adulterações do usuário, você pode usar o middleware de cookies 
-criptografado do CakePHP para criptografar e descriptografar de forma transparente 
-os dados de cookies via middleware. Os dados dos cookies são criptografados via 
+Se o seu aplicativo possui cookies que contêm dados que você deseja ofuscar e
+proteger contra adulterações do usuário, você pode usar o middleware de cookies
+criptografado do CakePHP para criptografar e descriptografar de forma transparente
+os dados de cookies via middleware. Os dados dos cookies são criptografados via
 OpenSSL usando AES::
 
     use Cake\Http\Middleware\EncryptedCookieMiddleware;
@@ -313,10 +314,10 @@ OpenSSL usando AES::
     $middlwareQueue->add($cookies);
 
 .. note::
-   É recomendável que a chave de criptografia usada para os dados do 
+   É recomendável que a chave de criptografia usada para os dados do
    cookie seja usada *exclusivamente* para os dados do cookie.
 
-Os algoritmos de criptografia e o estilo de preenchimento usados pelo middleware 
+Os algoritmos de criptografia e o estilo de preenchimento usados pelo middleware
 do cookie são compatíveis com o ``CookieComponent`` de versões anteriores do CakePHP.
 
 .. _csrf-middleware:
@@ -328,11 +329,11 @@ A proteção CSRF pode ser aplicada a todo o aplicativo ou a escopos de roteamen
 
 .. note::
 
-    Você não pode usar as duas abordagens a seguir juntas; deve escolher apenas uma. 
-    Se você usar as duas abordagens juntas, ocorrerá um erro de incompatibilidade de 
+    Você não pode usar as duas abordagens a seguir juntas; deve escolher apenas uma.
+    Se você usar as duas abordagens juntas, ocorrerá um erro de incompatibilidade de
     token CSRF em cada solicitação `PUT` e` POST`
 
-Ao aplicar o ``CsrfProtectionMiddleware`` à pilha de middleware do Aplicativo, 
+Ao aplicar o ``CsrfProtectionMiddleware`` à pilha de middleware do Aplicativo,
 você protege todas as ações no aplicativo::
 
     // Em src/Application.php
@@ -345,10 +346,11 @@ você protege todas as ações no aplicativo::
         $csrf = new CsrfProtectionMiddleware($options);
 
         $middlwareQueue->add($csrf);
+
         return $middlwareQueue;
     }
 
-Ao aplicar o ``CsrfProtectionMiddleware`` aos escopos de roteamento, você pode 
+Ao aplicar o ``CsrfProtectionMiddleware`` aos escopos de roteamento, você pode
 incluir ou excluir grupos de rotas específicos::
 
     // Em src/Application.php
@@ -386,27 +388,27 @@ Quando ativado, você pode acessar o token CSRF atual no objeto de solicitação
 
 .. note::
 
-    Você deve aplicar o middleware de proteção CSRF apenas para URLs que manipulam solicitações 
-    com estado usando cookies/sessão. Solicitações sem estado, por ex. ao desenvolver uma API, 
+    Você deve aplicar o middleware de proteção CSRF apenas para URLs que manipulam solicitações
+    com estado usando cookies/sessão. Solicitações sem estado, por ex. ao desenvolver uma API,
     não são afetados pelo CSRF; portanto, o middleware não precisa ser aplicado a essas URLs.
 
 Integração com FormHelper
 -------------------------
 
-O ``CsrfProtectionMiddleware`` se integra perfeitamente ao ``FormHelper``. Cada vez 
+O ``CsrfProtectionMiddleware`` se integra perfeitamente ao ``FormHelper``. Cada vez
 que você cria um formulário com ``FormHelper``, ele insere um campo oculto que contém o token CSRF.
 
 .. note::
 
-    Ao usar a proteção CSRF, você sempre deve iniciar seus formulários com o ``FormHelper``. 
+    Ao usar a proteção CSRF, você sempre deve iniciar seus formulários com o ``FormHelper``.
     Caso contrário, será necessário criar manualmente entradas ocultas em cada um dos seus formulários.
 
 Solicitações de Proteção CSRF e AJAX
 ------------------------------------
 
-Além de solicitar parâmetros de dados, os tokens CSRF podem ser enviados por meio 
-de um cabeçalho especial ``X-CSRF-Token``. O uso de um cabeçalho geralmente facilita 
-a integração de um token CSRF com aplicativos pesados de JavaScript ou endpoints de API 
+Além de solicitar parâmetros de dados, os tokens CSRF podem ser enviados por meio
+de um cabeçalho especial ``X-CSRF-Token``. O uso de um cabeçalho geralmente facilita
+a integração de um token CSRF com aplicativos pesados de JavaScript ou endpoints de API
 baseados em XML/JSON.
 
 O token CSRF pode ser obtido através do cookie ``csrfToken``.
@@ -417,11 +419,11 @@ O token CSRF pode ser obtido através do cookie ``csrfToken``.
 Body Parser Middleware
 ======================
 
-Se seu aplicativo aceitar JSON, XML ou outros corpos de solicitação codificados, 
-o ``BodyParserMiddleware`` permitirá que você decodifique essas solicitações em 
-uma matriz que esteja disponível em ``$request->getParsedData()`` e 
-``$request->getData()``. Por padrão, apenas os corpos ``json`` serão analisados, 
-mas a análise XML pode ser ativada com uma opção. Você também pode definir seus 
+Se seu aplicativo aceitar JSON, XML ou outros corpos de solicitação codificados,
+o ``BodyParserMiddleware`` permitirá que você decodifique essas solicitações em
+uma matriz que esteja disponível em ``$request->getParsedData()`` e
+``$request->getData()``. Por padrão, apenas os corpos ``json`` serão analisados,
+mas a análise XML pode ser ativada com uma opção. Você também pode definir seus
 próprios analisadores::
 
     use Cake\Http\Middleware\BodyParserMiddleware;
@@ -435,7 +437,7 @@ próprios analisadores::
     // Desativar a análise JSON
     $bodies = new BodyParserMiddleware(['json' => false]);
 
-    // Adicione seu próprio analisador que corresponda aos 
+    // Adicione seu próprio analisador que corresponda aos
     // valores do cabeçalho do tipo de conteúdo à chamada que pode analisá-los.
     $bodies = new BodyParserMiddleware();
     $bodies->addParser(['text/csv'], function ($body, $request) {

--- a/pt/core-libraries/events.rst
+++ b/pt/core-libraries/events.rst
@@ -65,6 +65,7 @@ o Model Orders limpo você poderia usar eventos::
                     'order' => $order
                 ]);
                 $this->eventManager()->dispatch($event);
+
                 return true;
             }
             return false;
@@ -453,6 +454,7 @@ diretamente ou retornando o valor no próprio callback::
     {
         // ...
         $alteredData = $event->getData('order') + $moreData;
+
         return $alteredData;
     }
     // Outro callback

--- a/pt/development/configuration.rst
+++ b/pt/development/configuration.rst
@@ -431,6 +431,7 @@ aplicação::
         public function read($key)
         {
             $xml = Xml::build($this->_path . $key . '.xml');
+
             return Xml::toArray($xml);
         }
 

--- a/pt/development/sessions.rst
+++ b/pt/development/sessions.rst
@@ -258,6 +258,7 @@ A classe deve se parecer com::
         public function write($id, $data)
         {
             Cache::write($id, $data, $this->cacheKey);
+
             return parent::write($id, $data);
         }
 
@@ -265,6 +266,7 @@ A classe deve se parecer com::
         public function destroy($id)
         {
             Cache::delete($id, $this->cacheKey);
+
             return parent::destroy($id);
         }
 

--- a/pt/development/testing.rst
+++ b/pt/development/testing.rst
@@ -137,6 +137,7 @@ que vamos testar estará formatando a barra de progresso HTML. Nosso ajudante se
         public function bar($value)
         {
             $width = round($value / 100, 2) * 100;
+
             return sprintf(
                 '<div class="progress-container">
                     <div class="progress-bar" style="width: %s%%"></div>
@@ -684,6 +685,7 @@ Digamos que já temos nossa classe de tabela de artigos definida em
             $query->where([
                 $this->alias() . '.published' => 1
             ]);
+
             return $query;
         }
     }
@@ -1707,6 +1709,7 @@ Expandindo no exemplo Orders, digamos que temos as seguintes tabelas::
                     'order' => $order
                 ]);
                 $this->eventManager()->dispatch($event);
+
                 return true;
             }
             return false;

--- a/pt/orm/behaviors.rst
+++ b/pt/orm/behaviors.rst
@@ -192,6 +192,7 @@ evento em seu callback::
     {
         if (...) {
             $event->stopPropagation();
+
             return;
         }
         $this->slug($entity);

--- a/pt/orm/behaviors/tree.rst
+++ b/pt/orm/behaviors/tree.rst
@@ -187,6 +187,7 @@ Opcionalmente, você pode ter um controle mais refinado do escopo passando um cl
 
     $this->behaviors()->Tree->config('scope', function ($query) {
         $country = $this->getConfigureContry(); // uma função inventada
+
         return $query->where(['country_name' => $country]);
     });
 

--- a/pt/orm/query-builder.rst
+++ b/pt/orm/query-builder.rst
@@ -176,6 +176,7 @@ você também pode fazer em um objeto Query::
         ->order(['title' => 'DESC'])
         ->map(function ($row) { // map() é um método de coleção, ele executa a consulta
             $row->trimmedTitle = trim($row->title);
+
             return $row;
         })
         ->combine('id', 'trimmedTitle') // combine() é outro método de coleção
@@ -573,6 +574,7 @@ um formatador de resultados::
     $query->formatResults(function (\Cake\Collection\CollectionInterface $results) {
         return $results->map(function ($row) {
             $row['age'] = $row['birth_date']->diff(new \DateTime)->y;
+
             return $row;
         });
     });
@@ -594,6 +596,7 @@ funcionaria conforme o esperado::
         return $q->formatResults(function (\Cake\Collection\CollectionInterface $authors) {
             return $authors->map(function ($author) {
                 $author['age'] = $author['birth_date']->diff(new \DateTime)->y;
+
                 return $author;
             });
         });
@@ -705,6 +708,7 @@ No entanto, se quisermos usar as condições ``AND`` e ``OR``, poderíamos fazer
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or_(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->add($orConditions)
                 ->eq('published', true)
@@ -731,6 +735,7 @@ Muitas vezes, é mais fácil ler do que encadear métodos::
                 return $or->eq('author_id', 2)
                     ->eq('author_id', 5);
             });
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -742,6 +747,7 @@ Você pode negar sub-expressões usando ``not()``::
         ->where(function (QueryExpression $exp) {
             $orConditions = $exp->or_(['author_id' => 2])
                 ->eq('author_id', 5);
+
             return $exp
                 ->not($orConditions)
                 ->lte('view_count', 10);
@@ -764,6 +770,7 @@ Também é possível construir expressões usando as funções SQL::
             $year = $q->func()->year([
                 'created' => 'identifier'
             ]);
+
             return $exp
                 ->gte($year, 2014)
                 ->eq('published', true);

--- a/pt/orm/retrieving-data-and-resultsets.rst
+++ b/pt/orm/retrieving-data-and-resultsets.rst
@@ -347,6 +347,7 @@ Neste exemplo mostramos como encontrarmos um artigo quando este estiver publicad
         public function findOwnedBy(Query $query, array $options)
         {
             $user = $options['user'];
+
             return $query->where(['author_id' => $user->id]);
         }
 
@@ -1188,6 +1189,7 @@ This is particularly useful for building custom finder methods as described in t
         // Same as in the common words example in the previous section
         $mapper = ...;
         $reducer = ...;
+
         return $query->mapReduce($mapper, $reducer);
     }
 

--- a/pt/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/pt/tutorials-and-examples/blog-auth-example/auth.rst
@@ -92,6 +92,7 @@ geração de código ``bake`` fornecido com CakePHP::
                 $user = $this->Users->patchEntity($user, $this->request->getData());
                 if ($this->Users->save($user)) {
                     $this->Flash->success(__('O usuário foi salvo.'));
+
                     return $this->redirect(['action' => 'add']);
                 }
                 $this->Flash->error(__('Não é possível adicionar o usuário.'));
@@ -202,6 +203,7 @@ execute as ações de ``login`` e ``logout``::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error(__('Usuário ou senha ínvalido, tente novamente'));
@@ -315,6 +317,7 @@ criado::
             //$article = $this->Articles->patchEntity($article, $newData);
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Seu artigo foi salvo.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Não foi possível adicionar seu artigo.'));

--- a/pt/tutorials-and-examples/blog/part-three.rst
+++ b/pt/tutorials-and-examples/blog/part-three.rst
@@ -356,6 +356,7 @@ ele:
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Your article has been saved.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Unable to add your article.'));

--- a/pt/tutorials-and-examples/blog/part-two.rst
+++ b/pt/tutorials-and-examples/blog/part-two.rst
@@ -280,6 +280,7 @@ Primeiro, comece criando a action ``add()`` no ``ArticlesController``::
                 $article = $this->Articles->patchEntity($article, $this->request->getData());
                 if ($this->Articles->save($article)) {
                     $this->Flash->success(__('Seu artigo foi salvo.'));
+
                     return $this->redirect(['action' => 'index']);
                 }
                 $this->Flash->error(__('Não é possível adicionar o seu artigo.'));
@@ -439,6 +440,7 @@ a action ``edit()`` que deverá ser inserida no ``ArticlesController``::
             $this->Articles->patchEntity($article, $this->request->getData());
             if ($this->Articles->save($article)) {
                 $this->Flash->success(__('Seu artigo foi atualizado.'));
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error(__('Seu artigo não pôde ser atualizado.'));
@@ -527,6 +529,7 @@ A seguir, vamos criar uma forma de deletar artigos. Comece com uma action
         $article = $this->Articles->get($id);
         if ($this->Articles->delete($article)) {
             $this->Flash->success(__('O artigo com id: {0} foi deletado.', h($id)));
+
             return $this->redirect(['action' => 'index']);
         }
     }

--- a/pt/tutorials-and-examples/bookmarks/intro.rst
+++ b/pt/tutorials-and-examples/bookmarks/intro.rst
@@ -233,6 +233,7 @@ para a senha. Em **src/Model/Entity/User.php** adicione o seguinte::
         protected function _setPassword($value)
         {
             $hasher = new DefaultPasswordHasher();
+
             return $hasher->hash($value);
         }
     }

--- a/pt/tutorials-and-examples/bookmarks/part-two.rst
+++ b/pt/tutorials-and-examples/bookmarks/part-two.rst
@@ -66,6 +66,7 @@ Então, vamos criar a ação de login::
             $user = $this->Auth->identify();
             if ($user) {
                 $this->Auth->setUser($user);
+
                 return $this->redirect($this->Auth->redirectUrl());
             }
             $this->Flash->error('Your username or password is incorrect.');
@@ -103,6 +104,7 @@ fornecer uma maneira de encerrar a sessão também. Mais uma vez, no
     public function logout()
     {
         $this->Flash->success('You are now logged out.');
+
         return $this->redirect($this->Auth->logout());
     }
 
@@ -236,6 +238,7 @@ Com isso removido, nós também vamos atualizar o método add::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('The bookmark could not be saved. Please, try again.');
@@ -245,7 +248,7 @@ Com isso removido, nós também vamos atualizar o método add::
     }
 
 Ao definir a propriedade da entidade com os dados da sessão, nós removemos
-qualquer possibilidade do user modificar algo que não pertenca a ele. 
+qualquer possibilidade do user modificar algo que não pertenca a ele.
 Nós vamos fazer o mesmo para o formulário edit e action edit. Sua
 ação edit deve ficar assim::
 
@@ -259,6 +262,7 @@ ação edit deve ficar assim::
             $bookmark->user_id = $this->Auth->user('id');
             if ($this->Bookmarks->save($bookmark)) {
                 $this->Flash->success('The bookmark has been saved.');
+
                 return $this->redirect(['action' => 'index']);
             }
             $this->Flash->error('The bookmark could not be saved. Please, try again.');
@@ -317,6 +321,7 @@ entidade. Em **src/Model/Entity/Bookmark.php** adicione o seguinte::
         $str = $tags->reduce(function ($string, $tag) {
             return $string . $tag->title . ', ';
         }, '');
+
         return trim($str, ', ');
     }
 


### PR DESCRIPTION
This brings the examples in line with the CakePHP coding conventions / code style standard, respectively:

https://book.cakephp.org/4/en/contributing/cakephp-coding-conventions.html#method-definition

https://github.com/cakephp/cakephp-codesniffer/blob/b12f9307475a74f8ee7625c7741fe2f54598cb0b/docs/README.md#L14 https://github.com/cakephp/cakephp-codesniffer/blob/b12f9307475a74f8ee7625c7741fe2f54598cb0b/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php