### PR TITLE
[4.next] Comment out ellipsis for better copy-paste-ability

### DIFF
--- a/en/contributing/cakephp-coding-conventions.rst
+++ b/en/contributing/cakephp-coding-conventions.rst
@@ -265,7 +265,7 @@ Try to avoid unnecessary nesting by bailing early::
     {
         ...
         if (!$success) {
-            throw new RuntimeException(...);
+            throw new RuntimeException(/* ... */);
         }
 
         ...

--- a/en/core-libraries/httpclient.rst
+++ b/en/core-libraries/httpclient.rst
@@ -45,9 +45,9 @@ Doing POST and PUT requests is equally simple::
     ]);
 
     // Other methods as well.
-    $http->delete(...);
-    $http->head(...);
-    $http->patch(...);
+    $http->delete(/* ... */);
+    $http->head(/* ... */);
+    $http->patch(/* ... */);
 
 If you have created a PSR-7 request object you can send it using
 ``sendRequest()``::
@@ -508,11 +508,11 @@ is making::
 
 There are methods to mock the most commonly used HTTP methods::
 
-    $this->mockClientGet(...);
-    $this->mockClientPatch(...);
-    $this->mockClientPost(...);
-    $this->mockClientPut(...);
-    $this->mockClientDelete(...);
+    $this->mockClientGet(/* ... */);
+    $this->mockClientPatch(/* ... */);
+    $this->mockClientPost(/* ... */);
+    $this->mockClientPut(/* ... */);
+    $this->mockClientDelete(/* ... */);
 
 .. php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
 

--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -464,7 +464,7 @@ complex expressions::
 To build complex order clauses, use a Closure to build order expressions::
 
     $query->orderAsc(function (QueryExpression $exp, Query $query) {
-        return $exp->addCase(...);
+        return $exp->addCase(/* ... */);
     });
 
 

--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -648,7 +648,7 @@ Use the ``queryBuilder`` option to customize the query when using an array::
         'Authors' => [
             'foreignKey' => false,
             'queryBuilder' => function (Query $q) {
-                return $q->where(...); // Full conditions for filtering
+                return $q->where(/* ... */); // Full conditions for filtering
             }
         ]
     ]);

--- a/en/orm/validation.rst
+++ b/en/orm/validation.rst
@@ -578,7 +578,7 @@ those rules into re-usable classes::
     // Add the custom rule
     use App\Model\Rule\CustomRule;
 
-    $rules->add(new CustomRule(...), 'ruleName');
+    $rules->add(new CustomRule(/* ... */), 'ruleName');
 
 By creating custom rule classes you can keep your code DRY and tests your domain
 rules in isolation.

--- a/fr/core-libraries/httpclient.rst
+++ b/fr/core-libraries/httpclient.rst
@@ -46,9 +46,9 @@ Faire des requêtes POST et PUT est tout aussi simple::
     ]);
 
     // Autres méthodes.
-    $http->delete(...);
-    $http->head(...);
-    $http->patch(...);
+    $http->delete(/* ... */);
+    $http->head(/* ... */);
+    $http->patch(/* ... */);
 
 Si vous avez créé un objet de requêtes PSR-7, vous pouvez l'envoyer avec
 ``sendRequest()``::
@@ -521,11 +521,11 @@ requêtes faites par votre application::
 
 Il existe des méthodes pour mocker les méthodes HTTP les plus courantes::
 
-    $this->mockClientGet(...);
-    $this->mockClientPatch(...);
-    $this->mockClientPost(...);
-    $this->mockClientPut(...);
-    $this->mockClientDelete(...);
+    $this->mockClientGet(/* ... */);
+    $this->mockClientPatch(/* ... */);
+    $this->mockClientPost(/* ... */);
+    $this->mockClientPut(/* ... */);
+    $this->mockClientDelete(/* ... */);
 
 .. php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
 

--- a/fr/orm/query-builder.rst
+++ b/fr/orm/query-builder.rst
@@ -481,7 +481,7 @@ des expressions complexes::
 Pour construire des clauses de tri complexes, utilisez une Closure::
 
     $query->orderAsc(function (QueryExpression $exp, Query $query) {
-        return $exp->addCase(...);
+        return $exp->addCase(/* ... */);
      });
 
 Limiter les Résultats

--- a/fr/orm/retrieving-data-and-resultsets.rst
+++ b/fr/orm/retrieving-data-and-resultsets.rst
@@ -667,7 +667,7 @@ passez un tableau::
         'Authors' => [
             'foreignKey' => false,
             'queryBuilder' => function (Query $q) {
-                return $q->where(...); // Conditions complètes pour le filtrage
+                return $q->where(/* ... */); // Conditions complètes pour le filtrage
             }
         ]
     ]);

--- a/fr/orm/validation.rst
+++ b/fr/orm/validation.rst
@@ -614,7 +614,7 @@ utile de packager ces règles dans des classes réutilisables::
     // Ajouter la règle personnalisée
     use App\Model\Rule\CustomRule;
 
-    $rules->add(new CustomRule(...), 'ruleName');
+    $rules->add(new CustomRule(/* ... */), 'ruleName');
 
 En ajoutant des classes de règles personnalisées, vous pouvez garder votre code
 DRY et tester vos règles de domaine isolément.

--- a/ja/contributing/cakephp-coding-conventions.rst
+++ b/ja/contributing/cakephp-coding-conventions.rst
@@ -254,7 +254,7 @@ false を、関数呼び出しが成功したかどうかを判定できるよ�
     {
         ...
         if (!$success) {
-            throw new RuntimeException(...);
+            throw new RuntimeException(/* ... */);
         }
 
         ...

--- a/ja/core-libraries/httpclient.rst
+++ b/ja/core-libraries/httpclient.rst
@@ -52,9 +52,9 @@ POST や PUT のリクエストを実行することは、同様に簡単です�
     ]);
 
     // 他のメソッドも同様に、
-    $http->delete(...);
-    $http->head(...);
-    $http->patch(...);
+    $http->delete(/* ... */);
+    $http->head(/* ... */);
+    $http->patch(/* ... */);
 
 If you have created a PSR-7 request object you can send it using
 ``sendRequest()``::
@@ -515,11 +515,11 @@ is making::
 
 There are methods to mock the most commonly used HTTP methods::
 
-    $this->mockClientGet(...);
-    $this->mockClientPatch(...);
-    $this->mockClientPost(...);
-    $this->mockClientPut(...);
-    $this->mockClientDelete(...);
+    $this->mockClientGet(/* ... */);
+    $this->mockClientPatch(/* ... */);
+    $this->mockClientPost(/* ... */);
+    $this->mockClientPut(/* ... */);
+    $this->mockClientDelete(/* ... */);
 
 .. php:method:: newClientResponse(int $code = 200, array $headers = [], string $body = '')
 

--- a/ja/orm/retrieving-data-and-resultsets.rst
+++ b/ja/orm/retrieving-data-and-resultsets.rst
@@ -596,7 +596,7 @@ contain に条件を渡す
         'Authors' => [
             'foreignKey' => false,
             'queryBuilder' => function (Query $q) {
-                return $q->where(...); // フィルターのための完全な条件
+                return $q->where(/* ... */); // フィルターのための完全な条件
             }
         ]
     ]);

--- a/ja/orm/validation.rst
+++ b/ja/orm/validation.rst
@@ -566,7 +566,7 @@ CakePHP は、エンティティーが保存される前に適用される「ル
     // カスタムルールの追加
     use App\Model\Rule\CustomRule;
 
-    $rules->add(new CustomRule(...), 'ruleName');
+    $rules->add(new CustomRule(/* ... */), 'ruleName');
 
 カスタムルールクラスを作ることでコードを *重複がない状態*
 (訳注：DRY = Don't Repeat Yourself の訳)
@@ -610,7 +610,7 @@ CakePHP の ORM は検証に二層のアプローチを使う点がユニーク�
 
     public function validationCustomName($validator)
     {
-        $validator->add(...);
+        $validator->add(/* ... */);
         return $validator;
     }
 

--- a/pt/core-libraries/httpclient.rst
+++ b/pt/core-libraries/httpclient.rst
@@ -45,9 +45,9 @@ Fazer solicitações POST e PUT é igualmente simples::
     ]);
 
     // Outros métodos também.
-    $http->delete(...);
-    $http->head(...);
-    $http->patch(...);
+    $http->delete(/* ... */);
+    $http->head(/* ... */);
+    $http->patch(/* ... */);
 
 Se você criou um objeto de solicitação PSR-7, pode enviá-lo usando
 ``sendRequest()``::

--- a/pt/orm/query-builder.rst
+++ b/pt/orm/query-builder.rst
@@ -666,7 +666,7 @@ criam novos objetos de expressão que mudam **como** as condições são combina
 segundo tipo de métodos são **condições**. As condições são adicionadas a uma expressão
 em que são alinhadas com o combinador atual.
 
-Por exemplo, chamar ``$exp->and_(...)`` criará um novo objeto ``Expression`` que
+Por exemplo, chamar ``$exp->and_(/* ... */)`` criará um novo objeto ``Expression`` que
 combina todas as condições que ele contém com ``AND``. Enquanto ``$exp->or_()`` criará
 um novo objeto ``Expression`` que combina todas as condições adicionadas a ele
 com ``OR``. Um exemplo de adição de condições com um objeto ``Expression`` seria::

--- a/pt/orm/retrieving-data-and-resultsets.rst
+++ b/pt/orm/retrieving-data-and-resultsets.rst
@@ -568,7 +568,7 @@ case you should use an array passing ``foreignKey`` and ``queryBuilder``::
         'Authors' => [
             'foreignKey' => false,
             'queryBuilder' => function ($q) {
-                return $q->where(...); // Full conditions for filtering
+                return $q->where(/* ... */); // Full conditions for filtering
             }
         ]
     ]);


### PR DESCRIPTION
This leads to fewer syntax errors when copying the examples into ones code/IDE.