### PR TITLE
Update installation.rst

### DIFF
--- a/en/tutorials-and-examples/cms/installation.rst
+++ b/en/tutorials-and-examples/cms/installation.rst
@@ -45,7 +45,7 @@ in the **cms** directory of the current working directory:
 
 .. code-block:: console
 
-    php composer.phar create-project --prefer-dist cakephp/app:5.* cms
+    php composer.phar create-project --prefer-dist cakephp/app:5 cms
 
 If you downloaded and ran the `Composer Windows Installer
 <https://getcomposer.org/Composer-Setup.exe>`_, then type the following line in


### PR DESCRIPTION
Running the provided install command leads to an error:  `no matches found: cakephp/app:5.*`

I removed the `.*` and the install was successful.