### PR TITLE
Update query-builder.rst

### DIFF
--- a/en/orm/query-builder.rst
+++ b/en/orm/query-builder.rst
@@ -58,7 +58,7 @@ that ``SelectQuery`` objects are lazy, and will not be executed unless you tell 
 to::
 
     $query->where(['id' => 1]); // Return the same query object
-    $query->order(['title' => 'DESC']); // Still same object, no SQL executed
+    $query->orderBy(['title' => 'DESC']); // Still same object, no SQL executed
 
 You can of course chain the methods you call on SelectQuery objects::
 
@@ -66,7 +66,7 @@ You can of course chain the methods you call on SelectQuery objects::
         ->find()
         ->select(['id', 'name'])
         ->where(['id !=' => 1])
-        ->order(['created' => 'DESC']);
+        ->orderBy(['created' => 'DESC']);
 
     foreach ($query->all() as $article) {
         debug($article->created);
@@ -165,7 +165,7 @@ by calling the ``SelectQuery``'s ``all()`` method) implements the collection int
     // An advanced example
     $results = $articles->find()
         ->where(['id >' => 1])
-        ->order(['title' => 'DESC'])
+        ->orderBy(['title' => 'DESC'])
         ->all()
         ->map(function ($row) {
             $row->trimmedTitle = trim($row->title);
@@ -432,20 +432,20 @@ Ordering Results
 To apply ordering, you can use the ``order`` method::
 
     $query = $articles->find()
-        ->order(['title' => 'ASC', 'id' => 'ASC']);
+        ->orderBy(['title' => 'ASC', 'id' => 'ASC']);
 
-When calling ``order()`` multiple times on a query, multiple clauses will be
+When calling ``orderBy()`` multiple times on a query, multiple clauses will be
 appended.  However, when using finders you may sometimes need to overwrite the
-``ORDER BY``.  Set the second parameter of ``order()`` (as well as
-``orderAsc()`` or ``orderDesc()``) to ``SelectQuery::OVERWRITE`` or to ``true``::
+``ORDER BY``.  Set the second parameter of ``orderBy()`` (as well as
+``orderByAsc()`` or ``orderByDesc()``) to ``SelectQuery::OVERWRITE`` or to ``true``::
 
     $query = $articles->find()
-        ->order(['title' => 'ASC']);
+        ->orderBy(['title' => 'ASC']);
     // Later, overwrite the ORDER BY clause instead of appending to it.
     $query = $articles->find()
-        ->order(['created' => 'DESC'], SelectQuery::OVERWRITE);
+        ->orderBy(['created' => 'DESC'], SelectQuery::OVERWRITE);
 
-The ``orderAsc`` and ``orderDesc`` methods can be used when you need to sort on
+The ``orderByAsc`` and ``orderByDesc`` methods can be used when you need to sort on
 complex expressions::
 
     $query = $articles->find();
@@ -453,11 +453,11 @@ complex expressions::
         'title' => 'identifier',
         'synopsis' => 'identifier'
     ]);
-    $query->orderAsc($concat);
+    $query->orderByAsc($concat);
 
 To build complex order clauses, use a Closure to build order expressions::
 
-    $query->orderAsc(function (QueryExpression $exp, SelectQuery $query) {
+    $query->orderByAsc(function (QueryExpression $exp, SelectQuery $query) {
         return $exp->addCase(/* ... */);
     });
 
@@ -1069,7 +1069,7 @@ You can use ``identifier()`` in comparisons to aggregations too::
     $query = $this->Orders->find();
     $query->select(['Customers.customer_name', 'total_orders' => $query->func()->count('Orders.order_id')])
         ->contain('Customers')
-        ->group(['Customers.customer_name'])
+        ->groupBy(['Customers.customer_name'])
         ->having(['total_orders >=' => $query->identifier('Customers.minimum_order_count')]);
 
 .. warning::
@@ -1781,14 +1781,14 @@ through ``FunctionsBuilder::aggregate()``.
 These are the most commonly supported window features. Most features are provided
 by ``AggregateExpresion``, but make sure you follow your database documentation on use and restrictions.
 
-- ``order($fields)`` Order the aggregate group the same as a query ORDER BY.
+- ``orderBy($fields)`` Order the aggregate group the same as a query ORDER BY.
 - ``partition($expressions)`` Add one or more partitions to the window based on column
   names.
 - ``rows($start, $end)`` Define a offset of rows that precede and/or follow the
   current row that should be included in the aggregate function.
 - ``range($start, $end)`` Define a range of row values that precede and/or follow
   the current row that should be included in the aggregate function. This
-  evaluates values based on the ``order()`` field.
+  evaluates values based on the ``orderBy()`` field.
 
 If you need to re-use the same window expression multiple times you can create
 named windows using the ``window()`` method::


### PR DESCRIPTION
**Task:**

Improve documentation:

- [x] Replace: `order()` with `orderBy()`
- [x] Replace: `orderAsc()` with `orderByAsc()`
- [x] Replace: `orderDesc()` with `orderByDesc()`
- [x] Replace: `group()` with `groupBy()`


As mentioned in the migration guide: https://book.cakephp.org/5/en/appendices/5-0-migration-guide.html#database

>Query::orderBy() was added to replace Query::order().
>Query::groupBy() was added to replace Query::group().

Code reference: 

1. https://github.com/cakephp/cakephp/blob/2da6ed819f520e472ea12b011a9c7a7f39310a4a/src/Database/Query.php#L1165
2. https://github.com/cakephp/cakephp/blob/2da6ed819f520e472ea12b011a9c7a7f39310a4a/src/Database/Query.php#L1263
3. https://github.com/cakephp/cakephp/blob/2da6ed819f520e472ea12b011a9c7a7f39310a4a/src/Database/Query.php#L1316
