### PR TITLE
Update datasources default setting referencing

### DIFF
--- a/fr/tutorials-and-examples/cms/database.rst
+++ b/fr/tutorials-and-examples/cms/database.rst
@@ -132,9 +132,9 @@ de configuration complétée ressemblera à ceci::
         // D'autres configurations au dessus
         'Datasources' => [
             'default' => [
-                'className' => 'Cake\Database\Connection',
+                'className' => Connection::class,
                 // Remplacez Mysql par Postgres si vous utilisez PostgreSQL
-                'driver' => 'Cake\Database\Driver\Mysql',
+                'driver' => Mysql::class,
                 'persistent' => false,
                 'host' => 'localhost',
                 'username' => 'cakephp',

--- a/ja/tutorials-and-examples/cms/database.rst
+++ b/ja/tutorials-and-examples/cms/database.rst
@@ -77,8 +77,8 @@ CMS チュートリアル - データベース作成
         // 上には他の設定があります
         'Datasources' => [
             'default' => [
-                'className' => 'Cake\Database\Connection',
-                'driver' => 'Cake\Database\Driver\Mysql',
+                'className' => Connection::class,
+                'driver' => Mysql::class,
                 'persistent' => false,
                 'host' => 'localhost',
                 'username' => 'cakephp',


### PR DESCRIPTION
- Change in CMS Tutorial Referencing.
  - `use Cake\Database\Connection;` and `use Cake\Database\Driver\Mysql;` are done by default.