### PR TITLE
[5.x] Corrected one of the notations in auth.rst (ja)

### DIFF
--- a/ja/tutorials-and-examples/blog-auth-example/auth.rst
+++ b/ja/tutorials-and-examples/blog-auth-example/auth.rst
@@ -256,7 +256,7 @@ composerを使ってAuthenticationプラグインをインストールします�
 デフォルトでは、認証情報はリクエストデータの ``email`` と ``password`` フィールドから
 抽出されます。認証結果は ``authentication`` という名前のリクエスト属性に注入されます。
 この結果はいつでもコントローラのアクションから
-``$this->request->getAttribute('authentication')``を使って調べることができます。
+``$this->request->getAttribute('authentication')`` を使って調べることができます。
 すべてのページは ``AuthenticationComponent`` がリクエストごとに結果をチェックしているため、
 制限されてしまいます。認証されたユーザを見つけられなかった場合は ユーザーを ``/users/login``
 のページにリダイレクトします。


### PR DESCRIPTION
I noticed a small mistake in the writing style and corrected it.

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/8212aead-b8d4-4425-b532-9674eddcb4e5">
