### PR TITLE
The `replaceToken()` method was added in version 4.5.0 instead of 4.3.0

### DIFF
--- a/en/security/csrf.rst
+++ b/en/security/csrf.rst
@@ -108,7 +108,7 @@ Should you need to rotate or replace the session CSRF token you can do so with::
 
     $this->request = SessionCsrfProtectionMiddleware::replaceToken($this->request);
 
-.. versionadded:: 4.3.0
+.. versionadded:: 4.5.0
     The ``replaceToken`` method was added.
 
 Skipping CSRF checks for specific actions


### PR DESCRIPTION
On my app, tried to use `SessionCsrfProtectionMiddleware::replaceToken()` method as per CSRF Protection docs:
https://book.cakephp.org/4/en/security/csrf.html#session-based-csrf-middleware-options
But the method is not available even though my version is higher than 4.3.0 (my app version is 4.4.5).

In version 4.3.0, there is no `replaceToken()` method: https://github.com/cakephp/cakephp/blob/4.3.0/src/Http/Middleware/SessionCsrfProtectionMiddleware.php

The method was actually added since version 4.5.0: https://github.com/cakephp/cakephp/blob/4.5.0/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
