### PR TITLE
Exception hook methods should be protected.

### DIFF
--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -225,7 +225,7 @@ a ``missingWidget()`` controller method, and CakePHP would use
 
     class ErrorController extends AppController
     {
-        public function missingWidget(MissingWidgetException $error)
+        protected function missingWidget(MissingWidgetException $error)
         {
             // You can prepare additional template context or trap errors.
         }


### PR DESCRIPTION
This prevents them from being executable through routing.