### PR TITLE
Fix schema type to be adjustable at runtime.

### DIFF
--- a/en/orm/database-basics.rst
+++ b/en/orm/database-basics.rst
@@ -599,14 +599,16 @@ We then have two ways to use our datatype in our models.
 
 Overwriting the reflected schema with our custom type will enable CakePHP's
 database layer to automatically convert JSON data when creating queries. In your
-Table's :ref:`getSchema() method <saving-complex-types>` add the
+Table's :ref:`initialize() method <saving-complex-types>` add the
 following::
 
     class WidgetsTable extends Table
     {
-        public function getSchema(): TableSchemaInterface
+        public function initialize(array $config): void
         {
-            return parent::getSchema()->setColumnType('widget_prefs', 'json');
+            parent::initialize($config);
+
+            return $this->getSchema()->setColumnType('widget_prefs', 'json');
         }
     }
 

--- a/en/orm/saving-data.rst
+++ b/en/orm/saving-data.rst
@@ -1094,12 +1094,11 @@ column Types::
 
     class UsersTable extends Table
     {
-        public function getSchema(): TableSchemaInterface
+        public function initialize(array $config): void
         {
-            $schema = parent::getSchema();
-            $schema->setColumnType('preferences', 'json');
+            parent::initialize($config);
 
-            return $schema;
+            $this->getSchema()->setColumnType('preferences', 'json');
         }
     }
 


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/18024

for a quick fix in docs to be in sync with the other example already on that page further up:

```
To use this type you need to specify which column is associated to which BackedEnum inside the table class::

    use \Cake\Database\Type\EnumType;
    use \App\Model\Enum\ArticleStatus;

    // in src/Model/Table/ArticlesTable.php
    public function initialize(array $config): void
    {
        $this->getSchema()->setColumnType('status', EnumType::from(ArticleStatus::class));
    }
```