### PR TITLE
Include model creation in the quick start guide

### DIFF
--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -6,6 +6,7 @@ To start off we'll build a simple Content Management application.
 
 .. include:: /tutorials-and-examples/cms/installation.rst
 .. include:: /tutorials-and-examples/cms/database.rst
+.. include:: /tutorials-and-examples/cms/articles-model.rst
 .. include:: /tutorials-and-examples/cms/articles-controller.rst
 
 .. meta::


### PR DESCRIPTION
Since fallback table class usage is disabled by default in the skeleton app, creating the model classes first is necessary.