### PR TITLE
Clarify tricky part about finder key.

### DIFF
--- a/en/controllers/pagination.rst
+++ b/en/controllers/pagination.rst
@@ -62,6 +62,8 @@ You can also use :ref:`custom-find-methods` in pagination by using the ``finder`
         ];
     }
 
+Note: This only works with Table as string input in ``$this->paginate('MyTable')``. Once you use ``$this->MyTable->find()`` as input for ``paginate()``, you must directly use that Query object instead.
+
 If your finder method requires additional options you can pass those
 as values for the finder::
 


### PR DESCRIPTION
Clarify tricky part about finder key.

for

    protected array $paginate = [
        'finder' => 'foo',

it has to be 

    $banks = $this->paginate('Banks');
    
The

        $query = $this->Banks->find();
        $banks = $this->paginate($query);
        
default bake code would not work.