### PR TITLE
Fix ComboSession implementation

### DIFF
--- a/en/development/sessions.rst
+++ b/en/development/sessions.rst
@@ -280,7 +280,8 @@ something like::
         // Removes expired sessions.
         public function gc($expires = null)
         {
-            return Cache::gc($this->cacheKey) && parent::gc($expires);
+            Cache::gc($this->cacheKey);
+            return parent::gc($expires);
         }
     }
 

--- a/fr/development/sessions.rst
+++ b/fr/development/sessions.rst
@@ -300,7 +300,8 @@ devrait ressembler à::
         // Retire des sessions expirées.
         public function gc($expires = null)
         {
-            return Cache::gc($this->cacheKey) && parent::gc($expires);
+            Cache::gc($this->cacheKey);
+            return parent::gc($expires);
         }
     }
 

--- a/ja/development/sessions.rst
+++ b/ja/development/sessions.rst
@@ -270,7 +270,8 @@ IO をもたらします。
         // 有効期限切れセッションの削除
         public function gc($expires = null)
         {
-            return Cache::gc($this->cacheKey) && parent::gc($expires);
+            Cache::gc($this->cacheKey);
+            return parent::gc($expires);
         }
     }
 

--- a/pt/development/sessions.rst
+++ b/pt/development/sessions.rst
@@ -271,7 +271,8 @@ A classe deve se parecer com::
         // Remove sessões expiradas.
         public function gc($expires = null)
         {
-            return Cache::gc($this->cacheKey) && parent::gc($expires);
+            Cache::gc($this->cacheKey);
+            return parent::gc($expires);
         }
     }
 

--- a/ru/development/sessions.rst
+++ b/ru/development/sessions.rst
@@ -283,7 +283,8 @@ CakePHP предоставляет возможность настраивать
         // Удаление истёкших сессий.
         public function gc($expires = null)
         {
-            return Cache::gc($this->cacheKey) && parent::gc($expires);
+            Cache::gc($this->cacheKey);
+            return parent::gc($expires);
         }
     }
 


### PR DESCRIPTION
The ComboSession example code is broken: since Cache::gc() returns void, parent::gc() is never called and garbage collection is never executed.