### PR TITLE
Fixes a warning when building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL Description="This image is used to create an environment to contribute to the cakephp/docs"
 


### PR DESCRIPTION
Warning issued: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)