### PR TITLE
Update entities.rst

### DIFF
--- a/en/orm/entities.rst
+++ b/en/orm/entities.rst
@@ -571,7 +571,7 @@ field that should be exposed::
 
     class User extends Entity
     {
-        protected $_virtual = ['full_name'];
+        protected array $_virtual = ['full_name'];
     }
 
 This list can be modified at runtime using the ``setVirtual()`` method::


### PR DESCRIPTION
`protected $_virtual` updated to `protected array $_virtual` as CakePHP 5 throws a fatal error: `Fatal error: Type of App\Model\Entity\EntityName::$_virtual must be array (as in class Cake\ORM\Entity)` without this specification.