### PR TITLE
Improve exception renderer overriding docs.

### DIFF
--- a/en/controllers/middleware.rst
+++ b/en/controllers/middleware.rst
@@ -73,16 +73,17 @@ called at the beginning of the request process, you can use the
 
     namespace App;
 
+    use Cake\Core\Configure;
+    use Cake\Error\Middleware\ErrorHandlerMiddleware;
     use Cake\Http\BaseApplication;
     use Cake\Http\MiddlewareQueue;
-    use Cake\Error\Middleware\ErrorHandlerMiddleware;
 
     class Application extends BaseApplication
     {
         public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
         {
             // Bind the error handler into the middleware queue.
-            $middlewareQueue->add(new ErrorHandlerMiddleware());
+            $middlewareQueue->add(new ErrorHandlerMiddleware(Configure::read('Error'), $this));
 
             // Add middleware by classname.
             // As of 4.5.0 classname middleware are optionally resolved

--- a/en/development/errors.rst
+++ b/en/development/errors.rst
@@ -225,7 +225,7 @@ a ``missingWidget()`` controller method, and CakePHP would use
 
     class ErrorController extends AppController
     {
-        protected function missingWidget(MissingWidgetException $error)
+        protected function missingWidget(MissingWidgetException $exception)
         {
             // You can prepare additional template context or trap errors.
         }
@@ -265,11 +265,11 @@ error pages when this error is handled::
         }
     }
 
-    // In config/app.php
-    'Error' => [
-        'exceptionRenderer' => 'App\Error\AppExceptionRenderer',
-        // ...
-    ],
+    // In Application::middleware()
+    $middlewareQueue->add(new ErrorHandlerMiddleware(
+        ['exceptionRenderer' => AppExceptionRenderer::class] + Configure::read('Error'),
+        $this,
+    ));
     // ...
 
 The above would handle our ``MissingWidgetException``,
@@ -315,11 +315,11 @@ override the ``_getController()`` method in your exception renderer::
         }
     }
 
-    // in config/app.php
-    'Error' => [
-        'exceptionRenderer' => 'App\Error\AppExceptionRenderer',
-        // ...
-    ],
+    // In Application::middleware()
+    $middlewareQueue->add(new ErrorHandlerMiddleware(
+        ['exceptionRenderer' => AppExceptionRenderer::class] + Configure::read('Error'),
+        $this,
+    ));
     // ...
 
 


### PR DESCRIPTION
Setting custom exception render using the `Error.exceptionRenderer` will cause the same renderer to be used for CLI too. In most cases users would want to use the custom renderer only for web requests.