### PR TITLE
Update standalone plugin test instructions

### DIFF
--- a/en/development/testing.rst
+++ b/en/development/testing.rst
@@ -273,7 +273,7 @@ a separate directory and install its dependencies:
     git clone git://github.com/cakephp/debug_kit.git
     cd debug_kit
     php ~/composer.phar install
-    php ~/phpunit.phar
+    vendor/bin/phpunit
 
 Filtering Test Cases
 --------------------


### PR DESCRIPTION
Do we still need a phpunit.phar?
Since CakePHP 5 requires PHPUnit 10+, you normally install it as a dev dependency via Composer, and then run it from `vendor/bin/phpunit`