### PR TITLE
Use correct function to add autoDiscovered commands in documentation

### DIFF
--- a/en/console-commands.rst
+++ b/en/console-commands.rst
@@ -117,7 +117,7 @@ You can customize the command names by defining each command in your plugin::
     }
 
 When overriding the ``console()`` hook in your application, remember to
-call ``$commands->autoDiscover()`` to add commands from CakePHP, your
+call ``$commands->addMany($commands->autoDiscover());`` to add commands from CakePHP, your
 application, and plugins.
 
 If you need to rename/remove any attached commands, you can use the

--- a/en/console-commands.rst
+++ b/en/console-commands.rst
@@ -117,7 +117,7 @@ You can customize the command names by defining each command in your plugin::
     }
 
 When overriding the ``console()`` hook in your application, remember to
-call ``$commands->addMany($commands->autoDiscover());`` to add commands from CakePHP, your
+call ``$commands->addMany($commands->autoDiscover())`` to add commands from CakePHP, your
 application, and plugins.
 
 If you need to rename/remove any attached commands, you can use the


### PR DESCRIPTION
We noticed that $commands->autoDiscover() only finds the commands and doesn't add them like the documentation says, which may be misleading. To add the discovered commands you have to do $commands->addMany($commands->autoDiscover())