### PR TITLE
Remove parent constructor call in CheckUsersCommand

### DIFF
--- a/en/development/dependency-injection.rst
+++ b/en/development/dependency-injection.rst
@@ -61,7 +61,6 @@ Command Example
     {
         public function __construct(protected UsersService $users, ?CommandFactoryInterface $factory = null)
         {
-            parent::__construct($factory);
         }
 
         public function execute(Arguments $args, ConsoleIo $io)


### PR DESCRIPTION
This was removed and causes a container exception.