### PR TITLE
fix styling for 5.3 migration guide

### DIFF
--- a/en/appendices/5-3-migration-guide.rst
+++ b/en/appendices/5-3-migration-guide.rst
@@ -28,14 +28,14 @@ Behavior Changes
 Core
 ----
 
-- ``InstanceConfigTrait::deleteConfig()`` was added. For classes using this
-   trait, you can now use ``$this->deleteConfig('key')`` instead of ``$this->setConfig('key', null)``
+- ``InstanceConfigTrait::deleteConfig()`` was added. For classes using this trait,
+  you can now use ``$this->deleteConfig('key')`` instead of ``$this->setConfig('key', null)``
 
 Database
 --------
 
-- ``Query::with()`` now accepts an array of expressions to align with other query clauses. This also
-   allows clearing the expressions with an empty array.
+- ``Query::with()`` now accepts an array of expressions to align with other query clauses.
+  This also allows clearing the expressions with an empty array.
 
 ORM
 ---


### PR DESCRIPTION
<img width="2560" height="1289" alt="image" src="https://github.com/user-attachments/assets/ae84eea3-a7a3-483a-9917-823138ae7b6a" />
