### PR TITLE
Add method headers to core-libraries documentation

### DIFF
--- a/docs/en/core-libraries/app.md
+++ b/docs/en/core-libraries/app.md
@@ -6,6 +6,8 @@ The App class is responsible for resource location and path management.
 
 ## Finding Classes
 
+### App::className()
+
 `static` Cake\\Core\\App::**className**($name, $type = '', $suffix = '')
 
 This method is used to resolve class names throughout CakePHP. It resolves
@@ -31,6 +33,8 @@ class names do not exist, `false` will be returned.
 
 ## Finding Paths to Resources
 
+### App::path()
+
 `static` Cake\\Core\\App::**path**(string $package, ?string $plugin = null)
 
 The method returns paths set using `App.paths` app config:
@@ -43,6 +47,8 @@ App::path('templates');
 The same way you can retrieve paths for `locales`, `plugins`.
 
 ## Finding Paths to Namespaces
+
+### App::classPath()
 
 `static` Cake\\Core\\App::**classPath**(string $package, ?string $plugin = null)
 
@@ -58,6 +64,8 @@ This can be done for all namespaces that are part of your application.
 `App::classPath()` will only return the default path, and will not be able to
 provide any information about additional paths the autoloader is configured
 for.
+
+### App::core()
 
 `static` Cake\\Core\\App::**core**(string $package)
 

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -39,6 +39,8 @@ Regardless of the CacheEngine you choose to use, your application interacts with
 
 ## Configuring Cache Engines
 
+### Cache::setConfig()
+
 `static` Cake\\Cache\\Cache::**setConfig**($key, $config = null)
 
 Your application can configure any number of 'engines' during its bootstrap
@@ -265,7 +267,7 @@ Cache::setConfig('redis', [
 
 When there is no fallback cache failures will be raised as exceptions.
 
-### Removing Configured Cache Engines
+### Cache::drop()
 
 `static` Cake\\Cache\\Cache::**drop**($key)
 
@@ -275,6 +277,8 @@ the configuration and re-create it using `Cake\Cache\Cache::drop()` and
 the config and destroy the adapter if it was constructed.
 
 ## Writing to a Cache
+
+### Cache::write()
 
 `static` Cake\\Cache\\Cache::**write**($key, $value, $config = 'default')
 
@@ -301,7 +305,7 @@ of trips made to the database to fetch posts.
 > it is better to use the built-in cache capabilities of the Query object
 > as described in the [Caching Query Results](../orm/query-builder#caching-query-results) section
 
-### Writing Multiple Keys at Once
+### Cache::writeMany()
 
 `static` Cake\\Cache\\Cache::**writeMany**($data, $config = 'default')
 
@@ -320,7 +324,7 @@ $result = Cache::writeMany([
 ['article-first-post' => true, 'article-first-post-comments' => true]
 ```
 
-### Atomic writes
+### Cache::add()
 
 `static` Cake\\Cache\\Cache::**add**($key, $value $config = 'default')
 
@@ -343,7 +347,7 @@ Cache::delete($lockKey);
 > [!WARNING]
 > File based caching does not support atomic writes.
 
-### Read Through Caching
+### Cache::remember()
 
 `static` Cake\\Cache\\Cache::**remember**($key, $callable, $config = 'default')
 
@@ -367,6 +371,8 @@ class IssueService
 ```
 
 ## Reading From a Cache
+
+### Cache::read()
 
 `static` Cake\\Cache\\Cache::**read**($key, $config = 'default')
 
@@ -411,7 +417,7 @@ if ($cloud === null) {
 return $cloud;
 ```
 
-### Reading Multiple Keys at Once
+### Cache::readMany()
 
 `static` Cake\\Cache\\Cache::**readMany**($keys, $config = 'default')
 
@@ -431,6 +437,8 @@ $result = Cache::readMany([
 
 ## Deleting From a Cache
 
+### Cache::delete()
+
 `static` Cake\\Cache\\Cache::**delete**($key, $config = 'default')
 
 `Cache::delete()` will allow you to completely remove a cached
@@ -448,7 +456,7 @@ which uses the `UNLINK` operation to remove cache keys:
 Cache::pool('redis')->deleteAsync('my_key');
 ```
 
-### Deleting Multiple Keys at Once
+### Cache::deleteMany()
 
 `static` Cake\\Cache\\Cache::**deleteMany**($keys, $config = 'default')
 
@@ -467,6 +475,8 @@ $result = Cache::deleteMany([
 ```
 
 ## Clearing Cached Data
+
+### Cache::clear()
 
 `static` Cake\\Cache\\Cache::**clear**($config = 'default')
 
@@ -493,7 +503,11 @@ Cache::pool('redis')->clearBlocking();
 
 ## Using Cache to Store Counters
 
+### Cache::increment()
+
 `static` Cake\\Cache\\Cache::**increment**($key, $offset = 1, $config = 'default')
+
+### Cache::decrement()
 
 `static` Cake\\Cache\\Cache::**decrement**($key, $offset = 1, $config = 'default')
 
@@ -547,6 +561,8 @@ Cache::setConfig('site_home', [
 ]);
 ```
 
+### Cache::clearGroup()
+
 `method` Cake\\Cache\\Cache::**clearGroup**($group, $config = 'default')
 
 Let's say you want to store the HTML generated for your homepage in cache, but
@@ -567,6 +583,8 @@ public function afterSave($event, $entity, $options = [])
     }
 }
 ```
+
+### Cache::groupConfigs()
 
 `static` Cake\\Cache\\Cache::**groupConfigs**($group = null)
 
@@ -597,6 +615,8 @@ choose a common prefix for all your configs.
 
 ## Globally Enable or Disable Cache
 
+### Cache::disable()
+
 `static` Cake\\Cache\\Cache::**disable**()
 
 You may need to disable all Cache read & writes when trying to figure out cache
@@ -610,6 +630,8 @@ Cache::disable();
 
 Once disabled, all reads and writes will return `null`.
 
+### Cache::enable()
+
 `static` Cake\\Cache\\Cache::**enable**()
 
 Once disabled, you can use `enable()` to re-enable caching:
@@ -618,6 +640,8 @@ Once disabled, you can use `enable()` to re-enable caching:
 // Re-enable all cache reads, and cache writes.
 Cache::enable();
 ```
+
+### Cache::enabled()
 
 `static` Cake\\Cache\\Cache::**enabled**()
 

--- a/docs/en/core-libraries/collections.md
+++ b/docs/en/core-libraries/collections.md
@@ -68,6 +68,8 @@ application as well.
 
 ## Iterating
 
+### each()
+
 `method` Cake\\Collection\\Collection::**each**($callback)
 
 Collections can be iterated and/or transformed into new collections with the
@@ -83,6 +85,8 @@ $collection = $collection->each(function ($value, $key) {
 
 The return of `each()` will be the collection object. Each will iterate the
 collection immediately applying the callback to each value in the collection.
+
+### map()
 
 `method` Cake\\Collection\\Collection::**map**($callback)
 
@@ -106,6 +110,8 @@ $result = $new->toArray();
 
 The `map()` method will create a new iterator which lazily creates
 the resulting items when iterated.
+
+### extract()
 
 `method` Cake\\Collection\\Collection::**extract**($path)
 
@@ -180,6 +186,8 @@ we'll be guaranteed to get all values even if there are duplicate keys.
 Unlike `Cake\Utility\Hash::extract()` this method only supports the
 `{*}` wildcard. All other wildcard and attributes matchers are not supported.
 
+### combine()
+
 `method` Cake\\Collection\\Collection::**combine**($keyPath, $valuePath, $groupPath = null)
 
 Collections allow you to create a new collection made from keys and values in
@@ -235,6 +243,8 @@ $combined = (new Collection($entities))->combine(
 ]
 ```
 
+### stopWhen()
+
 `method` Cake\\Collection\\Collection::**stopWhen**(callable $c)
 
 You can stop the iteration at any point using the `stopWhen()` method. Calling
@@ -253,6 +263,8 @@ $new = $collection->stopWhen(function ($value, $key) {
 // $result contains [10, 20];
 $result = $new->toList();
 ```
+
+### unfold()
 
 `method` Cake\\Collection\\Collection::**unfold**(callable $callback)
 
@@ -300,6 +312,8 @@ $new = $collection->unfold(function ($oddNumber) {
 $result = $new->toList();
 ```
 
+### chunk()
+
 `method` Cake\\Collection\\Collection::**chunk**($chunkSize)
 
 When dealing with large amounts of items in a collection, it may make sense to
@@ -329,6 +343,8 @@ $collection->map(function ($article) {
     });
 ```
 
+### chunkWithKeys()
+
 `method` Cake\\Collection\\Collection::**chunkWithKeys**($chunkSize)
 
 Much like `chunk()`, `chunkWithKeys()` allows you to slice up
@@ -354,6 +370,8 @@ $result = $chunked->toList();
 
 ## Filtering
 
+### filter()
+
 `method` Cake\\Collection\\Collection::**filter**($callback)
 
 Collections allow you to filter and create new collections based on
@@ -370,6 +388,8 @@ $guys = $collection->filter(function ($person, $key) {
 });
 ```
 
+### reject()
+
 `method` Cake\\Collection\\Collection::**reject**(callable $c)
 
 The inverse of `filter()` is `reject()`. This method does a negative filter,
@@ -381,6 +401,8 @@ $ladies = $collection->reject(function ($person, $key) {
     return $person->gender === 'male';
 });
 ```
+
+### every()
 
 `method` Cake\\Collection\\Collection::**every**($callback)
 
@@ -394,7 +416,11 @@ $allYoungPeople = $collection->every(function ($person) {
 });
 ```
 
+### any()
+
 `method` Cake\\Collection\\Collection::**any**($callback)
+
+### some()
 
 `method` Cake\\Collection\\Collection::**some**($callback)
 
@@ -411,6 +437,8 @@ $hasYoungPeople = $collection->any(function ($person) {
 > [!NOTE]
 > The `some()` method is an alias of `any()`.
 
+### match()
+
 `method` Cake\\Collection\\Collection::**match**($conditions)
 
 If you need to extract a new collection containing only the elements that
@@ -420,6 +448,8 @@ contain a given set of properties, you should use the `match()` method:
 $collection = new Collection($comments);
 $commentsFromMark = $collection->match(['user.name' => 'Mark']);
 ```
+
+### firstMatch()
 
 `method` Cake\\Collection\\Collection::**firstMatch**($conditions)
 
@@ -441,6 +471,8 @@ for different paths, allowing you to express complex conditions to match
 against.
 
 ## Aggregation
+
+### reduce()
 
 `method` Cake\\Collection\\Collection::**reduce**($callback, $initial)
 
@@ -464,6 +496,8 @@ $allTags = $collection->reduce(function ($accumulated, $article) {
     return array_merge($accumulated, $article->tags);
 }, []);
 ```
+
+### min()
 
 `method` Cake\\Collection\\Collection::**min**(string|callable $callback, $type = SORT_NUMERIC)
 
@@ -490,6 +524,8 @@ $personYoungestChild = $collection->min(function ($person) {
 $personWithYoungestDad = $collection->min('dad.age');
 ```
 
+### max()
+
 `method` Cake\\Collection\\Collection::**max**(string|callable $callback, $type = SORT_NUMERIC)
 
 The same can be applied to the `max()` function, which will return a single
@@ -505,6 +541,8 @@ $personOldestChild = $collection->max(function ($person) {
 
 $personWithOldestDad = $collection->max('dad.age');
 ```
+
+### sumOf()
 
 `method` Cake\\Collection\\Collection::**sumOf**($path = null)
 
@@ -522,6 +560,8 @@ $sumOfChildrenAges = $collection->sumOf(function ($person) {
 $sumOfDadAges = $collection->sumOf('dad.age');
 ```
 
+### avg()
+
 `method` Cake\\Collection\\Collection::**avg**($path = null)
 
 Calculate the average value of the elements in the collection. Optionally
@@ -537,6 +577,8 @@ $items = [
 // $average contains 150
 $average = (new Collection($items))->avg('invoice.total');
 ```
+
+### median()
 
 `method` Cake\\Collection\\Collection::**median**($path = null)
 
@@ -557,6 +599,8 @@ $median = (new Collection($items))->median('invoice.total');
 ```
 
 ### Grouping and Counting
+
+### groupBy()
 
 `method` Cake\\Collection\\Collection::**groupBy**($callback)
 
@@ -598,6 +642,8 @@ $classResults = $students->groupBy(function ($student) {
 });
 ```
 
+### countBy()
+
 `method` Cake\\Collection\\Collection::**countBy**($callback)
 
 If you only wish to know the number of occurrences per group, you can do so by
@@ -612,6 +658,8 @@ $classResults = $students->countBy(function ($student) {
 // Result could look like this when converted to array:
 ['approved' => 70, 'denied' => 20]
 ```
+
+### indexBy()
 
 `method` Cake\\Collection\\Collection::**indexBy**($callback)
 
@@ -640,6 +688,8 @@ $filesByHash = $files->indexBy(function ($file) {
     return md5($file);
 });
 ```
+
+### zip()
 
 `method` Cake\\Collection\\Collection::**zip**($items)
 
@@ -697,6 +747,8 @@ $result = $firstYear->zip($data[0], $data[1])->toList();
 ```
 
 ## Sorting
+
+### sortBy()
 
 `method` Cake\\Collection\\Collection::**sortBy**($callback, $order = SORT_DESC, $sort = SORT_NUMERIC)
 
@@ -764,6 +816,8 @@ $sorted = $collection->sortBy('title', SORT_ASC, SORT_NATURAL);
 
 ## Working with Tree Data
 
+### nest()
+
 `method` Cake\\Collection\\Collection::**nest**($idPath, $parentPath, $nestingKey = 'children')
 
 Not all data is meant to be represented in a linear way. Collections make it
@@ -813,6 +867,8 @@ $result = $nested->toList();
 Children elements are nested inside the `children` property inside each of the
 items in the collection. This type of data representation is helpful for
 rendering menus or traversing elements up to certain level in the tree.
+
+### listNested()
 
 `method` Cake\\Collection\\Collection::**listNested**($order = 'desc', $nestingKey = 'children')
 
@@ -887,6 +943,8 @@ $nested->listNested()->printer(
 
 ## Other Methods
 
+### isEmpty()
+
 `method` Cake\\Collection\\Collection::**isEmpty**()
 
 Allows you to see if a collection contains any elements:
@@ -900,6 +958,8 @@ $collection = new Collection([1]);
 // Returns false
 $collection->isEmpty();
 ```
+
+### contains()
 
 `method` Cake\\Collection\\Collection::**contains**($value)
 
@@ -915,6 +975,8 @@ $hasThree = $collection->contains(3);
 Comparisons are performed using the `===` operator. If you wish to do looser
 comparison types you can use the `some()` method.
 
+### shuffle()
+
 `method` Cake\\Collection\\Collection::**shuffle**()
 
 Sometimes you may wish to show a collection of values in a random order. In
@@ -927,6 +989,8 @@ $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3]);
 // This could return [2, 3, 1]
 $collection->shuffle()->toList();
 ```
+
+### transpose()
 
 `method` Cake\\Collection\\Collection::**transpose**()
 
@@ -954,6 +1018,8 @@ $result = $transpose->toList();
 
 ### Withdrawing Elements
 
+### sample()
+
 `method` Cake\\Collection\\Collection::**sample**($length = 10)
 
 Shuffling a collection is often useful when doing quick statistical analysis.
@@ -973,6 +1039,8 @@ $testSubjects = $collection->sample(20);
 argument. If there are not enough elements in the collection to satisfy the
 sample, the full collection in a random order is returned.
 
+### take()
+
 `method` Cake\\Collection\\Collection::**take**($length, $offset)
 
 Whenever you want to take a slice of a collection use the `take()` function,
@@ -988,6 +1056,8 @@ $nextTopFive = $collection->sortBy('age')->take(5, 4);
 
 Positions are zero-based, therefore the first position number is `0`.
 
+### skip()
+
 `method` Cake\\Collection\\Collection::**skip**($length)
 
 While the second argument of `take()` can help you skip some elements before
@@ -998,6 +1068,8 @@ purpose as a way to take the rest of the elements after a certain position:
 $collection = new Collection([1, 2, 3, 4]);
 $allExceptFirstTwo = $collection->skip(2)->toList(); // [3, 4]
 ```
+
+### first()
 
 `method` Cake\\Collection\\Collection::**first**()
 
@@ -1010,6 +1082,8 @@ $collection = new Collection([5, 4, 3, 2]);
 $collection->first(); // Returns 5
 ```
 
+### last()
+
 `method` Cake\\Collection\\Collection::**last**()
 
 Similarly, you can get the last element of a collection using the `last()`
@@ -1021,6 +1095,8 @@ $collection->last(); // Returns 2
 ```
 
 ### Expanding Collections
+
+### append()
 
 `method` Cake\\Collection\\Collection::**append**(array|Traversable $items)
 
@@ -1039,6 +1115,8 @@ $myTimeline->filter(function ($tweet) {
 });
 ```
 
+### appendItem()
+
 `method` Cake\\Collection\\Collection::**appendItem**($value, $key)
 
 Allows you to append an item with an optional key to the collection. If you
@@ -1050,6 +1128,8 @@ $cakephpTweets = new Collection($tweets);
 $myTimeline = $cakephpTweets->appendItem($newTweet, 99);
 ```
 
+### prepend()
+
 `method` Cake\\Collection\\Collection::**prepend**($items)
 
 The `prepend()` method will return a new collection containing the values from
@@ -1059,6 +1139,8 @@ both sources:
 $cakephpTweets = new Collection($tweets);
 $myTimeline = $cakephpTweets->prepend($phpTweets);
 ```
+
+### prependItem()
 
 `method` Cake\\Collection\\Collection::**prependItem**($value, $key)
 
@@ -1080,6 +1162,8 @@ $myTimeline = $cakephpTweets->prependItem($newTweet, 99);
 > `toList()` in order to drop the keys and preserve all values.
 
 ### Modifiying Elements
+
+### insert()
 
 `method` Cake\\Collection\\Collection::**insert**($path, $items)
 
@@ -1201,6 +1285,8 @@ class TotalOrderCalculator
 $collection->map(new TotalOrderCalculator)
 ```
 
+### through()
+
 `method` Cake\\Collection\\Collection::**through**($callback)
 
 Sometimes a chain of collection method calls can become reusable in other parts
@@ -1239,6 +1325,8 @@ $collection->through(new FinalCheckOutRowProcessor);
 ```
 
 ### Optimizing Collections
+
+### buffered()
 
 `method` Cake\\Collection\\Collection::**buffered**()
 
@@ -1319,6 +1407,8 @@ $rewindable = (new Collection(results()))->buffered();
 ```
 
 ### Cloning Collections
+
+### compile()
 
 `method` Cake\\Collection\\Collection::**compile**($preserveKeys = true)
 

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -255,6 +255,8 @@ following path:
 
 ## Sending Attachments
 
+### Mailer::setAttachments()
+
 `method` Cake\\Mailer\\Mailer::**setAttachments**($attachments)
 
 You can attach files to email messages as well. There are a few
@@ -296,6 +298,8 @@ you want the filenames to appear in the recipient's mail client:
     a string using the `data` option. This allows you to attach files without
     needing file paths to them.
 
+### Mailer::addAttachment()
+
 `method` Cake\\Mailer\\Mailer::**addAttachment**(\\Psr\\Http\\Message\\UploadedFileInterface|string $path, ?string $name, ?string $mimetype, ?string $contentId, ?bool $contentDisposition)
 
 You can also add attachments using the `addAttachment()` method.
@@ -303,6 +307,8 @@ You can also add attachments using the `addAttachment()` method.
 > \$mailer-\>addAttachment('/full/file/path/file.png');
 
 ### Relaxing Address Validation Rules
+
+### Mailer::setEmailPattern()
 
 `method` Cake\\Mailer\\Mailer::**setEmailPattern**($pattern)
 
@@ -537,6 +543,8 @@ TransportFactory::setConfig('default', [
 
 When using a DSN string you can define any additional parameters/options as
 query string arguments.
+
+### Mailer::drop()
 
 `static` Cake\\Mailer\\Mailer::**drop**($key)
 

--- a/docs/en/core-libraries/httpclient.md
+++ b/docs/en/core-libraries/httpclient.md
@@ -594,6 +594,8 @@ $this->mockClientPut(/* ... */);
 $this->mockClientDelete(/* ... */);
 ```
 
+### Response::newClientResponse()
+
 `method` Cake\\Http\\TestSuite\\Response::**newClientResponse**(int $code = 200, array $headers = [], string $body = '')
 
 As seen above you can use the `newClientResponse()` method to create responses

--- a/docs/en/core-libraries/inflector.md
+++ b/docs/en/core-libraries/inflector.md
@@ -116,7 +116,11 @@ when provided a multi-word argument:
 
 ## Creating Plural & Singular Forms
 
+### Inflector::singularize()
+
 `static` Cake\\Utility\\Inflector::**singularize**($singular)
+
+### Inflector::pluralize()
 
 `static` Cake\\Utility\\Inflector::**pluralize**($singular)
 
@@ -142,7 +146,11 @@ echo Inflector::singularize('People');
 
 ## Creating CamelCase and under_scored Forms
 
+### Inflector::camelize()
+
 `static` Cake\\Utility\\Inflector::**camelize**($underscored)
+
+### Inflector::underscore()
 
 `static` Cake\\Utility\\Inflector::**underscore**($camelCase)
 
@@ -162,6 +170,8 @@ underscore.
 
 ## Creating Human Readable Forms
 
+### Inflector::humanize()
+
 `static` Cake\\Utility\\Inflector::**humanize**($underscored)
 
 This method is useful when converting underscored forms into "Title Case" forms
@@ -174,9 +184,15 @@ Inflector::humanize('apple_pie');
 
 ## Creating Table and Class Name Forms
 
+### Inflector::classify()
+
 `static` Cake\\Utility\\Inflector::**classify**($underscored)
 
+### Inflector::dasherize()
+
 `static` Cake\\Utility\\Inflector::**dasherize**($dashed)
+
+### Inflector::tableize()
 
 `static` Cake\\Utility\\Inflector::**tableize**($camelCase)
 
@@ -195,6 +211,8 @@ Inflector::tableize('UserProfileSetting');
 ```
 
 ## Creating Variable Names
+
+### Inflector::variable()
 
 `static` Cake\\Utility\\Inflector::**variable**($underscored)
 
@@ -223,6 +241,8 @@ CakePHP won't recognize your Foci or Fish, you can tell CakePHP about your
 special cases.
 
 ### Loading Custom Inflections
+
+### Inflector::rules()
 
 `static` Cake\\Utility\\Inflector::**rules**($type, $rules, $reset = false)
 

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -448,6 +448,8 @@ configured.
 
 `class` Cake\\Log\\**Log**
 
+### Log::setConfig()
+
 `static` Cake\\Log\\Log::**setConfig**($key, $config)
 
 param string \$name  
@@ -461,6 +463,8 @@ constructor arguments for the logger.
 Get or set the configuration for a Logger. See [Log Configuration](#log-configuration) for
 more information.
 
+### Log::configured()
+
 `static` Cake\\Log\\Log::**configured**()
 
 returns  
@@ -468,11 +472,15 @@ An array of configured loggers.
 
 Get the names of the configured loggers.
 
+### Log::drop()
+
 `static` Cake\\Log\\Log::**drop**($name)
 
 param string \$name  
 Name of the logger you wish to no longer receive
 messages.
+
+### Log::write()
 
 `static` Cake\\Log\\Log::**write**($level, $message, $scope = [])
 
@@ -480,6 +488,8 @@ Write a message into all the configured loggers.
 `$level` indicates the level of log message being created.
 `$message` is the message of the log entry being written to.
 `$scope` is the scope(s) a log message is being created in.
+
+### Log::levels()
 
 `static` Cake\\Log\\Log::**levels**()
 
@@ -491,25 +501,43 @@ level configuration.
 The following convenience methods were added to log <span class="title-ref">\$message</span> with the
 appropriate log level.
 
+### Log::emergency()
+
 `static` Cake\\Log\\Log::**emergency**($message, $scope = [])
+
+### Log::alert()
 
 `static` Cake\\Log\\Log::**alert**($message, $scope = [])
 
+### Log::critical()
+
 `static` Cake\\Log\\Log::**critical**($message, $scope = [])
+
+### Log::error()
 
 `static` Cake\\Log\\Log::**error**($message, $scope = [])
 
+### Log::warning()
+
 `static` Cake\\Log\\Log::**warning**($message, $scope = [])
+
+### Log::notice()
 
 `static` Cake\\Log\\Log::**notice**($message, $scope = [])
 
+### Log::info()
+
 `static` Cake\\Log\\Log::**info**($message, $scope = [])
+
+### Log::debug()
 
 `static` Cake\\Log\\Log::**debug**($message, $scope = [])
 
 ## Logging Trait
 
 > A trait that provides shortcut methods for logging
+
+### Log::log()
 
 `method` Cake\\Log\\Log::**log**($msg, $level = LOG_ERR)
 

--- a/docs/en/core-libraries/number.md
+++ b/docs/en/core-libraries/number.md
@@ -37,6 +37,8 @@ automatically echo the output into the view.
 
 ## Formatting Currency Values
 
+### Number::currency()
+
 `method` Cake\\I18n\\Number::**currency**(mixed $value, string $currency = null, array $options = [])
 
 This method is used to display a number in common currency formats
@@ -87,6 +89,8 @@ Number::setDefaultCurrencyFormat(Number::FORMAT_CURRENCY_ACCOUNTING);
 
 ## Setting the Default Currency
 
+### Number::setDefaultCurrency()
+
 `method` Cake\\I18n\\Number::**setDefaultCurrency**($currency)
 
 Setter for the default currency. This removes the need to always pass the
@@ -96,6 +100,8 @@ it will clear the currently stored value.
 
 ## Getting the Default Currency
 
+### Number::getDefaultCurrency()
+
 `method` Cake\\I18n\\Number::**getDefaultCurrency**()
 
 Getter for the default currency. If default currency was set earlier using
@@ -103,6 +109,8 @@ Getter for the default currency. If default currency was set earlier using
 retrieve the `intl.default_locale` ini value if set and `'en_US'` if not.
 
 ## Formatting Floating Point Numbers
+
+### Number::precision()
 
 `method` Cake\\I18n\\Number::**precision**(float $value, int $precision = 3, array $options = [])
 
@@ -122,6 +130,8 @@ echo Number::precision(456.91873645, 2);
 ```
 
 ## Formatting Percentages
+
+### Number::toPercentage()
 
 `method` Cake\\I18n\\Number::**toPercentage**(mixed $value, int $precision = 2, array $options = [])
 
@@ -149,6 +159,8 @@ echo Number::toPercentage(0.45691, 1, [
 
 ## Interacting with Human Readable Values
 
+### Number::toReadableSize()
+
 `method` Cake\\I18n\\Number::**toReadableSize**(string $size)
 
 This method formats data sizes in human readable forms. It provides
@@ -172,6 +184,8 @@ echo Number::toReadableSize(5368709120); // 5 GB
 ```
 
 ## Formatting Numbers
+
+### Number::format()
 
 `method` Cake\\I18n\\Number::**format**(mixed $value, array $options = [])
 
@@ -239,6 +253,8 @@ echo Number::format('123456.7890', [
 // Output '123 456,79 !'
 ```
 
+### Number::ordinal()
+
 `method` Cake\\I18n\\Number::**ordinal**(mixed $value, array $options = [])
 
 This method will output an ordinal number.
@@ -262,6 +278,8 @@ echo Number::ordinal(410);
 ```
 
 ## Format Differences
+
+### Number::formatDelta()
 
 `method` Cake\\I18n\\Number::**formatDelta**(mixed $value, array $options = [])
 
@@ -313,6 +331,8 @@ echo Number::formatDelta('123456.7890', [
 <!-- end-cakenumber -->
 
 ## Configure formatters
+
+### Number::config()
 
 `method` Cake\\I18n\\Number::**config**(string $locale, int $type = NumberFormatter::DECIMAL, array $options = [])
 

--- a/docs/en/core-libraries/plugin.md
+++ b/docs/en/core-libraries/plugin.md
@@ -6,6 +6,8 @@ The Plugin class is responsible for resource location and path management of plu
 
 ## Locating Plugins
 
+### Plugin::path()
+
 `static` Cake\\Core\\Plugin::**path**(string $plugin)
 
 Plugins can be located with Plugin. Using `Plugin::path('DebugKit');`
@@ -27,6 +29,8 @@ Use `Plugin::loaded()` if you want to get a list of all currently loaded plugins
 
 ## Finding Paths to Namespaces
 
+### Plugin::classPath()
+
 `static` Cake\\Core\\Plugin::**classPath**(string $plugin)
 
 Used to get the location of the plugin's class files:
@@ -36,6 +40,8 @@ $path = App::classPath('DebugKit');
 ```
 
 ## Finding Paths to Resources
+
+### Plugin::templatePath()
 
 `static` Cake\\Core\\Plugin::**templatePath**(string $plugin)
 

--- a/docs/en/core-libraries/security.md
+++ b/docs/en/core-libraries/security.md
@@ -8,7 +8,11 @@ hashing and encrypting data.
 
 ## Encrypting and Decrypting Data
 
+### Security::encrypt()
+
 `static` Cake\\Utility\\Security::**encrypt**($text, $key, $hmacSalt = null)
+
+### Security::decrypt()
 
 `static` Cake\\Utility\\Security::**decrypt**($cipher, $key, $hmacSalt = null)
 
@@ -51,6 +55,8 @@ If the value cannot be decrypted due to changes in the key or HMAC salt
 
 ## Hashing Data
 
+### Security::hash()
+
 `static` Cake\\Utility\\Security::**hash**( $string, $type = NULL, $salt = false )
 
 Create a hash from string using given method. Fallback on next
@@ -83,6 +89,8 @@ And any other hash algorithm that PHP's `hash()` function supports.
 
 ## Getting Secure Random Data
 
+### Security::randomBytes()
+
 `static` Cake\\Utility\\Security::**randomBytes**($length)
 
 Get `$length` number of bytes from a secure random source. This function draws
@@ -93,6 +101,8 @@ data from one of the following sources:
 
 If neither source is available a warning will be emitted and an unsafe value
 will be used for backwards compatibility reasons.
+
+### Security::randomString()
 
 `static` Cake\\Utility\\Security::**randomString**($length)
 

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -38,6 +38,8 @@ class UsersController extends AppController
 
 ## Convert Strings into ASCII
 
+### Text::transliterate()
+
 `static` Cake\\Utility\\Text::**transliterate**($string, $transliteratorId = null)
 
 Transliterate by default converts all characters in provided string into
@@ -59,6 +61,8 @@ Text::transliterate('Übérmensch', 'Latin-ASCII;');
 ```
 
 ## Creating URL Safe Strings
+
+### Text::slug()
 
 `static` Cake\\Utility\\Text::**slug**(string $string, array|string $options = [])
 
@@ -90,6 +94,8 @@ options are:
   ```
 
 ## Generating UUIDs
+
+### Text::uuid()
 
 `static` Cake\\Utility\\Text::**uuid**()
 
@@ -124,6 +130,8 @@ be used instead of the default UUID generation method.
 
 ## Simple String Parsing
 
+### Text::tokenize()
+
 `static` Cake\\Utility\\Text::**tokenize**(string $data, string $separator = ',', string $leftBound = '(', string $rightBound = ')')
 
 Tokenizes a string using `$separator`, ignoring any instance of `$separator`
@@ -139,6 +147,8 @@ $result = Text::tokenize($data, ' ', "'", "'");
 ['cakephp', "'great framework'", 'php'];
 ```
 
+### Text::parseFileSize()
+
 `method` Cake\\Utility\\Text::**parseFileSize**(string $size, mixed $default = false)
 
 This method unformats a number from a human-readable byte size to an integer
@@ -149,6 +159,8 @@ $int = Text::parseFileSize('2GB');
 ```
 
 ## Formatting Strings
+
+### Text::insert()
 
 `static` Cake\\Utility\\Text::**insert**(string $str, array $data, array $options = [])
 
@@ -162,6 +174,8 @@ Text::insert(
 );
 // Returns: "My name is Bob and I am 65 years old."
 ```
+
+### Text::cleanInsert()
 
 `static` Cake\\Utility\\Text::**cleanInsert**(string $str, array $options)
 
@@ -185,6 +199,8 @@ $options = [
 
 ## Wrapping Text
 
+### Text::wrap()
+
 `static` Cake\\Utility\\Text::**wrap**(string $text, array|int $options = [])
 
 Wraps a block of text to a set width and indents blocks as well.
@@ -206,6 +222,8 @@ supported options are:
 - `wordWrap` Whether or not to wrap whole words. Defaults to `true`.
 - `indent` The character to indent lines with. Defaults to ''.
 - `indentAt` The line number to start indenting text. Defaults to 0.
+
+### Text::wrapBlock()
 
 `static` Cake\\Utility\\Text::**wrapBlock**(string $text, array|int $options = [])
 
@@ -232,6 +250,8 @@ This is the song that
 <!-- start-text -->
 
 ## Highlighting Substrings
+
+### Text::highlight()
 
 `method` Cake\\Utility\\Text::**highlight**(string $text, array|string $phrase, array $options = [])
 
@@ -271,6 +291,8 @@ Output:
 > \$options\['format'\] string specified or a default string.
 
 ## Truncating Text
+
+### Text::truncate()
 
 `method` Cake\\Utility\\Text::**truncate**(string $text, int $length = 100, array $options = [])
 
@@ -322,6 +344,8 @@ Output:
     The killer crept...
 
 ## Truncating the Tail of a String
+
+### Text::tail()
 
 `method` Cake\\Utility\\Text::**tail**(string $text, int $length = 100, array $options = [])
 
@@ -376,6 +400,8 @@ Output:
 
 ## Extracting an Excerpt
 
+### Text::excerpt()
+
 `method` Cake\\Utility\\Text::**excerpt**(string $text, string $phrase, int $radius = 100, string $ellipsis = '…')
 
 Extracts an excerpt from `$text` surrounding the `$phrase` with a number
@@ -399,6 +425,8 @@ Output:
     handy for search results. The query...
 
 ## Converting an Array to Sentence Form
+
+### Text::toList()
 
 `method` Cake\\Utility\\Text::**toList**(array $list, ?string $and = null, $separator = ', ')
 

--- a/docs/en/core-libraries/time.md
+++ b/docs/en/core-libraries/time.md
@@ -147,6 +147,8 @@ echo $time->timezoneName; // America/New_York
 
 ## Formatting
 
+### DateTime::setJsonEncodeFormat()
+
 `static` Cake\\I18n\\DateTime::**setJsonEncodeFormat**($format)
 
 This method sets the default format used when converting an object to json:
@@ -174,6 +176,8 @@ Date::setJsonEncodeFormat(static function($time) {
 ::: info Changed in version 4.1.0
 The `callable` parameter type was added.
 :::
+
+### DateTime::i18nFormat()
 
 `method` Cake\\I18n\\DateTime::**i18nFormat**($format = null, $timezone = null, $locale = null)
 
@@ -240,6 +244,8 @@ The following calendar types are supported:
 > For constant strings i.e. IntlDateFormatter::FULL Intl uses ICU library
 > that feeds its data from CLDR (<https://cldr.unicode.org/>) which version
 > may vary depending on PHP installation and give different results.
+
+### DateTime::nice()
 
 `method` Cake\\I18n\\DateTime::**nice**()
 
@@ -333,6 +339,8 @@ format string.
 
 ### Formatting Relative Times
 
+### DateTime::timeAgoInWords()
+
 `method` Cake\\I18n\\DateTime::**timeAgoInWords**(array $options = [])
 
 Often it is useful to print times relative to the present:
@@ -370,7 +378,11 @@ echo $time->timeAgoInWords([
 
 ## Conversion
 
+### DateTime::toQuarter()
+
 `method` Cake\\I18n\\DateTime::**toQuarter**()
+
+### DateTime::toQuarterRange()
 
 `method` Cake\\I18n\\DateTime::**toQuarterRange**()
 
@@ -401,11 +413,19 @@ $range = $time->toQuarterRange();
 
 ## Comparing With the Present
 
+### DateTime::isYesterday()
+
 `method` Cake\\I18n\\DateTime::**isYesterday**()
+
+### DateTime::isThisWeek()
 
 `method` Cake\\I18n\\DateTime::**isThisWeek**()
 
+### DateTime::isThisMonth()
+
 `method` Cake\\I18n\\DateTime::**isThisMonth**()
+
+### DateTime::isThisYear()
 
 `method` Cake\\I18n\\DateTime::**isThisYear**()
 
@@ -425,6 +445,8 @@ not the `DateTime` instance matches the present.
 
 ## Comparing With Intervals
 
+### DateTime::isWithinNext()
+
 `method` Cake\\I18n\\DateTime::**isWithinNext**($interval)
 
 You can see if a `DateTime` instance falls within a given range using
@@ -439,6 +461,8 @@ debug($time->isWithinNext('2 days'));
 // Within 2 next weeks. Outputs 'true'
 debug($time->isWithinNext('2 weeks'));
 ```
+
+### DateTime::wasWithinLast()
 
 `method` Cake\\I18n\\DateTime::**wasWithinLast**($interval)
 

--- a/docs/en/core-libraries/xml.md
+++ b/docs/en/core-libraries/xml.md
@@ -7,6 +7,8 @@ DOMDocument objects, and back into arrays again.
 
 ## Loading XML documents
 
+### Xml::build()
+
 `static` Cake\\Utility\\Xml::**build**($input, array $options = [])
 
 You can load XML-ish data using `Xml::build()`. Depending on your
@@ -74,6 +76,8 @@ By default entity loading and huge document parsing are disabled. These modes
 can be enabled with the `loadEntities` and `parseHuge` options respectively.
 
 ## Transforming a XML String in Array
+
+### Xml::toArray()
 
 `static` Cake\\Utility\\Xml::**toArray**($obj)
 


### PR DESCRIPTION
## Summary

Add `### ClassName::methodName()` headers above method signatures in core-libraries documentation to enable anchor links for direct linking to specific methods.

**Files updated (13 files, ~142 methods total):**

| File | Methods |
|------|---------|
| collections.md | 45 |
| caching.md | 18 |
| logging.md | 14 |
| text.md | 14 |
| time.md | 12 |
| number.md | 10 |
| inflector.md | 10 |
| security.md | 5 |
| app.md | 4 |
| email.md | 4 |
| plugin.md | 3 |
| xml.md | 2 |
| httpclient.md | 1 |

Refs https://github.com/cakephp/docs/issues/8120