### PR TITLE
Add ConsoleIo method headers to input-output documentation

### DIFF
--- a/docs/en/console-commands/input-output.md
+++ b/docs/en/console-commands/input-output.md
@@ -214,12 +214,20 @@ $io->createFile('bower.json', $stuff, true);
 
 ## Creating Output
 
-Writing to `stdout` and `stderr` is another common operation in CakePHP:
+### ConsoleIo::out()
+
+Writing to `stdout` is done using the `out()` method:
 
 ``` php
 // Write to stdout
 $io->out('Normal message');
+```
 
+### ConsoleIo::err()
+
+Writing to `stderr` is done using the `err()` method:
+
+``` php
 // Write to stderr
 $io->err('Error message');
 ```


### PR DESCRIPTION
## Summary

- Add method-level `###` headers for `ConsoleIo::out()` and `ConsoleIo::err()` in `console-commands/input-output.md`
- This enables VitePress to generate proper anchor links (`#consoleio-out`, `#consoleio-err`)
- These anchors are referenced by `@link` annotations in `src/Console/ConsoleIo.php`

## Related

- Closes cakephp/docs#8160 (partially)
- cakephp/cakephp#19221