### PR TITLE
Add trailing slashes to directory references

### DIFF
--- a/docs/en/appendices/glossary.md
+++ b/docs/en/appendices/glossary.md
@@ -96,7 +96,7 @@ are part of a plugin:
 ```
 
 routes.php  
-A file in `config` directory that contains routing configuration.
+A file in `config/` directory that contains routing configuration.
 This file is included before each request is processed.
 It should connect all the routes your application needs so
 requests can be routed to the correct controller + action.

--- a/docs/en/appendices/glossary.md
+++ b/docs/en/appendices/glossary.md
@@ -2,30 +2,30 @@
 
 <div class="glossary">
 
-CDN  
+CDN
 Content Delivery Network. A 3rd party vendor you can pay to help
 distribute your content to data centers around the world. This helps
 put your static assets closer to geographically distributed users.
 
-columns  
+columns
 Used in the ORM when referring to the table columns in an database
 table.
 
-CSRF  
+CSRF
 Cross Site Request Forgery. Prevents replay attacks, double
 submissions and forged requests from other domains.
 
-DI Container  
+DI Container
 In `Application::services()` you can configure application services
 and their dependencies. Application services are automatically injected
 into Controller actions, and Command Constructors. See
 [Dependency Injection](../development/dependency-injection).
 
-DSN  
+DSN
 Data Source Name. A connection string format that is formed like a URI.
 CakePHP supports DSNs for Cache, Database, Log and Email connections.
 
-dot notation  
+dot notation
 Dot notation defines an array path, by separating nested levels with `.`
 For example:
 
@@ -43,17 +43,17 @@ Would point to the following value:
 ]
 ```
 
-DRY  
+DRY
 Don't repeat yourself. Is a principle of software development aimed at
 reducing repetition of information of all kinds. In CakePHP DRY is used
 to allow you to code things once and re-use them across your
 application.
 
-fields  
+fields
 A generic term used to describe both entity properties, or database
 columns. Often used in conjunction with the FormHelper.
 
-HTML attributes  
+HTML attributes
 An array of key =\> values that are composed into HTML attributes. For example:
 
 ``` text
@@ -75,15 +75,15 @@ can be used:
 checked="checked"
 ```
 
-PaaS  
+PaaS
 Platform as a Service. Platform as a Service providers will provide
 cloud based hosting, database and caching resources. Some popular
 providers include Heroku, EngineYard and PagodaBox
 
-properties  
+properties
 Used when referencing columns mapped onto an ORM entity.
 
-plugin syntax  
+plugin syntax
 Plugin syntax refers to the dot separated class name indicating classes
 are part of a plugin:
 
@@ -95,13 +95,13 @@ are part of a plugin:
 'AcmeCorp/Tools.Toolbar'
 ```
 
-routes.php  
-A file in `config/` directory that contains routing configuration.
+routes.php
+A file in the `config/` directory that contains routing configuration.
 This file is included before each request is processed.
 It should connect all the routes your application needs so
 requests can be routed to the correct controller + action.
 
-routing array  
+routing array
 An array of attributes that are passed to `Router::url()`.
 They typically look like:
 

--- a/docs/en/console-commands/i18n.md
+++ b/docs/en/console-commands/i18n.md
@@ -39,8 +39,8 @@ This will generate the required POT files used in the plugins.
 
 Sometimes, you might need to extract strings from more than one directory of
 your application. For instance, if you are defining some strings in the
-`config` directory of your application, you probably want to extract strings
-from this directory as well as from the `src` directory. You can do it by
+`config/` directory of your application, you probably want to extract strings
+from this directory as well as from the `src/` directory. You can do it by
 using the `--paths` option. It takes a comma-separated list of absolute paths
 to extract:
 

--- a/docs/en/core-libraries/app.md
+++ b/docs/en/core-libraries/app.md
@@ -44,7 +44,7 @@ The method returns paths set using `App.paths` app config:
 App::path('templates');
 ```
 
-The same way you can retrieve paths for `locales/`, `plugins/`.
+The same way you can retrieve paths for `locales` and `plugins`.
 
 ## Finding Paths to Namespaces
 

--- a/docs/en/core-libraries/app.md
+++ b/docs/en/core-libraries/app.md
@@ -44,7 +44,7 @@ The method returns paths set using `App.paths` app config:
 App::path('templates');
 ```
 
-The same way you can retrieve paths for `locales`, `plugins`.
+The same way you can retrieve paths for `locales/`, `plugins/`.
 
 ## Finding Paths to Namespaces
 

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -152,7 +152,7 @@ Emails are often much more than just a simple text message. In order
 to facilitate that, CakePHP provides a way to send emails using CakePHP's
 [view layer](../views).
 
-The templates for emails reside in a special folder `templates/email` of your
+The templates for emails reside in a special folder `templates/email/` of your
 application. Mailer views can also use layouts and elements just like normal views:
 
 ``` php

--- a/docs/en/deployment.md
+++ b/docs/en/deployment.md
@@ -71,7 +71,7 @@ sure it doesn't have any obvious leaks:
   of mass-assignment issues.
 - Ensure your models have the correct [Validation](core-libraries/validation) rules
   enabled.
-- Check that only your `webroot` directory is publicly visible, and that your
+- Check that only your `webroot/` directory is publicly visible, and that your
   secrets (such as your app salt, and any security keys) are private and unique
   as well.
 
@@ -106,8 +106,8 @@ the `plugin` command:
 
     bin/cake plugin assets symlink
 
-The above command will symlink the `webroot` directory of all loaded plugins
-to appropriate path in the app's `webroot` directory.
+The above command will symlink the `webroot/` directory of all loaded plugins
+to appropriate path in the app's `webroot/` directory.
 
 If your filesystem doesn't allow creating symlinks the directories will be
 copied instead of being symlinked. You can also explicitly copy the directories

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -97,11 +97,11 @@ will be used if no environment variable exists for the given key.
 Below is a description of the variables and how they affect your CakePHP
 application.
 
-debug  
+debug
 Changes CakePHP debugging output. `false` = Production mode. No error
 messages, errors, or warnings shown. `true` = Errors and warnings shown.
 
-App.namespace  
+App.namespace
 The namespace to find app classes under.
 
 > [!NOTE]
@@ -112,29 +112,29 @@ The namespace to find app classes under.
 
 <div id="core-configuration-baseurl">
 
-App.baseUrl  
+App.baseUrl
 Un-comment this definition if you **don’t** plan to use Apache’s
 mod_rewrite with CakePHP. Don’t forget to remove your .htaccess
 files too.
 
-App.base  
+App.base
 The base directory the app resides in. If `false` this
 will be auto detected. If not `false`, ensure your string starts
 with a <span class="title-ref">/</span> and does NOT end with a <span class="title-ref">/</span>. For example, <span class="title-ref">/basedir</span> is a valid
 App.base.
 
-App.encoding  
+App.encoding
 Define what encoding your application uses. This encoding
 is used to generate the charset in the layout, and encode entities.
 It should match the encoding values specified for your database.
 
-App.webroot  
+App.webroot
 The webroot directory.
 
-App.wwwRoot  
+App.wwwRoot
 The file path to webroot.
 
-App.fullBaseUrl  
+App.fullBaseUrl
 The fully qualified domain name (including protocol) to your application's
 root. This is used when generating absolute URLs. By default this value
 is generated using the `$_SERVER` environment. However, you should define it
@@ -144,34 +144,34 @@ In a CLI context (from command) the <span class="title-ref">fullBaseUrl</span> c
 as there is no webserver involved. You do need to specify it yourself if
 you do need to generate URLs from a shell (for example, when sending emails).
 
-App.imageBaseUrl  
+App.imageBaseUrl
 Web path to the public images directory under webroot. If you are using
 a `CDN` you should set this value to the CDN's location.
 
-App.cssBaseUrl  
+App.cssBaseUrl
 Web path to the public css directory under webroot. If you are using
 a `CDN` you should set this value to the CDN's location.
 
-App.jsBaseUrl  
+App.jsBaseUrl
 Web path to the public js directory under webroot. If you are using
 a `CDN` you should set this value to the CDN's location.
 
-App.paths  
+App.paths
 Configure paths for non class based resources. Supports the
-`plugins/`, `templates/`, `locales/` subkeys, which allow the definition
+`plugins`, `templates`, `locales` subkeys, which allow the definition
 of paths for plugins, view templates and locale files respectively.
 
-App.uploadedFilesAsObjects  
+App.uploadedFilesAsObjects
 Defines whether uploaded files are being represented as objects (`true`),
 or arrays (`false`). This option is being treated as enabled by default.
 See the [File Uploads section](../controllers/request-response#request-file-uploads) in the Request &
 Response Objects chapter for more information.
 
-Security.salt  
+Security.salt
 A random string used in hashing. This value is also used as the
 HMAC salt when doing symmetric encryption.
 
-Asset.timestamp  
+Asset.timestamp
 Appends a timestamp which is last modified time of the particular
 file at the end of asset files URLs (CSS, JavaScript, Image) when
 using proper helpers. Valid values:
@@ -180,7 +180,7 @@ using proper helpers. Valid values:
 - (bool) `true` - Appends the timestamp when debug is `true`
 - (string) 'force' - Always appends the timestamp.
 
-Asset.cacheTime  
+Asset.cacheTime
 Sets the asset cache time. This determines the http header `Cache-Control`'s
 `max-age`, and the http header's `Expire`'s time for assets.
 This can take anything that you version of PHP's [strtotime function](https://php.net/manual/en/function.strtotime.php) can take.

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -158,7 +158,7 @@ a `CDN` you should set this value to the CDN's location.
 
 App.paths  
 Configure paths for non class based resources. Supports the
-`plugins`, `templates`, `locales` subkeys, which allow the definition
+`plugins/`, `templates/`, `locales/` subkeys, which allow the definition
 of paths for plugins, view templates and locale files respectively.
 
 App.uploadedFilesAsObjects  

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -127,7 +127,7 @@ The above overrides the timeout and cookie name for the 'php' session
 configuration. The built-in configurations are:
 
 - `php` - Saves sessions with the standard settings in your php.ini file.
-- `cake` - Saves sessions as files inside `tmp/sessions`. This is a
+- `cake` - Saves sessions as files inside `tmp/sessions/`. This is a
   good option when on hosts that don't allow you to write outside your own home
   dir.
 - `database` - Use the built-in database sessions. See below for more

--- a/docs/en/intro/cakephp-folder-structure.md
+++ b/docs/en/intro/cakephp-folder-structure.md
@@ -3,54 +3,53 @@
 After you've downloaded the CakePHP application skeleton, there are a few top
 level folders you should see:
 
-- `bin` holds the Cake console executables so you can execute e.g. `bin/cake bake all`.
+- `bin/` holds the Cake console executables so you can execute e.g. `bin/cake bake all`.
 
-- `config` holds the [Configuration](../development/configuration) files.
+- `config/` holds the [Configuration](../development/configuration) files.
   Database connection details, bootstrapping, core configuration files
   and more should be stored here.
 
-- `plugins` is where the [Plugins](../plugins) your application uses are stored.
+- `plugins/` is where the [Plugins](../plugins) your application uses are stored.
 
-- `logs` contains your log files, can be adjusted via [Log Configuration](../core-libraries/logging.md#logging-configuration).
+- `logs/` contains your log files, can be adjusted via [Log Configuration](../core-libraries/logging.md#logging-configuration).
 
-- `src` will be where your application’s source files like Controllers, Models, Commands etc. will be placed.
+- `src/` will be where your application's source files like Controllers, Models, Commands etc. will be placed.
 
-- `templates` has presentational files placed here:
+- `templates/` has presentational files placed here:
   elements, error pages, layouts, and view template files.
 
-- `resources` is primarily used for the `locales` sub folder storing language files for static internationalization.
+- `resources/` is primarily used for the `locales/` subfolder storing language files for static internationalization.
 
-- `tests` will be where you put the test cases for your application.
+- `tests/` will be where you put the test cases for your application.
 
-- `tmp` is where CakePHP stores temporary data. The actual data it
+- `tmp/` is where CakePHP stores temporary data. The actual data it
   stores depends on how you have CakePHP configured, but this folder
   is usually used to store translation messages, model descriptions and sometimes
   session information.
 
-- `vendor` is where CakePHP and other application dependencies will
+- `vendor/` is where CakePHP and other application dependencies will
   be installed by [Composer](https://getcomposer.org). **Editing these files is not
   advised, as Composer will overwrite your changes next time you update.**
 
-- `webroot` is the public document root of your application. It
+- `webroot/` is the public document root of your application. It
   contains all the files you want to be publicly reachable.
 
-Make sure that the `tmp` and `logs` folders exist and are writable,
+Make sure that the `tmp/` and `logs/` folders exist and are writable,
 otherwise the performance of your application will be severely
-impacted. In debug mode, CakePHP will warn you, if these directories are not
+impacted. In debug mode, CakePHP will warn you if these directories are not
 writable.
 
 ## The src Folder
 
-CakePHP's `src` folder is where you will do most of your application
-development. Let's look a little closer at the folders inside
-`src`.
+CakePHP's `src/` folder is where you will do most of your application
+development. Let's look a little closer at the folders inside.
 
 ### Command
 Contains your application's console commands. See
 [Command Objects](../console-commands/commands) to learn more.
 
 > [!NOTE]
-> The folder `Command` is not present by default.
+> The folder `Command/` is not present by default.
 > It will be auto generated when you create your first command using bake.
 
 ### Console

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -47,7 +47,7 @@ are the plugin's src, tests and any other directories.
 If you install your plugins via `composer` or `bake` you shouldn't need to
 configure class autoloading for your plugins.
 
-If you create a plugin manually under the `plugins` folder then will need to
+If you create a plugin manually under the `plugins/` folder then will need to
 tell `composer` to refresh its autoloading cache:
 
 ``` bash
@@ -655,7 +655,7 @@ plugin implemented an 'Admin' prefix the overriding path would be:
 ## Plugin Assets
 
 A plugin's web assets (but not PHP files) can be served through the plugin's
-`webroot` directory, just like the main application's assets:
+`webroot/` directory, just like the main application's assets:
 
     /plugins/ContactManager/webroot/
                                    css/

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -47,7 +47,7 @@ are the plugin's src, tests and any other directories.
 If you install your plugins via `composer` or `bake` you shouldn't need to
 configure class autoloading for your plugins.
 
-If you create a plugin manually under the `plugins/` folder then will need to
+If you create a plugin manually under the `plugins/` folder then you will need to
 tell `composer` to refresh its autoloading cache:
 
 ``` bash


### PR DESCRIPTION
## Summary

Follow-up to #8169 - adds trailing `/` to backtick-wrapped directory path references across the documentation to clearly distinguish directories from files.

- `webroot` → `webroot/`, `config` → `config/`, `src` → `src/`, etc.
- Applied consistently across 9 files (folder structure page + 8 others)

Also fixed a few grammar issues