### PR TITLE
Add headings for method signatures missing anchors

### DIFF
--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -476,6 +476,8 @@ $recentArticles = $this->fetchTable('Articles')->find('all',
     ->all();
 ```
 
+### fetchModel()
+
 `method` Cake\\Controller\\Controller::**fetchModel**(string|null $modelClass = null, string|null $modelType = null)
 
 The `fetchModel()` method is useful to load non ORM models or ORM tables that
@@ -557,9 +559,15 @@ logic around the request life-cycle:
 By default the following callback methods are connected to related events if the
 methods are implemented by your controllers
 
+#### beforeFilter()
+
 `method` Cake\\Controller\\Controller::**beforeFilter**(EventInterface $event)
 
+#### beforeRender()
+
 `method` Cake\\Controller\\Controller::**beforeRender**(EventInterface $event)
+
+#### afterFilter()
 
 `method` Cake\\Controller\\Controller::**afterFilter**(EventInterface $event)
 

--- a/docs/en/orm/deleting-data.md
+++ b/docs/en/orm/deleting-data.md
@@ -2,6 +2,8 @@
 
 `class` Cake\\ORM\\**Table**
 
+## Deleting a Single Entity
+
 `method` Cake\\ORM\\Table::**delete**(EntityInterface $entity, array $options = [])
 
 Once you've loaded an entity you can delete it by calling the originating
@@ -79,6 +81,8 @@ $this->Articles->deleteManyOrFail($entities);
 
 The `$options` for these methods are the same as `delete()`. Deleting
 records with these method **will** trigger events.
+
+### deleteAll()
 
 `method` Cake\\ORM\\Table::**deleteAll**($conditions)
 

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -95,7 +95,11 @@ echo $article->title;
 
 You can also use the `get()` and `set()` methods.
 
+### set()
+
 `method` Cake\\ORM\\Entity::**set**($field, $value = null, array $options = [])
+
+### get()
 
 `method` Cake\\ORM\\Entity::**get**($field)
 
@@ -105,6 +109,8 @@ For example:
 $article->set('title', 'This is my first post');
 echo $article->get('title');
 ```
+
+### patch()
 
 `method` Cake\\ORM\\Entity::**patch**(array $fields, array $options = [])
 

--- a/docs/en/views/helpers.md
+++ b/docs/en/views/helpers.md
@@ -375,14 +375,26 @@ subscribe your helper to the relevant event. Unlike previous versions of CakePHP
 you should *not* call `parent` in your callbacks, as the base Helper class
 does not implement any of the callback methods.
 
+#### beforeRenderFile()
+
 `method` Helper::**beforeRenderFile**(EventInterface $event, $viewFile)
+
+#### afterRenderFile()
 
 `method` Helper::**afterRenderFile**(EventInterface $event, $viewFile, $content)
 
+#### beforeRender()
+
 `method` Helper::**beforeRender**(EventInterface $event, $viewFile)
+
+#### afterRender()
 
 `method` Helper::**afterRender**(EventInterface $event, $viewFile)
 
+#### beforeLayout()
+
 `method` Helper::**beforeLayout**(EventInterface $event, $layoutFile)
+
+#### afterLayout()
 
 `method` Helper::**afterLayout**(EventInterface $event, $layoutFile)

--- a/docs/en/views/helpers/html.md
+++ b/docs/en/views/helpers/html.md
@@ -425,6 +425,8 @@ Will output:
 Also check `Cake\View\Helper\UrlHelper::build()` method
 for more examples of different types of URLs.
 
+### Creating Links from Route Paths
+
 `method` Cake\\View\\Helper\\HtmlHelper::**linkFromPath**(string $title, string $path, array $params = [], array $options = [])
 
 If you want to use route path strings, you can do that using this method:
@@ -591,6 +593,8 @@ $this->Html->scriptBlock('alert("hi")', ['defer' => true]);
 // Buffer a script block to be output later.
 $this->Html->scriptBlock('alert("hi")', ['block' => true]);
 ```
+
+### Starting and Ending Script Blocks
 
 `method` Cake\\View\\Helper\\HtmlHelper::**scriptStart**(array $options = [])
 

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -187,6 +187,8 @@ The lock option can be used to lock sorting into the specified direction:
 echo $this->Paginator->sort('user_id', null, ['direction' => 'asc', 'lock' => true]);
 ```
 
+### Getting Sort Direction and Key
+
 `method` Cake\\View\\Helper\\PaginatorHelper::**sortDir**(string $model = null, mixed $options = [])
 
 `method` Cake\\View\\Helper\\PaginatorHelper::**sortKey**(string $model = null, mixed $options = [])
@@ -247,11 +249,19 @@ In addition to generating links that go directly to specific page numbers,
 you'll often want links that go to the previous and next links, first and last
 pages in the paged data set.
 
+### prev()
+
 `method` Cake\\View\\Helper\\PaginatorHelper::**prev**($title = '<< Previous', $options = [])
+
+### next()
 
 `method` Cake\\View\\Helper\\PaginatorHelper::**next**($title = 'Next >>', $options = [])
 
+### first()
+
 `method` Cake\\View\\Helper\\PaginatorHelper::**first**($first = '<< first', $options = [])
+
+### last()
 
 `method` Cake\\View\\Helper\\PaginatorHelper::**last**($last = 'last >>', $options = [])
 
@@ -270,13 +280,23 @@ echo $this->Paginator->meta(['first' => true, 'last' => true]);
 
 ### Checking the Pagination State
 
+#### current()
+
 `method` Cake\\View\\Helper\\PaginatorHelper::**current**()
+
+#### hasNext()
 
 `method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**(string $model = null)
 
+#### hasPrev()
+
 `method` Cake\\View\\Helper\\PaginatorHelper::**hasPrev**()
 
+#### hasPage()
+
 `method` Cake\\View\\Helper\\PaginatorHelper::**hasPage**(int $page = 1)
+
+#### total()
 
 `method` Cake\\View\\Helper\\PaginatorHelper::**total**()
 

--- a/docs/en/views/helpers/url.md
+++ b/docs/en/views/helpers/url.md
@@ -111,6 +111,8 @@ $this->Url->build('/posts', [
 ]);
 ```
 
+### Building URLs from Route Paths
+
 `method` Cake\\View\\Helper\\UrlHelper::**buildFromPath**(string $path, array $params = [], array $options = [])
 
 If you want to use route path strings, you can do that using this method:


### PR DESCRIPTION
## Summary

Adds headings above method signatures that previously had no anchor, enabling direct URL linking to individual methods in the documentation.

Methods that were documented inline without their own heading now have `###` or `####` headings depending on their nesting level:

- **views/helpers/html.md**: `linkFromPath()`, `scriptStart()`/`scriptEnd()`
- **views/helpers/paginator.md**: `sortDir()`, `sortKey()`, `prev()`, `next()`, `first()`, `last()`, `current()`, `hasNext()`, `hasPrev()`, `hasPage()`, `total()`
- **views/helpers/url.md**: `buildFromPath()`
- **views/helpers.md**: 6 helper callback methods (`beforeRenderFile`, `afterRenderFile`, `beforeRender`, `afterRender`, `beforeLayout`, `afterLayout`)
- **controllers.md**: `fetchModel()`, `beforeFilter()`, `beforeRender()`, `afterFilter()`
- **orm/deleting-data.md**: `delete()`, `deleteAll()`
- **orm/entities.md**: `set()`, `get()`, `patch()`