### PR TITLE
Add return types to method signatures

### DIFF
--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -619,7 +619,7 @@ The `beforeExecute()` and `afterExecute()` hook methods were added.
 
 ### beforeExecute()
 
-`method` Cake\\Console\\Command::**beforeExecute**(EventInterface $event, Arguments $args, ConsoleIo $io)
+`method` Cake\\Console\\Command::**beforeExecute**(EventInterface $event, Arguments $args, ConsoleIo $io): void
 
 Called before the `execute()` method runs. Useful for initialization and
 validation:
@@ -644,7 +644,7 @@ class MyCommand extends Command
 
 ### afterExecute()
 
-`method` Cake\\Console\\Command::**afterExecute**(EventInterface $event, Arguments $args, ConsoleIo $io)
+`method` Cake\\Console\\Command::**afterExecute**(EventInterface $event, Arguments $args, ConsoleIo $io): void
 
 Called after the `execute()` method completes. Useful for cleanup and
 logging:

--- a/docs/en/console-commands/input-output.md
+++ b/docs/en/console-commands/input-output.md
@@ -181,7 +181,7 @@ The `BannerHelper` was added in 5.1
 
 ## Getting User Input
 
-`method` Cake\\Console\\ConsoleIo::**ask**($question, $choices = null, $default = null)
+`method` Cake\\Console\\ConsoleIo::**ask**($question, $choices = null, $default = null): string
 
 When building interactive console applications you'll need to get user input.
 CakePHP provides a way to do this:
@@ -198,7 +198,7 @@ Selection validation is case-insensitive.
 
 ## Creating Files
 
-`method` Cake\\Console\\ConsoleIo::**createFile**($path, $contents)
+`method` Cake\\Console\\ConsoleIo::**createFile**($path, $contents): bool
 
 Creating files is often important part of many console commands that help
 automate development and deployment. The `createFile()` method gives you

--- a/docs/en/console-commands/option-parsers.md
+++ b/docs/en/console-commands/option-parsers.md
@@ -212,7 +212,7 @@ included its default value would be `false`, and when defined it will be
 
 ### Building a ConsoleOptionParser from an Array
 
-`method` Cake\\Console\\ConsoleOptionParser::**buildFromArray**($spec)
+`method` Cake\\Console\\ConsoleOptionParser::**buildFromArray**($spec): static
 
 Option parsers can also be defined as arrays. Within the array, you can define
 keys for `arguments`, `options`, `description` and `epilog`. The values

--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -612,7 +612,7 @@ As of 4.1.0 you can also raise a `RedirectException` to signal a redirect.
 
 ## Controller Middleware
 
-`method` Cake\\Controller\\Controller::**middleware**($middleware, array $options = [])
+`method` Cake\\Controller\\Controller::**middleware**($middleware, array $options = []): void
 
 [Middleware](controllers/middleware) can be defined globally, in
 a routing scope or within a controller. To define middleware for a specific

--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -561,15 +561,15 @@ methods are implemented by your controllers
 
 #### beforeFilter()
 
-`method` Cake\\Controller\\Controller::**beforeFilter**(EventInterface $event)
+`method` Cake\\Controller\\Controller::**beforeFilter**(EventInterface $event): void
 
 #### beforeRender()
 
-`method` Cake\\Controller\\Controller::**beforeRender**(EventInterface $event)
+`method` Cake\\Controller\\Controller::**beforeRender**(EventInterface $event): void
 
 #### afterFilter()
 
-`method` Cake\\Controller\\Controller::**afterFilter**(EventInterface $event)
+`method` Cake\\Controller\\Controller::**afterFilter**(EventInterface $event): void
 
 In addition to controller life-cycle callbacks, [Components](controllers/components)
 also provide a similar set of callbacks.

--- a/docs/en/controllers/components.md
+++ b/docs/en/controllers/components.md
@@ -306,15 +306,15 @@ $controller = $this->getController();
 Components also offer a few request life-cycle callbacks that allow them to
 augment the request cycle.
 
-`method` Class::**beforeFilter**(EventInterface $event)
+`method` Class::**beforeFilter**(EventInterface $event): void
 
-`method` Class::**startup**(EventInterface $event)
+`method` Class::**startup**(EventInterface $event): void
 
-`method` Class::**beforeRender**(EventInterface $event)
+`method` Class::**beforeRender**(EventInterface $event): void
 
-`method` Class::**afterFilter**(EventInterface $event)
+`method` Class::**afterFilter**(EventInterface $event): void
 
-`method` Class::**beforeRedirect**(EventInterface $event, $url, Response $response)
+`method` Class::**beforeRedirect**(EventInterface $event, $url, Response $response): void
 
 <a id="redirect-component-events"></a>
 

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -83,7 +83,7 @@ are also all found in the routing parameters:
 
 ### Query String Parameters
 
-`method` Cake\\Http\\ServerRequest::**getQuery**($name, $default = null)
+`method` Cake\\Http\\ServerRequest::**getQuery**($name, $default = null): mixed
 
 Query string parameters can be read using the `getQuery()` method:
 
@@ -143,7 +143,7 @@ Casting functions were added.
 
 ### Request Body Data
 
-`method` Cake\\Http\\ServerRequest::**getData**($name, $default = null)
+`method` Cake\\Http\\ServerRequest::**getData**($name, $default = null): mixed
 
 All POST data normally available through PHP's `$_POST` global variable can be
 accessed using `Cake\Http\ServerRequest::getData()`. For example:
@@ -231,7 +231,7 @@ Unlike `Cake\Http\ServerRequest::getData()`, `Cake\Http\ServerRequest::getUpload
 only return data when an actual file upload exists for the given path, if there is regular, non-file request body data
 present at the given path, then this method will return `null`, just like it would for any non-existent path.
 
-`method` Cake\\Http\\ServerRequest::**getUploadedFiles**()
+`method` Cake\\Http\\ServerRequest::**getUploadedFiles**(): array
 
 Returns all uploaded files in a normalized array structure. For the above example with the file input name of
 `attachment`, the structure would look like:
@@ -244,7 +244,7 @@ Returns all uploaded files in a normalized array structure. For the above exampl
 ]
 ```
 
-`method` Cake\\Http\\ServerRequest::**withUploadedFiles**(array $files)
+`method` Cake\\Http\\ServerRequest::**withUploadedFiles**(array $files): static
 
 This method sets the uploaded files of the request object, it accepts an array of objects that implement
 [\Psr\Http\Message\UploadedFileInterface](https://www.php-fig.org/psr/psr-7/#16-uploaded-files). It will
@@ -304,7 +304,7 @@ types making the parsed data available in `$request->getData()` and
 
 ### Environment Variables (from \$\_SERVER and \$\_ENV)
 
-`method` Cake\\Http\\ServerRequest::**getEnv**($key, $default = null)
+`method` Cake\\Http\\ServerRequest::**getEnv**($key, $default = null): string|null
 
 `ServerRequest::getEnv()` is a wrapper for `getenv()` global function and acts as
 a getter for environment variables without possible undefined keys:
@@ -319,7 +319,7 @@ To access all the environment variables in a request use `getServerParams()`:
 $env = $this->request->getServerParams();
 ```
 
-`method` Cake\\Http\\ServerRequest::**withEnv**($key, $value)
+`method` Cake\\Http\\ServerRequest::**withEnv**($key, $value): static
 
 `ServerRequest::withEnv()` is a wrapper for `putenv()` global function and acts as
 a setter for environment variables without having to modify globals
@@ -376,7 +376,7 @@ $base = $request->getAttribute('webroot');
 
 ### Checking Request Conditions
 
-`method` Cake\\Http\\ServerRequest::**is**($type, $args...)
+`method` Cake\\Http\\ServerRequest::**is**($type, $args...): bool
 
 The request object provides a way to inspect certain conditions in a given
 request. By using the `is()` method you can check a number of common
@@ -403,7 +403,7 @@ detectors. There are different types of detectors that you can create:
   to handle the check. The callback will receive the request object as its only
   parameter.
 
-`method` Cake\\Http\\ServerRequest::**addDetector**($name, $options)
+`method` Cake\\Http\\ServerRequest::**addDetector**($name, $options): void
 
 Some examples would be:
 
@@ -500,7 +500,7 @@ to use the session object.
 
 ### Host and Domain Name
 
-`method` Cake\\Http\\ServerRequest::**domain**($tldLength = 1)
+`method` Cake\\Http\\ServerRequest::**domain**($tldLength = 1): string
 
 Returns the domain name your application is running on:
 
@@ -509,7 +509,7 @@ Returns the domain name your application is running on:
 echo $request->domain();
 ```
 
-`method` Cake\\Http\\ServerRequest::**subdomains**($tldLength = 1)
+`method` Cake\\Http\\ServerRequest::**subdomains**($tldLength = 1): array
 
 Returns the subdomains your application is running on as an array:
 
@@ -518,7 +518,7 @@ Returns the subdomains your application is running on as an array:
 $subdomains = $request->subdomains();
 ```
 
-`method` Cake\\Http\\ServerRequest::**host**()
+`method` Cake\\Http\\ServerRequest::**host**(): string|null
 
 Returns the host your application is on:
 
@@ -529,7 +529,7 @@ echo $request->host();
 
 ### Reading the HTTP Method
 
-`method` Cake\\Http\\ServerRequest::**getMethod**()
+`method` Cake\\Http\\ServerRequest::**getMethod**(): string
 
 Returns the HTTP method the request was made with:
 
@@ -540,7 +540,7 @@ echo $request->getMethod();
 
 ### Restricting Which HTTP method an Action Accepts
 
-`method` Cake\\Http\\ServerRequest::**allowMethod**($methods)
+`method` Cake\\Http\\ServerRequest::**allowMethod**($methods): bool
 
 Set allowed HTTP methods. If not matched, will throw
 `MethodNotAllowedException`. The 405 response will include the required
@@ -574,11 +574,11 @@ $hasAcceptHeader = $this->request->hasHeader('Accept');
 While some apache installs don't make the `Authorization` header accessible,
 CakePHP will make it available through apache specific methods as required.
 
-`method` Cake\\Http\\ServerRequest::**referer**($local = true)
+`method` Cake\\Http\\ServerRequest::**referer**($local = true): string|null
 
 Returns the referring address for the request.
 
-`method` Cake\\Http\\ServerRequest::**clientIp**()
+`method` Cake\\Http\\ServerRequest::**clientIp**(): string
 
 Returns the current visitor's IP address.
 
@@ -616,7 +616,7 @@ proxy.
 
 ### Checking Accept Headers
 
-`method` Cake\\Http\\ServerRequest::**accepts**($type = null)
+`method` Cake\\Http\\ServerRequest::**accepts**($type = null): array|bool
 
 Find out which content types the client accepts, or check whether it accepts a
 particular type of content.
@@ -633,7 +633,7 @@ Check for a single type:
 $acceptsJson = $this->request->accepts('application/json');
 ```
 
-`method` Cake\\Http\\ServerRequest::**acceptLanguage**($language = null)
+`method` Cake\\Http\\ServerRequest::**acceptLanguage**($language = null): array|bool
 
 Get all the languages accepted by the client,
 or check whether a specific language is accepted.
@@ -731,7 +731,7 @@ tasks such as:
 
 ### Dealing with Content Types
 
-`method` Cake\\Http\\Response::**withType**($contentType = null)
+`method` Cake\\Http\\Response::**withType**($contentType = null): static
 
 You can control the Content-Type of your application's responses with
 `Cake\Http\Response::withType()`. If your application needs to deal
@@ -754,7 +754,7 @@ automatic view switching provided by [Controller Viewclasses](../controllers#con
 
 ### Sending Files
 
-`method` Cake\\Http\\Response::**withFile**(string $path, array $options = [])
+`method` Cake\\Http\\Response::**withFile**(string $path, array $options = []): static
 
 There are times when you want to send files as responses for your requests.
 You can accomplish that by using `Cake\Http\Response::withFile()`:
@@ -850,7 +850,7 @@ redirect location header.
 
 ### Setting the Body
 
-`method` Cake\\Http\\Response::**withStringBody**($string)
+`method` Cake\\Http\\Response::**withStringBody**($string): static
 
 To set a string as the response body, do the following:
 
@@ -905,7 +905,7 @@ $response = $response->withBody($stream);
 
 ### Setting the Character Set
 
-`method` Cake\\Http\\Response::**withCharset**($charset)
+`method` Cake\\Http\\Response::**withCharset**($charset): static
 
 Sets the charset that will be used in the response:
 
@@ -915,7 +915,7 @@ $this->response = $this->response->withCharset('UTF-8');
 
 ### Interacting with Browser Caching
 
-`method` Cake\\Http\\Response::**withDisabledCache**()
+`method` Cake\\Http\\Response::**withDisabledCache**(): static
 
 You sometimes need to force browsers not to cache the results of a controller
 action. `Cake\Http\Response::withDisabledCache()` is intended for just
@@ -933,7 +933,7 @@ public function index()
 > Disabling caching from SSL domains while trying to send
 > files to Internet Explorer can result in errors.
 
-`method` Cake\\Http\\Response::**withCache**($since, $time = '+1 day')
+`method` Cake\\Http\\Response::**withCache**($since, $time = '+1 day'): static
 
 You can also tell clients that you want them to cache responses. By using
 `Cake\Http\Response::withCache()`:
@@ -971,7 +971,7 @@ or reverse proxy caching.
 
 #### The Cache Control Header
 
-`method` Cake\\Http\\Response::**withSharable**($public, $time = null)
+`method` Cake\\Http\\Response::**withSharable**($public, $time = null): static
 
 Used under the expiration model, this header contains multiple indicators that
 can change the way browsers or proxies use the cached content. A
@@ -1012,7 +1012,7 @@ the `Cache-Control` header.
 
 #### The Expiration Header
 
-`method` Cake\\Http\\Response::**withExpires**($time)
+`method` Cake\\Http\\Response::**withExpires**($time): static
 
 You can set the `Expires` header to a date and time after which the response
 is no longer considered fresh. This header can be set using the
@@ -1030,7 +1030,7 @@ be parsed by the `DateTime` class.
 
 #### The Etag Header
 
-`method` Cake\\Http\\Response::**withEtag**($tag, $weak = false)
+`method` Cake\\Http\\Response::**withEtag**($tag, $weak = false): static
 
 Cache validation in HTTP is often used when content is constantly changing, and
 asks the application to only generate the response contents if the cache is no
@@ -1073,7 +1073,7 @@ public function index()
 
 #### The Last Modified Header
 
-`method` Cake\\Http\\Response::**withModified**($time)
+`method` Cake\\Http\\Response::**withModified**($time): static
 
 Also, under the HTTP cache validation model, you can set the `Last-Modified`
 header to indicate the date and time at which the resource was modified for the
@@ -1099,7 +1099,7 @@ public function view()
 
 #### The Vary Header
 
-`method` Cake\\Http\\Response::**withVary**($header)
+`method` Cake\\Http\\Response::**withVary**($header): static
 
 In some cases, you might want to serve different content using the same URL.
 This is often the case if you have a multilingual page or respond with different
@@ -1114,7 +1114,7 @@ $response = $this->response->withVary('Accept-Language');
 
 #### Sending Not-Modified Responses
 
-`method` Cake\\Http\\Response::**isNotModified**(Request $request)
+`method` Cake\\Http\\Response::**isNotModified**(Request $request): bool
 
 Compares the cache headers for the request object with the cache header from the
 response and determines whether it can still be considered fresh. If so, deletes

--- a/docs/en/core-libraries/app.md
+++ b/docs/en/core-libraries/app.md
@@ -8,7 +8,7 @@ The App class is responsible for resource location and path management.
 
 ### App::className()
 
-`static` Cake\\Core\\App::**className**($name, $type = '', $suffix = '')
+`static` Cake\\Core\\App::**className**($name, $type = '', $suffix = ''): string|null
 
 This method is used to resolve class names throughout CakePHP. It resolves
 the short form names CakePHP uses and returns the fully resolved class name:
@@ -35,7 +35,7 @@ class names do not exist, `false` will be returned.
 
 ### App::path()
 
-`static` Cake\\Core\\App::**path**(string $package, ?string $plugin = null)
+`static` Cake\\Core\\App::**path**(string $package, ?string $plugin = null): array
 
 The method returns paths set using `App.paths` app config:
 
@@ -50,7 +50,7 @@ The same way you can retrieve paths for `locales` and `plugins`.
 
 ### App::classPath()
 
-`static` Cake\\Core\\App::**classPath**(string $package, ?string $plugin = null)
+`static` Cake\\Core\\App::**classPath**(string $package, ?string $plugin = null): array
 
 Used to get locations for paths based on conventions:
 
@@ -67,7 +67,7 @@ for.
 
 ### App::core()
 
-`static` Cake\\Core\\App::**core**(string $package)
+`static` Cake\\Core\\App::**core**(string $package): array
 
 Used for finding the path to a package inside CakePHP:
 

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -41,7 +41,7 @@ Regardless of the CacheEngine you choose to use, your application interacts with
 
 ### Cache::setConfig()
 
-`static` Cake\\Cache\\Cache::**setConfig**($key, $config = null)
+`static` Cake\\Cache\\Cache::**setConfig**($key, $config = null): void
 
 Your application can configure any number of 'engines' during its bootstrap
 process. Cache engine configurations are defined in **config/app.php**.
@@ -269,7 +269,7 @@ When there is no fallback cache failures will be raised as exceptions.
 
 ### Cache::drop()
 
-`static` Cake\\Cache\\Cache::**drop**($key)
+`static` Cake\\Cache\\Cache::**drop**($key): bool
 
 Once a configuration is created you cannot change it. Instead you should drop
 the configuration and re-create it using `Cake\Cache\Cache::drop()` and
@@ -280,7 +280,7 @@ the config and destroy the adapter if it was constructed.
 
 ### Cache::write()
 
-`static` Cake\\Cache\\Cache::**write**($key, $value, $config = 'default')
+`static` Cake\\Cache\\Cache::**write**($key, $value, $config = 'default'): bool
 
 `Cache::write()` will write a \$value to the Cache. You can read or
 delete this value later by referring to it by `$key`. You may
@@ -307,7 +307,7 @@ of trips made to the database to fetch posts.
 
 ### Cache::writeMany()
 
-`static` Cake\\Cache\\Cache::**writeMany**($data, $config = 'default')
+`static` Cake\\Cache\\Cache::**writeMany**($data, $config = 'default'): bool
 
 You may find yourself needing to write multiple cache keys at once. While you
 can use multiple calls to `write()`, `writeMany()` allows CakePHP to use
@@ -326,7 +326,7 @@ $result = Cache::writeMany([
 
 ### Cache::add()
 
-`static` Cake\\Cache\\Cache::**add**(string $key, mixed $value, string $config = 'default')
+`static` Cake\\Cache\\Cache::**add**(string $key, mixed $value, string $config = 'default'): bool
 
 Using `Cache::add()` will let you atomically set a key to a value if the key
 does not already exist in the cache. If the key already exists in the cache
@@ -349,7 +349,7 @@ Cache::delete($lockKey);
 
 ### Cache::remember()
 
-`static` Cake\\Cache\\Cache::**remember**($key, $callable, $config = 'default')
+`static` Cake\\Cache\\Cache::**remember**($key, $callable, $config = 'default'): mixed
 
 Cache helps with read-through caching. If the named cache key exists,
 it will be returned. If the key does not exist, the callable will be invoked
@@ -374,7 +374,7 @@ class IssueService
 
 ### Cache::read()
 
-`static` Cake\\Cache\\Cache::**read**($key, $config = 'default')
+`static` Cake\\Cache\\Cache::**read**($key, $config = 'default'): mixed
 
 `Cache::read()` is used to read the cached value stored under
 `$key` from the `$config`. If `$config` is null the default
@@ -439,7 +439,7 @@ $result = Cache::readMany([
 
 ### Cache::delete()
 
-`static` Cake\\Cache\\Cache::**delete**($key, $config = 'default')
+`static` Cake\\Cache\\Cache::**delete**($key, $config = 'default'): bool
 
 `Cache::delete()` will allow you to completely remove a cached
 object from the store:
@@ -458,7 +458,7 @@ Cache::pool('redis')->deleteAsync('my_key');
 
 ### Cache::deleteMany()
 
-`static` Cake\\Cache\\Cache::**deleteMany**($keys, $config = 'default')
+`static` Cake\\Cache\\Cache::**deleteMany**($keys, $config = 'default'): bool
 
 After you've written multiple keys at once, you may want to delete them. While
 you could use multiple calls to `delete()`, `deleteMany()` allows CakePHP to use
@@ -478,7 +478,7 @@ $result = Cache::deleteMany([
 
 ### Cache::clear()
 
-`static` Cake\\Cache\\Cache::**clear**($config = 'default')
+`static` Cake\\Cache\\Cache::**clear**($config = 'default'): bool
 
 Destroy all cached values for a cache configuration. In engines like: Apcu,
 Memcached, the cache configuration's prefix is used to remove
@@ -505,11 +505,11 @@ Cache::pool('redis')->clearBlocking();
 
 ### Cache::increment()
 
-`static` Cake\\Cache\\Cache::**increment**($key, $offset = 1, $config = 'default')
+`static` Cake\\Cache\\Cache::**increment**($key, $offset = 1, $config = 'default'): int|false
 
 ### Cache::decrement()
 
-`static` Cake\\Cache\\Cache::**decrement**($key, $offset = 1, $config = 'default')
+`static` Cake\\Cache\\Cache::**decrement**($key, $offset = 1, $config = 'default'): int|false
 
 Counters in your application are good candidates for storage in a cache. As an
 example, a simple countdown for remaining 'slots' in a contest could be stored
@@ -563,7 +563,7 @@ Cache::setConfig('site_home', [
 
 ### Cache::clearGroup()
 
-`method` Cake\\Cache\\Cache::**clearGroup**($group, $config = 'default')
+`method` Cake\\Cache\\Cache::**clearGroup**($group, $config = 'default'): bool
 
 Let's say you want to store the HTML generated for your homepage in cache, but
 would also want to automatically invalidate this cache every time a comment or
@@ -586,7 +586,7 @@ public function afterSave($event, $entity, $options = [])
 
 ### Cache::groupConfigs()
 
-`static` Cake\\Cache\\Cache::**groupConfigs**($group = null)
+`static` Cake\\Cache\\Cache::**groupConfigs**($group = null): array
 
 `groupConfigs()` can be used to retrieve mapping between group and
 configurations, i.e.: having the same group:
@@ -617,7 +617,7 @@ choose a common prefix for all your configs.
 
 ### Cache::disable()
 
-`static` Cake\\Cache\\Cache::**disable**()
+`static` Cake\\Cache\\Cache::**disable**(): void
 
 You may need to disable all Cache read & writes when trying to figure out cache
 expiration related issues. You can do this using `enable()` and
@@ -632,7 +632,7 @@ Once disabled, all reads and writes will return `null`.
 
 ### Cache::enable()
 
-`static` Cake\\Cache\\Cache::**enable**()
+`static` Cake\\Cache\\Cache::**enable**(): void
 
 Once disabled, you can use `enable()` to re-enable caching:
 
@@ -643,7 +643,7 @@ Cache::enable();
 
 ### Cache::enabled()
 
-`static` Cake\\Cache\\Cache::**enabled**()
+`static` Cake\\Cache\\Cache::**enabled**(): bool
 
 If you need to check on the state of Cache, you can use `enabled()`.
 
@@ -676,15 +676,15 @@ The required API for a CacheEngine is
 
 `method` Cake\\Cache\\CacheEngine::**read**($key)
 
-`method` Cake\\Cache\\CacheEngine::**delete**($key)
+`method` Cake\\Cache\\CacheEngine::**delete**($key): bool
 
-`method` Cake\\Cache\\CacheEngine::**clear**($check)
+`method` Cake\\Cache\\CacheEngine::**clear**($check): bool
 
-`method` Cake\\Cache\\CacheEngine::**clearGroup**($group)
+`method` Cake\\Cache\\CacheEngine::**clearGroup**($group): bool
 
-`method` Cake\\Cache\\CacheEngine::**decrement**($key, $offset = 1)
+`method` Cake\\Cache\\CacheEngine::**decrement**($key, $offset = 1): int|false
 
-`method` Cake\\Cache\\CacheEngine::**increment**($key, $offset = 1)
+`method` Cake\\Cache\\CacheEngine::**increment**($key, $offset = 1): int|false
 
 <a id="cache-events"></a>
 

--- a/docs/en/core-libraries/collections.md
+++ b/docs/en/core-libraries/collections.md
@@ -404,7 +404,7 @@ $ladies = $collection->reject(function ($person, $key) {
 
 ### every()
 
-`method` Cake\\Collection\\Collection::**every**($callback)
+`method` Cake\\Collection\\Collection::**every**($callback): bool
 
 You can do truth tests with filter functions. To see if every element in
 a collection matches a test you can use `every()`:
@@ -418,11 +418,11 @@ $allYoungPeople = $collection->every(function ($person) {
 
 ### any()
 
-`method` Cake\\Collection\\Collection::**any**($callback)
+`method` Cake\\Collection\\Collection::**any**($callback): bool
 
 ### some()
 
-`method` Cake\\Collection\\Collection::**some**($callback)
+`method` Cake\\Collection\\Collection::**some**($callback): bool
 
 You can see if the collection contains at least one element matching a filter
 function using the `any()` method:
@@ -451,7 +451,7 @@ $commentsFromMark = $collection->match(['user.name' => 'Mark']);
 
 ### firstMatch()
 
-`method` Cake\\Collection\\Collection::**firstMatch**($conditions)
+`method` Cake\\Collection\\Collection::**firstMatch**($conditions): mixed
 
 The property name can be a dot-separated path. You can traverse into nested
 entities and match the values they contain. When you only need the first
@@ -474,7 +474,7 @@ against.
 
 ### reduce()
 
-`method` Cake\\Collection\\Collection::**reduce**($callback, $initial)
+`method` Cake\\Collection\\Collection::**reduce**($callback, $initial): mixed
 
 The counterpart of a `map()` operation is usually a `reduce`. This
 function will help you build a single result out of all the elements in a
@@ -499,7 +499,7 @@ $allTags = $collection->reduce(function ($accumulated, $article) {
 
 ### min()
 
-`method` Cake\\Collection\\Collection::**min**(string|callable $callback, $type = SORT_NUMERIC)
+`method` Cake\\Collection\\Collection::**min**(string|callable $callback, $type = SORT_NUMERIC): mixed
 
 To extract the minimum value for a collection based on a property, just use the
 `min()` function. This will return the full element from the collection and
@@ -526,7 +526,7 @@ $personWithYoungestDad = $collection->min('dad.age');
 
 ### max()
 
-`method` Cake\\Collection\\Collection::**max**(string|callable $callback, $type = SORT_NUMERIC)
+`method` Cake\\Collection\\Collection::**max**(string|callable $callback, $type = SORT_NUMERIC): mixed
 
 The same can be applied to the `max()` function, which will return a single
 element from the collection having the highest property value:
@@ -544,7 +544,7 @@ $personWithOldestDad = $collection->max('dad.age');
 
 ### sumOf()
 
-`method` Cake\\Collection\\Collection::**sumOf**($path = null)
+`method` Cake\\Collection\\Collection::**sumOf**($path = null): float|int
 
 Finally, the `sumOf()` method will return the sum of a property of all
 elements:
@@ -562,7 +562,7 @@ $sumOfDadAges = $collection->sumOf('dad.age');
 
 ### avg()
 
-`method` Cake\\Collection\\Collection::**avg**($path = null)
+`method` Cake\\Collection\\Collection::**avg**($path = null): float|int|null
 
 Calculate the average value of the elements in the collection. Optionally
 provide a matcher path, or function to extract values to generate the average
@@ -580,7 +580,7 @@ $average = (new Collection($items))->avg('invoice.total');
 
 ### median()
 
-`method` Cake\\Collection\\Collection::**median**($path = null)
+`method` Cake\\Collection\\Collection::**median**($path = null): float|int|null
 
 Calculate the median value of a set of elements. Optionally provide a matcher
 path, or function to extract values to generate the median for:
@@ -945,7 +945,7 @@ $nested->listNested()->printer(
 
 ### isEmpty()
 
-`method` Cake\\Collection\\Collection::**isEmpty**()
+`method` Cake\\Collection\\Collection::**isEmpty**(): bool
 
 Allows you to see if a collection contains any elements:
 
@@ -961,7 +961,7 @@ $collection->isEmpty();
 
 ### contains()
 
-`method` Cake\\Collection\\Collection::**contains**($value)
+`method` Cake\\Collection\\Collection::**contains**($value): bool
 
 Collections allow you to quickly check if they contain one particular
 value: by using the `contains()` method:
@@ -1071,7 +1071,7 @@ $allExceptFirstTwo = $collection->skip(2)->toList(); // [3, 4]
 
 ### first()
 
-`method` Cake\\Collection\\Collection::**first**()
+`method` Cake\\Collection\\Collection::**first**(): mixed
 
 One of the most common uses of `take()` is getting the first element in the
 collection. A shortcut method for achieving the same goal is using the
@@ -1084,7 +1084,7 @@ $collection->first(); // Returns 5
 
 ### last()
 
-`method` Cake\\Collection\\Collection::**last**()
+`method` Cake\\Collection\\Collection::**last**(): mixed
 
 Similarly, you can get the last element of a collection using the `last()`
 method:

--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -49,7 +49,7 @@ elements, you can use attribute matching with certain methods. They are `extract
 
 ### Hash::get()
 
-`static` Cake\\Utility\\Hash::**get**(array|ArrayAccess $data, $path, $default = null)
+`static` Cake\\Utility\\Hash::**get**(array|ArrayAccess $data, $path, $default = null): mixed
 
 `get()` is a simplified version of `extract()`, it only supports direct
 path expressions. Paths with `{n}`, `{s}`, `{*}` or matchers are not
@@ -175,7 +175,7 @@ $result = Hash::remove($data, '{n}[clear].Item[id=4]');
 
 ### Hash::combine()
 
-`static` Cake\\Utility\\Hash::**combine**(array $data, $keyPath, $valuePath = null, $groupPath = null)
+`static` Cake\\Utility\\Hash::**combine**(array $data, $keyPath, $valuePath = null, $groupPath = null): array
 
 Creates an associative array using a `$keyPath` as the path to build its keys,
 and optionally `$valuePath` as path to get the values. If `$valuePath` is not
@@ -322,7 +322,7 @@ $result = Hash::combine(
 
 ### Hash::format()
 
-`static` Cake\\Utility\\Hash::**format**(array $data, array $paths, $format)
+`static` Cake\\Utility\\Hash::**format**(array $data, array $paths, $format): array|null
 
 Returns a series of values extracted from an array, formatted with a
 format string:
@@ -379,7 +379,7 @@ $res = Hash::format($data, ['{n}.Person.first_name', '{n}.Person.something'], '%
 
 ### Hash::contains()
 
-`static` Cake\\Utility\\Hash::**contains**(array $data, array $needle)
+`static` Cake\\Utility\\Hash::**contains**(array $data, array $needle): bool
 
 Determines if one Hash or array contains the exact keys and values
 of another:
@@ -406,7 +406,7 @@ $result = Hash::contains($b, $a);
 
 ### Hash::check()
 
-`static` Cake\\Utility\\Hash::**check**(array $data, string $path = null)
+`static` Cake\\Utility\\Hash::**check**(array $data, string $path = null): bool
 
 Checks if a particular path is set in an array:
 
@@ -446,7 +446,7 @@ $result = Hash::check($set, 'My Index 1.First.Seconds.Third.Fourth');
 
 ### Hash::filter()
 
-`static` Cake\\Utility\\Hash::**filter**(array $data, $callback = ['Hash', 'filter'])
+`static` Cake\\Utility\\Hash::**filter**(array $data, $callback = ['Hash', 'filter']): array
 
 Filters empty elements out of array, excluding '0'. You can also supply a
 custom `$callback` to filter the array elements. The callback should
@@ -478,7 +478,7 @@ $res = Hash::filter($data);
 
 ### Hash::flatten()
 
-`static` Cake\\Utility\\Hash::**flatten**(array $data, string $separator = '.')
+`static` Cake\\Utility\\Hash::**flatten**(array $data, string $separator = '.'): array
 
 Collapses a multi-dimensional array into a single dimension:
 
@@ -510,7 +510,7 @@ $res = Hash::flatten($arr);
 
 ### Hash::expand()
 
-`static` Cake\\Utility\\Hash::**expand**(array $data, string $separator = '.')
+`static` Cake\\Utility\\Hash::**expand**(array $data, string $separator = '.'): array
 
 Expands an array that was previously flattened with
 `Hash::flatten()`:
@@ -543,7 +543,7 @@ $res = Hash::expand($data);
 
 ### Hash::merge()
 
-`static` Cake\\Utility\\Hash::**merge**(array $data, array $merge[, array $n])
+`static` Cake\\Utility\\Hash::**merge**(array $data, array $merge[, array $n]): array
 
 This function can be thought of as a hybrid between PHP's
 `array_merge` and `array_merge_recursive`. The difference to the two
@@ -596,7 +596,7 @@ $res = Hash::merge($array, $arrayB, $arrayC, $arrayD);
 
 ### Hash::numeric()
 
-`static` Cake\\Utility\\Hash::**numeric**(array $data)
+`static` Cake\\Utility\\Hash::**numeric**(array $data): bool
 
 Checks to see if all the values in the array are numeric:
 
@@ -612,7 +612,7 @@ $res = Hash::numeric($data);
 
 ### Hash::dimensions()
 
-`static` Cake\\Utility\\Hash::**dimensions**(array $data)
+`static` Cake\\Utility\\Hash::**dimensions**(array $data): int
 
 Counts the dimensions of an array. This method will only
 consider the dimension of the first element in the array:
@@ -641,7 +641,7 @@ $result = Hash::dimensions($data);
 
 ### Hash::maxDimensions()
 
-`static` Cake\\Utility\\Hash::**maxDimensions**(array $data)
+`static` Cake\\Utility\\Hash::**maxDimensions**(array $data): int
 
 Similar to `~Hash::dimensions()`, however this method returns,
 the deepest number of dimensions of any element in the array:
@@ -658,7 +658,7 @@ $result = Hash::maxDimensions($data);
 
 ### Hash::map()
 
-`static` Cake\\Utility\\Hash::**map**(array $data, $path, $function)
+`static` Cake\\Utility\\Hash::**map**(array $data, $path, $function): array
 
 Creates a new array, by extracting `$path`, and mapping `$function`
 across the results. You can use both expression and matching elements with
@@ -677,7 +677,7 @@ public function noop(array $array)
 
 ### Hash::reduce()
 
-`static` Cake\\Utility\\Hash::**reduce**(array $data, $path, $function)
+`static` Cake\\Utility\\Hash::**reduce**(array $data, $path, $function): mixed
 
 Creates a single value, by extracting `$path`, and reducing the extracted
 results with `$function`. You can use both expression and matching elements
@@ -685,7 +685,7 @@ with this method.
 
 ### Hash::apply()
 
-`static` Cake\\Utility\\Hash::**apply**(array $data, $path, $function)
+`static` Cake\\Utility\\Hash::**apply**(array $data, $path, $function): mixed
 
 Apply a callback to a set of extracted values using `$function`. The function
 will get the extracted values as the first argument:
@@ -707,7 +707,7 @@ $result = Hash::apply($data, '{n}[booked=true].date', 'array_count_values');
 
 ### Hash::sort()
 
-`static` Cake\\Utility\\Hash::**sort**(array $data, $path, $dir, $type = 'regular')
+`static` Cake\\Utility\\Hash::**sort**(array $data, $path, $dir, $type = 'regular'): array
 
 Sorts an array by any value, determined by a [Hash Path Syntax](#hash-path-syntax)
 Only expression elements are supported by this method:
@@ -745,7 +745,7 @@ can be one of the following values:
 
 ### Hash::diff()
 
-`static` Cake\\Utility\\Hash::**diff**(array $data, array $compare)
+`static` Cake\\Utility\\Hash::**diff**(array $data, array $compare): array
 
 Computes the difference between two arrays:
 
@@ -772,7 +772,7 @@ $result = Hash::diff($a, $b);
 
 ### Hash::mergeDiff()
 
-`static` Cake\\Utility\\Hash::**mergeDiff**(array $data, array $compare)
+`static` Cake\\Utility\\Hash::**mergeDiff**(array $data, array $compare): array
 
 This function merges two arrays and pushes the differences in
 data to the bottom of the resultant array.
@@ -820,7 +820,7 @@ $res = Hash::mergeDiff($array1, $array2);
 
 ### Hash::normalize()
 
-`static` Cake\\Utility\\Hash::**normalize**(array $data, $assoc = true, $default = null)
+`static` Cake\\Utility\\Hash::**normalize**(array $data, $assoc = true, $default = null): array
 
 Normalizes an array. If `$assoc` is `true`, the resulting array will be
 normalized to be an associative array. Numeric keys with values, will be
@@ -877,7 +877,7 @@ The `$default` parameter was added.
 
 ### Hash::nest()
 
-`static` Cake\\Utility\\Hash::**nest**(array $data, array $options = [])
+`static` Cake\\Utility\\Hash::**nest**(array $data, array $options = []): array
 
 Takes a flat array set, and creates a nested, or threaded data structure.
 

--- a/docs/en/core-libraries/inflector.md
+++ b/docs/en/core-libraries/inflector.md
@@ -118,11 +118,11 @@ when provided a multi-word argument:
 
 ### Inflector::singularize()
 
-`static` Cake\\Utility\\Inflector::**singularize**($singular)
+`static` Cake\\Utility\\Inflector::**singularize**($singular): string
 
 ### Inflector::pluralize()
 
-`static` Cake\\Utility\\Inflector::**pluralize**($singular)
+`static` Cake\\Utility\\Inflector::**pluralize**($singular): string
 
 Both `pluralize` and `singularize()` work on most English nouns. If you need
 to support other languages, you can use [Inflection Configuration](#inflection-configuration) to
@@ -148,11 +148,11 @@ echo Inflector::singularize('People');
 
 ### Inflector::camelize()
 
-`static` Cake\\Utility\\Inflector::**camelize**($underscored)
+`static` Cake\\Utility\\Inflector::**camelize**($underscored): string
 
 ### Inflector::underscore()
 
-`static` Cake\\Utility\\Inflector::**underscore**($camelCase)
+`static` Cake\\Utility\\Inflector::**underscore**($camelCase): string
 
 These methods are useful when creating class names, or property names:
 
@@ -172,7 +172,7 @@ underscore.
 
 ### Inflector::humanize()
 
-`static` Cake\\Utility\\Inflector::**humanize**($underscored)
+`static` Cake\\Utility\\Inflector::**humanize**($underscored): string
 
 This method is useful when converting underscored forms into "Title Case" forms
 for human readable values:
@@ -186,15 +186,15 @@ Inflector::humanize('apple_pie');
 
 ### Inflector::classify()
 
-`static` Cake\\Utility\\Inflector::**classify**($underscored)
+`static` Cake\\Utility\\Inflector::**classify**($underscored): string
 
 ### Inflector::dasherize()
 
-`static` Cake\\Utility\\Inflector::**dasherize**($dashed)
+`static` Cake\\Utility\\Inflector::**dasherize**($dashed): string
 
 ### Inflector::tableize()
 
-`static` Cake\\Utility\\Inflector::**tableize**($camelCase)
+`static` Cake\\Utility\\Inflector::**tableize**($camelCase): string
 
 When generating code, or using CakePHP's conventions you may need to inflect
 table names or class names:
@@ -214,7 +214,7 @@ Inflector::tableize('UserProfileSetting');
 
 ### Inflector::variable()
 
-`static` Cake\\Utility\\Inflector::**variable**($underscored)
+`static` Cake\\Utility\\Inflector::**variable**($underscored): string
 
 Variable names are often useful when doing meta-programming tasks that involve
 generating code or doing work based on conventions:
@@ -244,7 +244,7 @@ special cases.
 
 ### Inflector::rules()
 
-`static` Cake\\Utility\\Inflector::**rules**($type, $rules, $reset = false)
+`static` Cake\\Utility\\Inflector::**rules**($type, $rules, $reset = false): void
 
 Define new inflection and transliteration rules for Inflector to use. Often,
 this method is used in your **config/bootstrap.php**:

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -450,7 +450,7 @@ configured.
 
 ### Log::setConfig()
 
-`static` Cake\\Log\\Log::**setConfig**($key, $config)
+`static` Cake\\Log\\Log::**setConfig**($key, $config): void
 
 param string \$name
 Name for the logger being connected, used
@@ -465,7 +465,7 @@ more information.
 
 ### Log::configured()
 
-`static` Cake\\Log\\Log::**configured**()
+`static` Cake\\Log\\Log::**configured**(): array
 
 returns
 An array of configured loggers.
@@ -474,7 +474,7 @@ Get the names of the configured loggers.
 
 ### Log::drop()
 
-`static` Cake\\Log\\Log::**drop**($name)
+`static` Cake\\Log\\Log::**drop**($name): bool
 
 param string \$name
 Name of the logger you wish to no longer receive
@@ -482,7 +482,7 @@ messages.
 
 ### Log::write()
 
-`static` Cake\\Log\\Log::**write**($level, $message, $scope = [])
+`static` Cake\\Log\\Log::**write**($level, $message, $scope = []): bool
 
 Write a message into all the configured loggers.
 `$level` indicates the level of log message being created.
@@ -491,7 +491,7 @@ Write a message into all the configured loggers.
 
 ### Log::levels()
 
-`static` Cake\\Log\\Log::**levels**()
+`static` Cake\\Log\\Log::**levels**(): array
 
 Call this method without arguments, eg: <span class="title-ref">Log::levels()</span> to obtain current
 level configuration.
@@ -503,35 +503,35 @@ appropriate log level.
 
 #### Log::emergency()
 
-`static` Cake\\Log\\Log::**emergency**($message, $scope = [])
+`static` Cake\\Log\\Log::**emergency**($message, $scope = []): bool
 
 #### Log::alert()
 
-`static` Cake\\Log\\Log::**alert**($message, $scope = [])
+`static` Cake\\Log\\Log::**alert**($message, $scope = []): bool
 
 #### Log::critical()
 
-`static` Cake\\Log\\Log::**critical**($message, $scope = [])
+`static` Cake\\Log\\Log::**critical**($message, $scope = []): bool
 
 #### Log::error()
 
-`static` Cake\\Log\\Log::**error**($message, $scope = [])
+`static` Cake\\Log\\Log::**error**($message, $scope = []): bool
 
 #### Log::warning()
 
-`static` Cake\\Log\\Log::**warning**($message, $scope = [])
+`static` Cake\\Log\\Log::**warning**($message, $scope = []): bool
 
 #### Log::notice()
 
-`static` Cake\\Log\\Log::**notice**($message, $scope = [])
+`static` Cake\\Log\\Log::**notice**($message, $scope = []): bool
 
 #### Log::info()
 
-`static` Cake\\Log\\Log::**info**($message, $scope = [])
+`static` Cake\\Log\\Log::**info**($message, $scope = []): bool
 
 #### Log::debug()
 
-`static` Cake\\Log\\Log::**debug**($message, $scope = [])
+`static` Cake\\Log\\Log::**debug**($message, $scope = []): bool
 
 ## Logging Trait
 

--- a/docs/en/core-libraries/number.md
+++ b/docs/en/core-libraries/number.md
@@ -39,7 +39,7 @@ automatically echo the output into the view.
 
 ### Number::currency()
 
-`method` Cake\\I18n\\Number::**currency**(mixed $value, string $currency = null, array $options = [])
+`method` Cake\\I18n\\Number::**currency**(mixed $value, string $currency = null, array $options = []): string
 
 This method is used to display a number in common currency formats
 (EUR, GBP, USD), based on the 3-letter ISO 4217 currency code. Usage in a view looks like:
@@ -91,7 +91,7 @@ Number::setDefaultCurrencyFormat(Number::FORMAT_CURRENCY_ACCOUNTING);
 
 ### Number::setDefaultCurrency()
 
-`method` Cake\\I18n\\Number::**setDefaultCurrency**($currency)
+`method` Cake\\I18n\\Number::**setDefaultCurrency**($currency): void
 
 Setter for the default currency. This removes the need to always pass the
 currency to `Cake\I18n\Number::currency()` and change all
@@ -102,7 +102,7 @@ it will clear the currently stored value.
 
 ### Number::getDefaultCurrency()
 
-`method` Cake\\I18n\\Number::**getDefaultCurrency**()
+`method` Cake\\I18n\\Number::**getDefaultCurrency**(): string
 
 Getter for the default currency. If default currency was set earlier using
 `setDefaultCurrency()`, then that value will be returned. By default, it will
@@ -112,7 +112,7 @@ retrieve the `intl.default_locale` ini value if set and `'en_US'` if not.
 
 ### Number::precision()
 
-`method` Cake\\I18n\\Number::**precision**(float $value, int $precision = 3, array $options = [])
+`method` Cake\\I18n\\Number::**precision**(float $value, int $precision = 3, array $options = []): string
 
 This method displays a number with the specified amount of
 precision (decimal places). It will round in order to maintain the
@@ -133,7 +133,7 @@ echo Number::precision(456.91873645, 2);
 
 ### Number::toPercentage()
 
-`method` Cake\\I18n\\Number::**toPercentage**(mixed $value, int $precision = 2, array $options = [])
+`method` Cake\\I18n\\Number::**toPercentage**(mixed $value, int $precision = 2, array $options = []): string
 
 | Option | Description |
 |----|----|
@@ -161,7 +161,7 @@ echo Number::toPercentage(0.45691, 1, [
 
 ### Number::toReadableSize()
 
-`method` Cake\\I18n\\Number::**toReadableSize**(string $size)
+`method` Cake\\I18n\\Number::**toReadableSize**(string $size): string
 
 This method formats data sizes in human readable forms. It provides
 a shortcut way to convert bytes to KB, MB, GB, and TB. The size is
@@ -187,7 +187,7 @@ echo Number::toReadableSize(5368709120); // 5 GB
 
 ### Number::format()
 
-`method` Cake\\I18n\\Number::**format**(mixed $value, array $options = [])
+`method` Cake\\I18n\\Number::**format**(mixed $value, array $options = []): string
 
 This method gives you much more control over the formatting of
 numbers for use in your views (and is used as the main method by
@@ -255,7 +255,7 @@ echo Number::format('123456.7890', [
 
 ### Number::ordinal()
 
-`method` Cake\\I18n\\Number::**ordinal**(mixed $value, array $options = [])
+`method` Cake\\I18n\\Number::**ordinal**(mixed $value, array $options = []): string
 
 This method will output an ordinal number.
 
@@ -281,7 +281,7 @@ echo Number::ordinal(410);
 
 ### Number::formatDelta()
 
-`method` Cake\\I18n\\Number::**formatDelta**(mixed $value, array $options = [])
+`method` Cake\\I18n\\Number::**formatDelta**(mixed $value, array $options = []): string
 
 This method displays differences in value as a signed number:
 
@@ -334,7 +334,7 @@ echo Number::formatDelta('123456.7890', [
 
 ### Number::config()
 
-`method` Cake\\I18n\\Number::**config**(string $locale, int $type = NumberFormatter::DECIMAL, array $options = [])
+`method` Cake\\I18n\\Number::**config**(string $locale, int $type = NumberFormatter::DECIMAL, array $options = []): void
 
 This method allows you to configure formatter defaults which persist across calls
 to various methods.

--- a/docs/en/core-libraries/plugin.md
+++ b/docs/en/core-libraries/plugin.md
@@ -8,7 +8,7 @@ The Plugin class is responsible for resource location and path management of plu
 
 ### Plugin::path()
 
-`static` Cake\\Core\\Plugin::**path**(string $plugin)
+`static` Cake\\Core\\Plugin::**path**(string $plugin): string
 
 Plugins can be located with Plugin. Using `Plugin::path('DebugKit');`
 for example, will give you the full path to the DebugKit plugin:
@@ -31,7 +31,7 @@ Use `Plugin::loaded()` if you want to get a list of all currently loaded plugins
 
 ### Plugin::classPath()
 
-`static` Cake\\Core\\Plugin::**classPath**(string $plugin)
+`static` Cake\\Core\\Plugin::**classPath**(string $plugin): string
 
 Used to get the location of the plugin's class files:
 
@@ -43,7 +43,7 @@ $path = App::classPath('DebugKit');
 
 ### Plugin::templatePath()
 
-`static` Cake\\Core\\Plugin::**templatePath**(string $plugin)
+`static` Cake\\Core\\Plugin::**templatePath**(string $plugin): string
 
 The method returns the path to the plugins' templates:
 

--- a/docs/en/core-libraries/security.md
+++ b/docs/en/core-libraries/security.md
@@ -10,11 +10,11 @@ hashing and encrypting data.
 
 ### Security::encrypt()
 
-`static` Cake\\Utility\\Security::**encrypt**($text, $key, $hmacSalt = null)
+`static` Cake\\Utility\\Security::**encrypt**($text, $key, $hmacSalt = null): string
 
 ### Security::decrypt()
 
-`static` Cake\\Utility\\Security::**decrypt**($cipher, $key, $hmacSalt = null)
+`static` Cake\\Utility\\Security::**decrypt**($cipher, $key, $hmacSalt = null): string|null
 
 Encrypt `$text` using AES-256. The `$key` should be a value with a
 lots of variance in the data much like a good password. The returned result
@@ -57,7 +57,7 @@ If the value cannot be decrypted due to changes in the key or HMAC salt
 
 ### Security::hash()
 
-`static` Cake\\Utility\\Security::**hash**( $string, $type = NULL, $salt = false )
+`static` Cake\\Utility\\Security::**hash**( $string, $type = NULL, $salt = false ): string
 
 Create a hash from string using given method. Fallback on next
 available method. If `$salt` is set to `true`, the application's salt
@@ -91,7 +91,7 @@ And any other hash algorithm that PHP's `hash()` function supports.
 
 ### Security::randomBytes()
 
-`static` Cake\\Utility\\Security::**randomBytes**($length)
+`static` Cake\\Utility\\Security::**randomBytes**($length): string
 
 Get `$length` number of bytes from a secure random source. This function draws
 data from one of the following sources:
@@ -104,7 +104,7 @@ will be used for backwards compatibility reasons.
 
 ### Security::randomString()
 
-`static` Cake\\Utility\\Security::**randomString**($length)
+`static` Cake\\Utility\\Security::**randomString**($length): string
 
 Get a random string `$length` long from a secure random source. This method
 draws from the same random source as `randomBytes()` and will encode the data

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -40,7 +40,7 @@ class UsersController extends AppController
 
 ### Text::transliterate()
 
-`static` Cake\\Utility\\Text::**transliterate**($string, $transliteratorId = null)
+`static` Cake\\Utility\\Text::**transliterate**($string, $transliteratorId = null): string
 
 Transliterate by default converts all characters in provided string into
 equivalent ASCII characters. The method expects UTF-8 encoding. The character
@@ -64,7 +64,7 @@ Text::transliterate('Übérmensch', 'Latin-ASCII;');
 
 ### Text::slug()
 
-`static` Cake\\Utility\\Text::**slug**(string $string, array|string $options = [])
+`static` Cake\\Utility\\Text::**slug**(string $string, array|string $options = []): string
 
 Slug transliterates all characters into ASCII versions and converting unmatched
 characters and spaces to dashes. The slug method expects UTF-8 encoding.
@@ -97,7 +97,7 @@ options are:
 
 ### Text::uuid()
 
-`static` Cake\\Utility\\Text::**uuid**()
+`static` Cake\\Utility\\Text::**uuid**(): string
 
 The UUID method is used to generate unique identifiers as per `4122`. The
 UUID is a 128-bit string in the format of
@@ -132,7 +132,7 @@ be used instead of the default UUID generation method.
 
 ### Text::tokenize()
 
-`static` Cake\\Utility\\Text::**tokenize**(string $data, string $separator = ',', string $leftBound = '(', string $rightBound = ')')
+`static` Cake\\Utility\\Text::**tokenize**(string $data, string $separator = ',', string $leftBound = '(', string $rightBound = ')'): array
 
 Tokenizes a string using `$separator`, ignoring any instance of `$separator`
 that appears between `$leftBound` and `$rightBound`.
@@ -149,7 +149,7 @@ $result = Text::tokenize($data, ' ', "'", "'");
 
 ### Text::parseFileSize()
 
-`method` Cake\\Utility\\Text::**parseFileSize**(string $size, mixed $default = false)
+`method` Cake\\Utility\\Text::**parseFileSize**(string $size, mixed $default = false): mixed
 
 This method unformats a number from a human-readable byte size to an integer
 number of bytes:
@@ -162,7 +162,7 @@ $int = Text::parseFileSize('2GB');
 
 ### Text::insert()
 
-`static` Cake\\Utility\\Text::**insert**(string $str, array $data, array $options = [])
+`static` Cake\\Utility\\Text::**insert**(string $str, array $data, array $options = []): string
 
 The insert method is used to create string templates and to allow for key/value
 replacements:
@@ -177,7 +177,7 @@ Text::insert(
 
 ### Text::cleanInsert()
 
-`static` Cake\\Utility\\Text::**cleanInsert**(string $str, array $options)
+`static` Cake\\Utility\\Text::**cleanInsert**(string $str, array $options): string
 
 Cleans up a `Text::insert` formatted string with given `$options` depending
 on the 'clean' key in `$options`. The default method used is text but html is
@@ -201,7 +201,7 @@ $options = [
 
 ### Text::wrap()
 
-`static` Cake\\Utility\\Text::**wrap**(string $text, array|int $options = [])
+`static` Cake\\Utility\\Text::**wrap**(string $text, array|int $options = []): string
 
 Wraps a block of text to a set width and indents blocks as well.
 Can intelligently wrap text so words are not sliced across lines:
@@ -225,7 +225,7 @@ supported options are:
 
 ### Text::wrapBlock()
 
-`static` Cake\\Utility\\Text::**wrapBlock**(string $text, array|int $options = [])
+`static` Cake\\Utility\\Text::**wrapBlock**(string $text, array|int $options = []): string
 
 If you need to ensure that the total width of the generated block won't
 exceed a certain length even with internal indentation, you need to use
@@ -253,7 +253,7 @@ This is the song that
 
 ### Text::highlight()
 
-`method` Cake\\Utility\\Text::**highlight**(string $text, array|string $phrase, array $options = [])
+`method` Cake\\Utility\\Text::**highlight**(string $text, array|string $phrase, array $options = []): string
 
 Highlights `$phrase` in `$text` using the `$options['format']` string
 specified or a default string.
@@ -294,7 +294,7 @@ Output:
 
 ### Text::truncate()
 
-`method` Cake\\Utility\\Text::**truncate**(string $text, int $length = 100, array $options = [])
+`method` Cake\\Utility\\Text::**truncate**(string $text, int $length = 100, array $options = []): string
 
 If `$text` is longer than `$length`, this method truncates it at `$length`
 and adds a suffix consisting of `'ellipsis'`, if defined. If `'exact'` is
@@ -347,7 +347,7 @@ Output:
 
 ### Text::tail()
 
-`method` Cake\\Utility\\Text::**tail**(string $text, int $length = 100, array $options = [])
+`method` Cake\\Utility\\Text::**tail**(string $text, int $length = 100, array $options = []): string
 
 If `$text` is longer than `$length`, this method removes an initial
 substring with length consisting of the difference and prepends a prefix
@@ -402,7 +402,7 @@ Output:
 
 ### Text::excerpt()
 
-`method` Cake\\Utility\\Text::**excerpt**(string $text, string $phrase, int $radius = 100, string $ellipsis = '…')
+`method` Cake\\Utility\\Text::**excerpt**(string $text, string $phrase, int $radius = 100, string $ellipsis = '…'): string
 
 Extracts an excerpt from `$text` surrounding the `$phrase` with a number
 of characters on each side determined by `$radius`, and prefix/suffix with
@@ -428,7 +428,7 @@ Output:
 
 ### Text::toList()
 
-`method` Cake\\Utility\\Text::**toList**(array $list, ?string $and = null, $separator = ', ')
+`method` Cake\\Utility\\Text::**toList**(array $list, ?string $and = null, $separator = ', '): string
 
 Creates a comma-separated list where the last two items are joined with 'and':
 

--- a/docs/en/core-libraries/time.md
+++ b/docs/en/core-libraries/time.md
@@ -149,7 +149,7 @@ echo $time->timezoneName; // America/New_York
 
 ### DateTime::setJsonEncodeFormat()
 
-`static` Cake\\I18n\\DateTime::**setJsonEncodeFormat**($format)
+`static` Cake\\I18n\\DateTime::**setJsonEncodeFormat**($format): void
 
 This method sets the default format used when converting an object to json:
 
@@ -179,7 +179,7 @@ The `callable` parameter type was added.
 
 ### DateTime::i18nFormat()
 
-`method` Cake\\I18n\\DateTime::**i18nFormat**($format = null, $timezone = null, $locale = null)
+`method` Cake\\I18n\\DateTime::**i18nFormat**($format = null, $timezone = null, $locale = null): string|int
 
 A very common thing to do with `Time` instances is to print out formatted
 dates. CakePHP makes this a snap:
@@ -247,7 +247,7 @@ The following calendar types are supported:
 
 ### DateTime::nice()
 
-`method` Cake\\I18n\\DateTime::**nice**()
+`method` Cake\\I18n\\DateTime::**nice**(): string
 
 Print out a predefined 'nice' format:
 
@@ -341,7 +341,7 @@ format string.
 
 ### DateTime::timeAgoInWords()
 
-`method` Cake\\I18n\\DateTime::**timeAgoInWords**(array $options = [])
+`method` Cake\\I18n\\DateTime::**timeAgoInWords**(array $options = []): string
 
 Often it is useful to print times relative to the present:
 
@@ -380,11 +380,11 @@ echo $time->timeAgoInWords([
 
 ### DateTime::toQuarter()
 
-`method` Cake\\I18n\\DateTime::**toQuarter**()
+`method` Cake\\I18n\\DateTime::**toQuarter**(): int|array
 
 ### DateTime::toQuarterRange()
 
-`method` Cake\\I18n\\DateTime::**toQuarterRange**()
+`method` Cake\\I18n\\DateTime::**toQuarterRange**(): array
 
 Once created, you can convert `DateTime` instances into timestamps or quarter
 values:

--- a/docs/en/core-libraries/xml.md
+++ b/docs/en/core-libraries/xml.md
@@ -79,7 +79,7 @@ can be enabled with the `loadEntities` and `parseHuge` options respectively.
 
 ### Xml::toArray()
 
-`static` Cake\\Utility\\Xml::**toArray**($obj)
+`static` Cake\\Utility\\Xml::**toArray**($obj): array
 
 Converting XML strings into arrays is simple with the Xml class as well. By
 default you'll get a SimpleXml object back:

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -319,7 +319,7 @@ won't end up breaking the MVC structure CakePHP provides.
 
 ### Writing Configuration data
 
-`static` Cake\\Core\\Configure::**write**($key, $value)
+`static` Cake\\Core\\Configure::**write**($key, $value): void
 
 Use `write()` to store data in the application's configuration:
 
@@ -350,7 +350,7 @@ production modes on the fly.
 
 ### Reading Configuration Data
 
-`static` Cake\\Core\\Configure::**read**($key = null, $default = null)
+`static` Cake\\Core\\Configure::**read**($key = null, $default = null): mixed
 
 Used to read configuration data from the application. If a key is supplied, the
 data is returned. Using our examples from write() above, we can read that data
@@ -373,7 +373,7 @@ Configure::read('Company.nope', 'fallback');
 
 If `$key` is left null, all values in Configure will be returned.
 
-`static` Cake\\Core\\Configure::**readOrFail**($key)
+`static` Cake\\Core\\Configure::**readOrFail**($key): mixed
 
 Reads configuration data just like `Cake\Core\Configure::read()`
 but expects to find a key/value pair. In case the requested pair does not
@@ -391,7 +391,7 @@ Configure::readOrFail('Company');
 
 ### Checking to see if Configuration Data is Defined
 
-`static` Cake\\Core\\Configure::**check**($key)
+`static` Cake\\Core\\Configure::**check**($key): bool
 
 Used to check if a key/path exists and has non-null value:
 
@@ -401,7 +401,7 @@ $exists = Configure::check('Company.name');
 
 ### Deleting Configuration Data
 
-`static` Cake\\Core\\Configure::**delete**($key)
+`static` Cake\\Core\\Configure::**delete**($key): void
 
 Used to delete information from the application's configuration:
 
@@ -411,12 +411,12 @@ Configure::delete('Company.name');
 
 ### Reading & Deleting Configuration Data
 
-`static` Cake\\Core\\Configure::**consume**($key)
+`static` Cake\\Core\\Configure::**consume**($key): mixed
 
 Read and delete a key from Configure. This is useful when you want to
 combine reading and deleting values in a single operation.
 
-`static` Cake\\Core\\Configure::**consumeOrFail**($key)
+`static` Cake\\Core\\Configure::**consumeOrFail**($key): mixed
 
 Consumes configuration data just like `Cake\Core\Configure::consume()`
 but expects to find a key/value pair. In case the requested pair does not
@@ -467,7 +467,7 @@ Configure::configured();
 Configure::configured('default');
 ```
 
-`static` Cake\\Core\\Configure::**drop**($name)
+`static` Cake\\Core\\Configure::**drop**($name): bool
 
 You can also remove attached engines. `Configure::drop('default')`
 would remove the default engine alias. Any future attempts to load configuration
@@ -481,7 +481,7 @@ Configure::drop('default');
 
 ### Loading Configuration Files
 
-`static` Cake\\Core\\Configure::**load**($key, $config = 'default', $merge = true)
+`static` Cake\\Core\\Configure::**load**($key, $config = 'default', $merge = true): bool
 
 Once you've attached a config engine to Configure you can load configuration
 files:
@@ -522,7 +522,7 @@ will not ever overwrite the existing configuration.
 
 ### Creating or Modifying Configuration Files
 
-`static` Cake\\Core\\Configure::**dump**($key, $config = 'default', $keys = [])
+`static` Cake\\Core\\Configure::**dump**($key, $config = 'default', $keys = []): bool
 
 Dumps all or some of the data in Configure into a file or storage system
 supported by a config engine. The serialization format is decided by the config
@@ -549,7 +549,7 @@ configuration files that are readable with `Configure::load()`
 
 ### Storing Runtime Configuration
 
-`static` Cake\\Core\\Configure::**store**($name, $cacheConfig = 'default', $data = null)
+`static` Cake\\Core\\Configure::**store**($name, $cacheConfig = 'default', $data = null): bool
 
 You can also store runtime configuration values for use in a future request.
 Since configure only remembers values for the current request, you will
@@ -566,7 +566,7 @@ Stored configuration data is persisted in the named cache configuration. See the
 
 ### Restoring Runtime Configuration
 
-`static` Cake\\Core\\Configure::**restore**($name, $cacheConfig = 'default')
+`static` Cake\\Core\\Configure::**restore**($name, $cacheConfig = 'default'): bool
 
 Once you've stored runtime configuration, you'll probably need to restore it
 so you can access it again. `Configure::restore()` does exactly that:

--- a/docs/en/development/debugging.md
+++ b/docs/en/development/debugging.md
@@ -69,7 +69,7 @@ The `Debugger.editorBasePath` configure option was added.
 
 ## Outputting Values
 
-`static` Cake\\Error\\Debugger::**dump**($var, $depth = 3)
+`static` Cake\\Error\\Debugger::**dump**($var, $depth = 3): void
 
 Dump prints out the contents of a variable. It will print out all
 properties and methods (if any) of the supplied variable:
@@ -118,7 +118,7 @@ output masks.
 
 ## Logging With Stack Traces
 
-`static` Cake\\Error\\Debugger::**log**($var, $level = 7, $depth = 3)
+`static` Cake\\Error\\Debugger::**log**($var, $level = 7, $depth = 3): void
 
 Creates a detailed stack trace log at the time of invocation. The
 `log()` method prints out data similar to that done by
@@ -128,7 +128,7 @@ writable by the web server for `log()` to work correctly.
 
 ## Generating Stack Traces
 
-`static` Cake\\Error\\Debugger::**trace**($options)
+`static` Cake\\Error\\Debugger::**trace**($options): array|string
 
 Returns the current stack trace. Each line of the trace includes
 the calling method, including which file and line the call
@@ -151,7 +151,7 @@ the order of currently running functions (stack frames).
 
 ## Getting an Excerpt From a File
 
-`static` Cake\\Error\\Debugger::**excerpt**($file, $line, $context)
+`static` Cake\\Error\\Debugger::**excerpt**($file, $line, $context): array
 
 Grab an excerpt from the file at \$path (which is an absolute
 filepath), highlights line number \$line with \$context number of

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -646,7 +646,7 @@ Geospatial schema types were added.
 
 `class` Cake\\Database\\**TypeFactory**
 
-`static` Cake\\Database\\TypeFactory::**map**($name, $class)
+`static` Cake\\Database\\TypeFactory::**map**($name, $class): void
 
 If you need to use vendor specific types that are not built into CakePHP you can
 add additional new types to CakePHP's type system. Type classes are expected to
@@ -1062,7 +1062,7 @@ $connection->execute('UPDATE articles SET published = ? WHERE id = ?', [false, 4
 $connection->commit();
 ```
 
-`method` Cake\\Database\\Connection::**transactional**(callable $callback)
+`method` Cake\\Database\\Connection::**transactional**(callable $callback): mixed
 
 In addition to this interface connection instances also provide the
 `transactional()` method which makes handling the begin/commit/rollback calls

--- a/docs/en/orm/deleting-data.md
+++ b/docs/en/orm/deleting-data.md
@@ -4,7 +4,7 @@
 
 ## Deleting a Single Entity
 
-`method` Cake\\ORM\\Table::**delete**(EntityInterface $entity, array $options = [])
+`method` Cake\\ORM\\Table::**delete**(EntityInterface $entity, array $options = []): bool
 
 Once you've loaded an entity you can delete it by calling the originating
 table's delete method:
@@ -84,7 +84,7 @@ records with these method **will** trigger events.
 
 ### deleteAll()
 
-`method` Cake\\ORM\\Table::**deleteAll**($conditions)
+`method` Cake\\ORM\\Table::**deleteAll**($conditions): int
 
 There may be times when deleting rows one by one is not efficient or useful.
 In these cases it is more performant to use a bulk-delete to remove many rows at
@@ -108,7 +108,7 @@ function returns the number of deleted records as an integer.
 
 ## Strict Deletes
 
-`method` Cake\\ORM\\Table::**deleteOrFail**(EntityInterface $entity, array $options = [])
+`method` Cake\\ORM\\Table::**deleteOrFail**(EntityInterface $entity, array $options = []): bool
 
 Using this method will throw an
 `Cake\ORM\Exception\PersistenceFailedException` if:

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -1371,7 +1371,7 @@ The result will be updated entities on success or `false` on failure.
 
 ## Bulk Updates
 
-`method` Cake\\ORM\\Table::**updateAll**($fields, $conditions)
+`method` Cake\\ORM\\Table::**updateAll**($fields, $conditions): int
 
 There may be times when updating rows individually is not efficient or
 necessary. In these cases it is more efficient to use a bulk-update to modify

--- a/docs/en/orm/table-objects.md
+++ b/docs/en/orm/table-objects.md
@@ -539,7 +539,7 @@ FactoryLocator::get('Table')->setConfig('Users', ['table' => 'my_users']);
 
 ### Flushing the Registry
 
-`method` Cake\\ORM\\TableLocator::**clear**()
+`method` Cake\\ORM\\TableLocator::**clear**(): void
 
 During test cases you may want to flush the registry. Doing so is often useful
 when you are using mock objects, or modifying a table's dependencies:

--- a/docs/en/orm/table-objects.md
+++ b/docs/en/orm/table-objects.md
@@ -174,7 +174,7 @@ public function afterSaveCommit(Event $event, EntityInterface $entity, ArrayObje
 
 ### initialize
 
-`method` Cake\\ORM\\Table::**initialize**(EventInterface $event, ArrayObject $data, ArrayObject $options)
+`method` Cake\\ORM\\Table::**initialize**(EventInterface $event, ArrayObject $data, ArrayObject $options): void
 
 The `Model.initialize` event is fired after the constructor and initialize
 methods are called. The `Table` classes do not listen to this event by
@@ -214,14 +214,14 @@ This will call the `initializeEvent` when any `Table` class is constructed.
 
 ### beforeMarshal
 
-`method` Cake\\ORM\\Table::**beforeMarshal**(EventInterface $event, ArrayObject $data, ArrayObject $options)
+`method` Cake\\ORM\\Table::**beforeMarshal**(EventInterface $event, ArrayObject $data, ArrayObject $options): void
 
 The `Model.beforeMarshal` event is fired before request data is converted
 into entities. See the [Before Marshal](../orm/saving-data#before-marshal) documentation for more information.
 
 ### afterMarshal
 
-`method` Cake\\ORM\\Table::**afterMarshal**(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options)
+`method` Cake\\ORM\\Table::**afterMarshal**(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options): void
 
 The `Model.afterMarshal` event is fired after request data is converted
 into entities. Event handlers will get the converted entities, original request
@@ -229,7 +229,7 @@ data and the options provided to the `patchEntity()` or `newEntity()` call.
 
 ### beforeFind
 
-`method` Cake\\ORM\\Table::**beforeFind**(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary)
+`method` Cake\\ORM\\Table::**beforeFind**(EventInterface $event, SelectQuery $query, ArrayObject $options, boolean $primary): void
 
 The `Model.beforeFind` event is fired before each find operation. By stopping
 the event, and feeding the query with a custom result set, you can bypass the find
@@ -266,7 +266,7 @@ been replaced with the [Map Reduce](../orm/retrieving-data-and-resultsets#map-re
 
 ### buildValidator
 
-`method` Cake\\ORM\\Table::**buildValidator**(EventInterface $event, Validator $validator, $name)
+`method` Cake\\ORM\\Table::**buildValidator**(EventInterface $event, Validator $validator, $name): void
 
 The `Model.buildValidator` event is fired when `$name` validator is created.
 Behaviors, can use this hook to add in validation methods.
@@ -280,7 +280,7 @@ created and after the `Table::buildRules()` method has been called.
 
 ### beforeRules
 
-`method` Cake\\ORM\\Table::**beforeRules**(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation)
+`method` Cake\\ORM\\Table::**beforeRules**(EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation): void
 
 The `Model.beforeRules` event is fired before an entity has had rules applied. By
 stopping this event, you can halt the rules checking and set the result
@@ -288,7 +288,7 @@ of applying rules.
 
 ### afterRules
 
-`method` Cake\\ORM\\Table::**afterRules**(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation)
+`method` Cake\\ORM\\Table::**afterRules**(EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation): void
 
 The `Model.afterRules` event is fired after an entity has rules applied. By
 stopping this event, you can return the final value of the rules checking
@@ -296,7 +296,7 @@ operation.
 
 ### beforeSave
 
-`method` Cake\\ORM\\Table::**beforeSave**(EventInterface $event, EntityInterface $entity, ArrayObject $options)
+`method` Cake\\ORM\\Table::**beforeSave**(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 
 The `Model.beforeSave` event is fired before each entity is saved. Stopping
 this event will abort the save operation. When the event is stopped the result
@@ -304,13 +304,13 @@ of the event will be returned.
 
 ### afterSave
 
-`method` Cake\\ORM\\Table::**afterSave**(EventInterface $event, EntityInterface $entity, ArrayObject $options)
+`method` Cake\\ORM\\Table::**afterSave**(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 
 The `Model.afterSave` event is fired after an entity is saved.
 
 ### afterSaveCommit
 
-`method` Cake\\ORM\\Table::**afterSaveCommit**(EventInterface $event, EntityInterface $entity, ArrayObject $options)
+`method` Cake\\ORM\\Table::**afterSaveCommit**(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 
 The `Model.afterSaveCommit` event is fired after the transaction in which the
 save operation is wrapped has been committed. It's also triggered for non atomic
@@ -320,7 +320,7 @@ not triggered if a transaction is started before calling save.
 
 ### beforeDelete
 
-`method` Cake\\ORM\\Table::**beforeDelete**(EventInterface $event, EntityInterface $entity, ArrayObject $options)
+`method` Cake\\ORM\\Table::**beforeDelete**(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 
 The `Model.beforeDelete` event is fired before an entity is deleted. By
 stopping this event you will abort the delete operation. When the event is stopped the result
@@ -328,13 +328,13 @@ of the event will be returned.
 
 ### afterDelete
 
-`method` Cake\\ORM\\Table::**afterDelete**(EventInterface $event, EntityInterface $entity, ArrayObject $options)
+`method` Cake\\ORM\\Table::**afterDelete**(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 
 The `Model.afterDelete` event is fired after an entity has been deleted.
 
 ### afterDeleteCommit
 
-`method` Cake\\ORM\\Table::**afterDeleteCommit**(EventInterface $event, EntityInterface $entity, ArrayObject $options)
+`method` Cake\\ORM\\Table::**afterDeleteCommit**(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 
 The `Model.afterDeleteCommit` event is fired after the transaction in which the
 delete operation is wrapped has been is committed. It's also triggered for non

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -539,7 +539,7 @@ class UsersController extends AppController
 
 ## Elements
 
-`method` Cake\\View\\View::**element**(string $elementPath, array $data, array $options = [])
+`method` Cake\\View\\View::**element**(string $elementPath, array $data, array $options = []): string
 
 Many applications have small blocks of presentation code that need to be
 repeated from page to page, sometimes in different places in the layout. CakePHP
@@ -699,7 +699,7 @@ file does not exist, it will be looked for in the default location.
 
 ### Caching Sections of Your View
 
-`method` Cake\\View\\View::**cache**(callable $block, array $options = [])
+`method` Cake\\View\\View::**cache**(callable $block, array $options = []): string
 
 Sometimes generating a section of your view output can be expensive because of
 rendered [View Cells](views/cells) or expensive helper operations. To help make your

--- a/docs/en/views/helpers.md
+++ b/docs/en/views/helpers.md
@@ -377,24 +377,24 @@ does not implement any of the callback methods.
 
 #### beforeRenderFile()
 
-`method` Helper::**beforeRenderFile**(EventInterface $event, $viewFile)
+`method` Helper::**beforeRenderFile**(EventInterface $event, $viewFile): void
 
 #### afterRenderFile()
 
-`method` Helper::**afterRenderFile**(EventInterface $event, $viewFile, $content)
+`method` Helper::**afterRenderFile**(EventInterface $event, $viewFile, $content): void
 
 #### beforeRender()
 
-`method` Helper::**beforeRender**(EventInterface $event, $viewFile)
+`method` Helper::**beforeRender**(EventInterface $event, $viewFile): void
 
 #### afterRender()
 
-`method` Helper::**afterRender**(EventInterface $event, $viewFile)
+`method` Helper::**afterRender**(EventInterface $event, $viewFile): void
 
 #### beforeLayout()
 
-`method` Helper::**beforeLayout**(EventInterface $event, $layoutFile)
+`method` Helper::**beforeLayout**(EventInterface $event, $layoutFile): void
 
 #### afterLayout()
 
-`method` Helper::**afterLayout**(EventInterface $event, $layoutFile)
+`method` Helper::**afterLayout**(EventInterface $event, $layoutFile): void

--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -10,7 +10,7 @@ only what you need.
 
 ## Starting a Form
 
-`method` Cake\\View\\Helper\\FormHelper::**create**(mixed $context = null, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**create**(mixed $context = null, array $options = []): string
 
 - `$context` - The context for which the form is being defined. Can be an ORM
   entity, ORM resultset, `Form` instance, array of metadata or `null` (to make a
@@ -350,7 +350,7 @@ return an object. If there is no match return null.
 
 ## Creating Form Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**control**(string $fieldName, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**control**(string $fieldName, array $options = []): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array that can include both
@@ -868,7 +868,7 @@ Will output:
 
 ### Creating Hidden Inputs
 
-`method` Cake\\View\\Helper\\FormHelper::**hidden**(string $fieldName, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**hidden**(string $fieldName, array $options): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array including any of the
@@ -890,7 +890,7 @@ Will output:
 
 ### Creating Textareas
 
-`method` Cake\\View\\Helper\\FormHelper::**textarea**(string $fieldName, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**textarea**(string $fieldName, array $options): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array including any of the
@@ -1148,7 +1148,7 @@ $options = $examples->map(function ($value, $key) {
 
 #### Creating Checkboxes
 
-`method` Cake\\View\\Helper\\FormHelper::**checkbox**(string $fieldName, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**checkbox**(string $fieldName, array $options): array|string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array including any of the
@@ -1220,7 +1220,7 @@ Will output:
 
 #### Creating Radio Buttons
 
-`method` Cake\\View\\Helper\\FormHelper::**radio**(string $fieldName, array $options, array $attributes)
+`method` Cake\\View\\Helper\\FormHelper::**radio**(string $fieldName, array $options, array $attributes): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array containing at minimum the labels for the
@@ -1347,7 +1347,7 @@ If the `label` key is used on an option, the attributes in
 
 #### Creating Select Pickers
 
-`method` Cake\\View\\Helper\\FormHelper::**select**(string $fieldName, array $options, array $attributes)
+`method` Cake\\View\\Helper\\FormHelper::**select**(string $fieldName, array $options, array $attributes): string
 
 - `$fieldName` - A field name in the form `'fieldname'` or `'related_entity.fieldname'`. This
   will provide the `name` attribute of the `select` element.
@@ -1629,7 +1629,7 @@ certain behaviors of the `select()` method.
 
 ### Creating File Inputs
 
-`method` Cake\\View\\Helper\\FormHelper::**file**(string $fieldName, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**file**(string $fieldName, array $options): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array including any of the
@@ -1704,7 +1704,7 @@ $fileobject->moveTo($destination);
 
 ### Creating Date & Time Related Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**dateTime**(string $fieldName, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**dateTime**(string $fieldName, array $options = []): string
 
 - `$fieldName` - A string that will be used as a prefix for the HTML `name`
   attribute of the `select` elements.
@@ -1741,7 +1741,7 @@ Output:
 
 #### Creating Date Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**date**(string $fieldName, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**date**(string $fieldName, array $options = []): string
 
 - `$fieldName` - A field name that will be used as a prefix for the HTML
   `name` attribute of the `select` elements.
@@ -1764,7 +1764,7 @@ Output:
 
 #### Creating Time Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**time**(string $fieldName, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**time**(string $fieldName, array $options = []): string
 
 - `$fieldName` - A field name that will be used as a prefix for the HTML
   `name` attribute of the `select` elements.
@@ -1787,7 +1787,7 @@ Output:
 
 #### Creating Month Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**month**(string $fieldName, array $attributes)
+`method` Cake\\View\\Helper\\FormHelper::**month**(string $fieldName, array $attributes): string
 
 - `$fieldName` - A field name that will be used as a prefix for the HTML
   `name` attribute of the `select` element.
@@ -1810,7 +1810,7 @@ Will output:
 
 #### Creating Year Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**year**(string $fieldName, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**year**(string $fieldName, array $options = []): string
 
 - `$fieldName` - A field name that will be used as a prefix for the HTML
   `name` attribute of the `select` element.
@@ -1860,7 +1860,7 @@ If it was 2009, you would get the following:
 
 ## Creating Labels
 
-`method` Cake\\View\\Helper\\FormHelper::**label**(string $fieldName, string $text, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**label**(string $fieldName, string $text, array $options): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$text` - An optional string providing the label caption text.
@@ -1906,7 +1906,7 @@ field errors and when necessary display customized error messages.
 
 ### Displaying Errors
 
-`method` Cake\\View\\Helper\\FormHelper::**error**(string $fieldName, mixed $text, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**error**(string $fieldName, mixed $text, array $options): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$text` - Optional. A string or array providing the error message(s). If an
@@ -1971,7 +1971,7 @@ for the *Ticket* field, your form would output:
 
 ### Checking for Errors
 
-`method` Cake\\View\\Helper\\FormHelper::**isFieldError**(string $fieldName)
+`method` Cake\\View\\Helper\\FormHelper::**isFieldError**(string $fieldName): bool
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 
@@ -2019,7 +2019,7 @@ You could then use JavaScript to set the `onvalid` and `oninvalid` events as you
 
 ### Creating Submit Elements
 
-`method` Cake\\View\\Helper\\FormHelper::**submit**(string $caption, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**submit**(string $caption, array $options): string
 
 - `$caption` - An optional string providing the button's text caption or a
   path to an image. Defaults to `'Submit'`.
@@ -2080,7 +2080,7 @@ more complex button content you should use `button()`.
 
 ### Creating Button Elements
 
-`method` Cake\\View\\Helper\\FormHelper::**button**(string $title, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**button**(string $title, array $options = []): string
 
 - `$title` - Mandatory string providing the button's text caption.
 - `$options` - An optional array including any of the
@@ -2136,7 +2136,7 @@ echo $this->Form->button('<em>Submit Form</em>', [
 
 ## Closing the Form
 
-`method` Cake\\View\\Helper\\FormHelper::**end**($secureAttributes = [])
+`method` Cake\\View\\Helper\\FormHelper::**end**($secureAttributes = []): string
 
 - `$secureAttributes` - Optional. Allows you to provide secure attributes
   which will be passed as HTML attributes into the hidden input elements
@@ -2184,7 +2184,7 @@ Will output:
 
 ### Creating POST Buttons
 
-`method` Cake\\View\\Helper\\FormHelper::**postButton**(string $title, mixed $url, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**postButton**(string $title, mixed $url, array $options = []): string
 
 - `$title` - Mandatory string providing the button's text caption. By default
   not HTML encoded.
@@ -2237,7 +2237,7 @@ inside opened forms.
 
 ### Creating POST Links
 
-`method` Cake\\View\\Helper\\FormHelper::**postLink**(string $title, array|string|null $url = null, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**postLink**(string $title, array|string|null $url = null, array $options = []): string
 
 - `$title` - Mandatory string providing the text to be wrapped in `<a>`
   tags.
@@ -2288,7 +2288,7 @@ use `Cake\View\Helper\FormHelper::button()` or
 
 ### Creating DELETE Links
 
-`method` Cake\\View\\Helper\\FormHelper::**deleteLink**(string $title, array|string|null $url = null, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**deleteLink**(string $title, array|string|null $url = null, array $options = []): string
 
 - `$title` - Mandatory string providing the text to be wrapped in `<a>`
   tags.
@@ -2456,7 +2456,7 @@ This will make radio buttons and checkboxes render outside of their labels.
 
 ### Creating Multiple Controls
 
-`method` Cake\\View\\Helper\\FormHelper::**controls**(array $fields = [], array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**controls**(array $fields = [], array $options = []): string
 
 - `$fields` - An array of fields to generate. Allows setting
   custom types, labels and other options for each specified field.
@@ -2512,7 +2512,7 @@ If you disable the `fieldset`, the `legend` will not print.
 
 ### Creating Controls for a Whole Entity
 
-`method` Cake\\View\\Helper\\FormHelper::**allControls**(array $fields, array $options = [])
+`method` Cake\\View\\Helper\\FormHelper::**allControls**(array $fields, array $options = []): string
 
 - `$fields` - Optional. An array of customizations for the fields that will
   be generated. Allows setting custom types, labels and other options.
@@ -2783,7 +2783,7 @@ The `$name` parameter should be the entity property name for the field:
 $this->Form->unlockField('id');
 ```
 
-`method` Cake\\View\\Helper\\FormHelper::**secure**(array $fields = [], array $secureAttributes = [])
+`method` Cake\\View\\Helper\\FormHelper::**secure**(array $fields = [], array $secureAttributes = []): string
 
 - `$fields` - Optional. An array containing the list of fields to use when
   generating the hash. If not provided, then `$this->fields` will be used.

--- a/docs/en/views/helpers/html.md
+++ b/docs/en/views/helpers/html.md
@@ -28,7 +28,7 @@ methods of the HtmlHelper and how to use them.
 
 ### Creating Charset Tags
 
-`method` Cake\\View\\Helper\\HtmlHelper::**charset**($charset=null)
+`method` Cake\\View\\Helper\\HtmlHelper::**charset**($charset=null): string
 
 Used to create a meta tag specifying the document's character. The default value
 is UTF-8. An example use:
@@ -57,7 +57,7 @@ Will output:
 
 ### Linking to CSS Files
 
-`method` Cake\\View\\Helper\\HtmlHelper::**css**(mixed $path, array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**css**(mixed $path, array $options = []): string|null
 
 Creates a link(s) to a CSS style-sheet. If the `block` option is set to
 `true`, the link tags are added to the `css` block which you can print
@@ -113,7 +113,7 @@ echo $this->Html->css('Blog.common.css', ['plugin' => false]);
 
 ### Creating CSS Programatically
 
-`method` Cake\\View\\Helper\\HtmlHelper::**style**(array $data, boolean $oneline = true)
+`method` Cake\\View\\Helper\\HtmlHelper::**style**(array $data, boolean $oneline = true): string
 
 Builds CSS style definitions based on the keys and values of the
 array passed to the method. Especially handy if your CSS file is
@@ -135,7 +135,7 @@ background:#633; border-bottom:1px solid #000; padding:10px;
 
 ### Creating meta Tags
 
-`method` Cake\\View\\Helper\\HtmlHelper::**meta**(string|array $type, string $url = null, array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**meta**(string|array $type, string $url = null, array $options = []): string|null
 
 This method is handy for linking to external resources like RSS/Atom feeds
 and favicons. Like css(), you can specify whether or not you'd like this tag
@@ -232,7 +232,7 @@ The `csrfToken` type was added.
 
 ### Linking to Images
 
-`method` Cake\\View\\Helper\\HtmlHelper::**image**(string $path, array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**image**(string $path, array $options = []): string
 
 Creates a formatted image tag. The path supplied should be relative
 to **webroot/img/**. :
@@ -308,7 +308,7 @@ Will output:
 
 ### Creating Links
 
-`method` Cake\\View\\Helper\\HtmlHelper::**link**($title, $url = null, array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**link**($title, $url = null, array $options = []): string
 
 General purpose method for creating HTML links. Use `$options` to
 specify attributes for the element and whether or not the
@@ -427,7 +427,7 @@ for more examples of different types of URLs.
 
 ### Creating Links from Route Paths
 
-`method` Cake\\View\\Helper\\HtmlHelper::**linkFromPath**(string $title, string $path, array $params = [], array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**linkFromPath**(string $title, string $path, array $params = [], array $options = []): string
 
 If you want to use route path strings, you can do that using this method:
 
@@ -441,7 +441,7 @@ echo $this->Html->linkFromPath('View', 'MyBackend.Admin/Articles::view', [3]);
 
 ### Linking to Videos and Audio Files
 
-`method` Cake\\View\\Helper\\HtmlHelper::**media**(string|array $path, array $options)
+`method` Cake\\View\\Helper\\HtmlHelper::**media**(string|array $path, array $options): string
 
 Options:
 
@@ -485,7 +485,7 @@ Returns a formatted audio/video tag:
 
 ### Linking to Javascript Files
 
-`method` Cake\\View\\Helper\\HtmlHelper::**script**(mixed $url, mixed $options)
+`method` Cake\\View\\Helper\\HtmlHelper::**script**(mixed $url, mixed $options): string|null
 
 Include a script file(s), contained either locally or as a remote URL.
 
@@ -581,7 +581,7 @@ echo $this->Html->script('Blog.plugins.js', ['plugin' => false]);
 
 ### Creating Inline Javascript Blocks
 
-`method` Cake\\View\\Helper\\HtmlHelper::**scriptBlock**(string $code, array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**scriptBlock**(string $code, array $options = []): string|null
 
 To generate Javascript blocks from PHP view code, you can use one of the script
 block methods. Scripts can either be output in place, or buffered into a block:
@@ -596,9 +596,9 @@ $this->Html->scriptBlock('alert("hi")', ['block' => true]);
 
 ### Starting and Ending Script Blocks
 
-`method` Cake\\View\\Helper\\HtmlHelper::**scriptStart**(array $options = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**scriptStart**(array $options = []): void
 
-`method` Cake\\View\\Helper\\HtmlHelper::**scriptEnd**()
+`method` Cake\\View\\Helper\\HtmlHelper::**scriptEnd**(): string|null
 
 You can use the `scriptStart()` method to create a capturing block that will
 output into a `<script>` tag. Captured script snippets can be output inline,
@@ -704,7 +704,7 @@ Will output:
 
 ### Creating Nested Lists
 
-`method` Cake\\View\\Helper\\HtmlHelper::**nestedList**(array $list, array $options = [], array $itemOptions = [])
+`method` Cake\\View\\Helper\\HtmlHelper::**nestedList**(array $list, array $options = [], array $itemOptions = []): string
 
 Build a nested list (UL/OL) out of an associative array:
 
@@ -746,7 +746,7 @@ Output:
 
 ### Creating Table Headings
 
-`method` Cake\\View\\Helper\\HtmlHelper::**tableHeaders**(array $names, array $trOptions = null, array $thOptions = null)
+`method` Cake\\View\\Helper\\HtmlHelper::**tableHeaders**(array $names, array $trOptions = null, array $thOptions = null): string
 
 Creates a row of table header cells to be placed inside of \<table\>
 tags. :
@@ -806,7 +806,7 @@ Output:
 
 ### Creating Table Cells
 
-`method` Cake\\View\\Helper\\HtmlHelper::**tableCells**(array $data, array $oddTrOptions = null, array $evenTrOptions = null, $useCount = false, $continueOddEven = true)
+`method` Cake\\View\\Helper\\HtmlHelper::**tableCells**(array $data, array $oddTrOptions = null, array $evenTrOptions = null, $useCount = false, $continueOddEven = true): string
 
 Creates table cells, in rows, assigning \<tr\> attributes differently
 for odd- and even-numbered rows. Wrap a single table cell within an

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -10,7 +10,7 @@ create paginated datasets and do paginated queries.
 
 ## Setting the paginated resultset
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**setPaginated**($paginated, $options)
+`method` Cake\\View\\Helper\\PaginatorHelper::**setPaginated**($paginated, $options): void
 
 By default the helper uses the first instance of `Cake\Datasource\Paging\PaginatedInterface`
 it finds in the view variables. (Generally the result of `Controller::paginate()`).
@@ -112,7 +112,7 @@ PaginatorHelper uses the following templates:
 
 ### Creating Sort Links
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**sort**($key, $title = null, $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**sort**($key, $title = null, $options = []): string
 
 Generates a sorting link. Sets querystring parameters for the sort and
 direction. Links will default to sorting by asc. After the first click, links
@@ -189,13 +189,13 @@ echo $this->Paginator->sort('user_id', null, ['direction' => 'asc', 'lock' => tr
 
 ### Getting Sort Direction and Key
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**sortDir**(string $model = null, mixed $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**sortDir**(string $model = null, mixed $options = []): string
 
 `method` Cake\\View\\Helper\\PaginatorHelper::**sortKey**(string $model = null, mixed $options = [])
 
 ### Creating Page Number Links
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**numbers**($options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**numbers**($options = []): string
 
 Returns a set of numbers for the paged result set. Uses a modulus to
 decide how many numbers to show on each side of the current page By default
@@ -251,19 +251,19 @@ pages in the paged data set.
 
 ### prev()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**prev**($title = '<< Previous', $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**prev**($title = '<< Previous', $options = []): string
 
 ### next()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**next**($title = 'Next >>', $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**next**($title = 'Next >>', $options = []): string
 
 ### first()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**first**($first = '<< first', $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**first**($first = '<< first', $options = []): string
 
 ### last()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**last**($last = 'last >>', $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**last**($last = 'last >>', $options = []): string
 
 ### Creating Header Link Tags
 
@@ -282,27 +282,27 @@ echo $this->Paginator->meta(['first' => true, 'last' => true]);
 
 #### current()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**current**()
+`method` Cake\\View\\Helper\\PaginatorHelper::**current**(): int
 
 #### hasNext()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**()
+`method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**(string $model = null): bool
 
 #### hasPrev()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**hasPrev**()
+`method` Cake\\View\\Helper\\PaginatorHelper::**hasPrev**(): bool
 
 #### hasPage()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**hasPage**(int $page = 1)
+`method` Cake\\View\\Helper\\PaginatorHelper::**hasPage**(int $page = 1): bool
 
 #### total()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**total**()
+`method` Cake\\View\\Helper\\PaginatorHelper::**total**(): int|null
 
 ### Creating a Page Counter
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**counter**(string $format = 'pages')
+`method` Cake\\View\\Helper\\PaginatorHelper::**counter**(string $format = 'pages', array $options = []): string
 
 Returns a counter string for the paged result set. Using a provided format
 string and a number of options you can create localized and application
@@ -340,7 +340,7 @@ echo $this->Paginator->counter('range');
 
 ### Generating Pagination URLs
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**generateUrl**(array $options = [], array $url = [], array $urlOptions = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**generateUrl**(array $options = [], ?string $model = null, array $url = [], array $urlOptions = []): string
 
 By default returns a full pagination URL string for use in non-standard contexts
 (i.e. JavaScript). :
@@ -362,7 +362,7 @@ echo $this->Paginator->generateUrl(
 
 ### Creating a Limit Selectbox Control
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**limitControl**(array $limits = [], $default = null, array $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**limitControl**(array $limits = [], $default = null, array $options = []): string
 
 Create a dropdown control that changes the `limit` query parameter:
 
@@ -419,7 +419,7 @@ automatically use the `maxLimit` value as the only available option.
 
 ### Configuring Pagination Options
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**options**($options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**options**($options = []): void
 
 Sets all the options for the PaginatorHelper. Supported options are:
 

--- a/docs/en/views/helpers/text.md
+++ b/docs/en/views/helpers/text.md
@@ -10,7 +10,7 @@ truncating long stretches of text.
 
 ## Linking Email addresses
 
-`method` Cake\\View\\Helper\\TextHelper::**autoLinkEmails**(string $text, array $options = [])
+`method` Cake\\View\\Helper\\TextHelper::**autoLinkEmails**(string $text, array $options = []): string
 
 Adds links to the well-formed email addresses in \$text, according
 to any options defined in `$options` (see
@@ -34,7 +34,7 @@ option to disable this if necessary.
 
 ## Linking URLs
 
-`method` Cake\\View\\Helper\\TextHelper::**autoLinkUrls**(string $text, array $options = [])
+`method` Cake\\View\\Helper\\TextHelper::**autoLinkUrls**(string $text, array $options = []): string
 
 Same as `autoLinkEmails()`, only this method searches for
 strings that start with https, http, ftp, or nntp and links them
@@ -45,7 +45,7 @@ option to disable this if necessary.
 
 ## Linking Both URLs and Email Addresses
 
-`method` Cake\\View\\Helper\\TextHelper::**autoLink**(string $text, array $options = [])
+`method` Cake\\View\\Helper\\TextHelper::**autoLink**(string $text, array $options = []): string
 
 Performs the functionality in both `autoLinkUrls()` and
 `autoLinkEmails()` on the supplied `$text`. All URLs and emails
@@ -64,7 +64,7 @@ Further options:
 
 ## Converting Text into Paragraphs
 
-`method` Cake\\View\\Helper\\TextHelper::**autoParagraph**(string $text)
+`method` Cake\\View\\Helper\\TextHelper::**autoParagraph**(string $text): string
 
 Adds proper \<p\> around text where double-line returns are found, and \<br\> where
 single-line returns are found. :

--- a/docs/en/views/helpers/url.md
+++ b/docs/en/views/helpers/url.md
@@ -9,7 +9,7 @@ overriding the core helper with an application one. See the
 
 ## Generating URLs
 
-`method` Cake\\View\\Helper\\UrlHelper::**build**($url = null, array $options = [])
+`method` Cake\\View\\Helper\\UrlHelper::**build**($url = null, array $options = []): string
 
 Returns a URL pointing to a combination of controller and action.
 If `$url` is empty, it returns the `REQUEST_URI`, otherwise it
@@ -113,7 +113,7 @@ $this->Url->build('/posts', [
 
 ### Building URLs from Route Paths
 
-`method` Cake\\View\\Helper\\UrlHelper::**buildFromPath**(string $path, array $params = [], array $options = [])
+`method` Cake\\View\\Helper\\UrlHelper::**buildFromPath**(string $path, array $params = [], array $options = []): string
 
 If you want to use route path strings, you can do that using this method:
 


### PR DESCRIPTION
## Summary

- Add scalar/simple return types to 243 method signatures across 28 documentation files
- Return types include `string`, `int`, `float`, `bool`, `void`, `array`, `mixed`, `null`, `self`, `static`, and union types (e.g., `string|null`, `int|false`)
- All return types cross-referenced against the CakePHP 5.x source code
- Object return types (Query, Entity, Response, etc.) are intentionally left out for a separate pass

## Files Changed

**Core Libraries (14 files):** app, caching, collections, hash, inflector, logging, number, plugin, security, text, time, xml
**Controllers (3 files):** controllers, request-response
**ORM (4 files):** database-basics, deleting-data, saving-data, table-objects
**Views (6 files):** views, form helper, html helper, paginator helper, text helper, url helper
**Development (2 files):** configuration, debugging
**Console Commands (2 files):** input-output, option-parsers