### PR TITLE
Add object/interface return types to method signatures

### DIFF
--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -204,7 +204,7 @@ view class.
 
 ### Rendering a View
 
-`method` Cake\\Controller\\Controller::**render**(string $view, string $layout)
+`method` Cake\\Controller\\Controller::**render**(string $view, string $layout): Response
 
 The `Controller::render()` method is automatically called at the end of each requested
 controller action. This method performs all the view logic (using the data
@@ -411,7 +411,7 @@ replaces usage of `RequestHandlerComponent` automatically using the
 
 ## Redirecting to Other Pages
 
-`method` Cake\\Controller\\Controller::**redirect**(string|array $url, integer $status)
+`method` Cake\\Controller\\Controller::**redirect**(string|array $url, integer $status): Response|null
 
 The `redirect()` method adds a `Location` header and sets the status code of
 a response and returns it. You should return the response created by
@@ -502,7 +502,7 @@ $authors = $this->fetchModel('Authors');
 
 ## Paginating a Model
 
-`method` Cake\\Controller\\Controller::**paginate**()
+`method` Cake\\Controller\\Controller::**paginate**(): PaginatedInterface
 
 This method is used for paginating results fetched by your models.
 You can specify page sizes, model find conditions and more. See the
@@ -525,7 +525,7 @@ class ArticlesController extends AppController
 
 ## Configuring Components to Load
 
-`method` Cake\\Controller\\Controller::**loadComponent**($name, $config = [])
+`method` Cake\\Controller\\Controller::**loadComponent**($name, $config = []): Component
 
 In your Controller's `initialize()` method you can define any components you
 want loaded, and any configuration data for them:

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -218,7 +218,7 @@ necessary. In an CLI environment, where the concept of uploading files doesn't
 exist, it will allow to move the file that you've referenced irrespective of its
 origins, which makes testing file uploads possible.
 
-`method` Cake\\Http\\ServerRequest::**getUploadedFile**($path)
+`method` Cake\\Http\\ServerRequest::**getUploadedFile**($path): UploadedFileInterface|null
 
 Returns the uploaded file at a specific path. The path uses the same dot syntax as the
 `Cake\Http\ServerRequest::getData()` method:
@@ -281,7 +281,7 @@ $this->request = $this->request->withUploadedFiles($files);
 
 ### PUT, PATCH or DELETE Data
 
-`method` Cake\\Http\\ServerRequest::**getBody**()
+`method` Cake\\Http\\ServerRequest::**getBody**(): StreamInterface
 
 When building REST services, you often accept request data on `PUT` and
 `DELETE` requests. Any `application/x-www-form-urlencoded` request body data
@@ -1205,7 +1205,7 @@ The `CorsBuilder` provides the following methods for configuring CORS:
 
 `method` Cake\\Http\\CorsBuilder::**maxAge**(string|int $age)
 
-`method` Cake\\Http\\CorsBuilder::**build**()
+`method` Cake\\Http\\CorsBuilder::**build**(): ResponseInterface
 
 #### Practical CORS Examples
 

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -419,7 +419,7 @@ return $cloud;
 
 ### Cache::readMany()
 
-`static` Cake\\Cache\\Cache::**readMany**($keys, $config = 'default')
+`static` Cake\\Cache\\Cache::**readMany**($keys, $config = 'default'): iterable
 
 After you've written multiple keys at once, you'll probably want to read them as
 well. While you could use multiple calls to `read()`, `readMany()` allows

--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -58,7 +58,7 @@ a matching path is not found the default value will be returned.
 
 ### Hash::extract()
 
-`static` Cake\\Utility\\Hash::**extract**(array|ArrayAccess $data, $path)
+`static` Cake\\Utility\\Hash::**extract**(array|ArrayAccess $data, $path): ArrayAccess|array
 
 `Hash::extract()` supports all expression, and matcher components of
 [Hash Path Syntax](#hash-path-syntax). You can use extract to retrieve data from arrays
@@ -130,7 +130,7 @@ $result = Hash::insert($data, '{n}[up].Item[id=4].new', 9);
 
 ### Hash::remove()
 
-`static` Cake\\Utility\\Hash::**remove**(array $data, $path)
+`static` Cake\\Utility\\Hash::**remove**(array $data, $path): ArrayAccess|array
 
 Removes all elements from an array that match `$path`:
 

--- a/docs/en/core-libraries/xml.md
+++ b/docs/en/core-libraries/xml.md
@@ -9,7 +9,7 @@ DOMDocument objects, and back into arrays again.
 
 ### Xml::build()
 
-`static` Cake\\Utility\\Xml::**build**($input, array $options = [])
+`static` Cake\\Utility\\Xml::**build**($input, array $options = []): SimpleXMLElement|DOMDocument
 
 You can load XML-ish data using `Xml::build()`. Depending on your
 `$options` parameter, this method will return a SimpleXMLElement (default)

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -339,7 +339,7 @@ references to existing connections.
 
 ### Accessing Connections
 
-`static` Cake\\Datasource\\ConnectionManager::**get**($name)
+`static` Cake\\Datasource\\ConnectionManager::**get**($name): ConnectionInterface
 
 Once configured connections can be fetched using
 `Cake\Datasource\ConnectionManager::get()`. This method will
@@ -956,7 +956,7 @@ transactional operations.
 
 ### Executing Queries
 
-`method` Cake\\Database\\Connection::**execute(string $sql, array $params = [], array $types = []): \\Cake\\Database\\StatementInterface**()
+`method` Cake\\Database\\Connection::**execute**(string $sql, array $params = [], array $types = []): StatementInterface
 
 Once you've gotten a connection object, you'll probably want to issue some
 queries with it. CakePHP's database abstraction layer provides wrapper features
@@ -990,7 +990,7 @@ $statement = $connection->execute(
 );
 ```
 
-`method` Cake\\Database\\Connection::**selectQuery**()
+`method` Cake\\Database\\Connection::**selectQuery**(): SelectQuery
 
 These methods allow you to use rich data types in your applications and properly convert
 them into SQL statements. The last and most flexible way of creating queries is
@@ -1015,7 +1015,7 @@ foreach ($query as $row) {
 > Instead of iterating the `$query` you can also call it's `all()` method
 > to get the results.
 
-`method` Cake\\Database\\Connection::**updateQuery**()
+`method` Cake\\Database\\Connection::**updateQuery**(): UpdateQuery
 
 This method provides you a builder for `UPDATE` queries:
 
@@ -1026,7 +1026,7 @@ $query = $connection->updateQuery('articles')
 $statement = $query->execute();
 ```
 
-`method` Cake\\Database\\Connection::**insertQuery**()
+`method` Cake\\Database\\Connection::**insertQuery**(): InsertQuery
 
 This method provides you a builder for `INSERT` queries:
 
@@ -1038,7 +1038,7 @@ $query->into('articles')
 $statement = $query->execute();
 ```
 
-`method` Cake\\Database\\Connection::**deleteQuery**()
+`method` Cake\\Database\\Connection::**deleteQuery**(): DeleteQuery
 
 This method provides you a builder for `DELETE` queries:
 

--- a/docs/en/orm/deleting-data.md
+++ b/docs/en/orm/deleting-data.md
@@ -66,7 +66,7 @@ $this->hasMany('Comments', [
 
 ## Bulk Deletes
 
-`method` Cake\\ORM\\Table::**deleteMany**(iterable $entities, array $options = [])
+`method` Cake\\ORM\\Table::**deleteMany**(iterable $entities, array $options = []): iterable|false
 
 If you have an array of entities you want to delete you can use `deleteMany()`
 to delete them in a single transaction:

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -25,7 +25,7 @@ ways to inspect the data returned by the ORM.
 
 ## Getting a Single Entity by Primary Key
 
-`method` Cake\\ORM\\Table::**get**(mixed $primaryKey, array|string $finder = 'all', CacheInterface|string|null $cache = null, Closure|string|null $cacheKey = null, mixed ...$args)
+`method` Cake\\ORM\\Table::**get**(mixed $primaryKey, array|string $finder = 'all', CacheInterface|string|null $cache = null, Closure|string|null $cacheKey = null, mixed ...$args): EntityInterface
 
 It is often convenient to load a single entity from the database when editing or
 viewing entities and their related data. You can do this by using `get()`:
@@ -79,7 +79,7 @@ The parameters supported by `get()` are:
 
 ## Using Finders to Load Data
 
-`method` Cake\\ORM\\Table::**find**(string $type = 'all', mixed ...$args)
+`method` Cake\\ORM\\Table::**find**(string $type = 'all', mixed ...$args): SelectQuery
 
 Before you can work with entities, you'll need to load them. The easiest way to
 do this is using the `find()` method. The find method provides a short and

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -795,7 +795,7 @@ The `strictFields` option was added in 5.3.0.
 
 ## Saving Entities
 
-`method` Cake\\ORM\\Table::**save**(Entity $entity, array $options = [])
+`method` Cake\\ORM\\Table::**save**(Entity $entity, array $options = []): EntityInterface|false
 
 When saving request data to your database you need to first hydrate a new entity
 using `newEntity()` for passing into `save()`. For example:
@@ -1253,7 +1253,7 @@ would not normally be able to.
 
 ## Strict Saving
 
-`method` Cake\\ORM\\Table::**saveOrFail**(EntityInterface $entity, array $options = [])
+`method` Cake\\ORM\\Table::**saveOrFail**(EntityInterface $entity, array $options = []): EntityInterface
 
 Using this method will throw an
 `Cake\ORM\Exception\PersistenceFailedException` if:
@@ -1285,7 +1285,7 @@ corresponding save events will be triggered.
 
 ## Find or Create an Entity
 
-`method` Cake\\ORM\\Table::**findOrCreate**($search, $callback = null, $options = [])
+`method` Cake\\ORM\\Table::**findOrCreate**($search, $callback = null, $options = []): EntityInterface
 
 Find an existing record based on `$search` or create a new record using the
 properties in `$search` and calling the optional `$callback`. This method is
@@ -1344,7 +1344,7 @@ $table->saveOrFail($record);
 
 ## Saving Multiple Entities
 
-`method` Cake\\ORM\\Table::**saveMany**(iterable $entities, array $options = [])
+`method` Cake\\ORM\\Table::**saveMany**(iterable $entities, array $options = []): iterable|false
 
 Using this method you can save multiple entities atomically. `$entities` can
 be an array of entities created using `newEntities()` / `patchEntities()`.


### PR DESCRIPTION
## Summary
- Adds object and interface return types to 24 method signatures across 9 documentation files
- Uses short class names (e.g., `Response`, `EntityInterface`, `SelectQuery`) rather than FQCN
- Also fixes malformed `Connection::execute()` signature formatting

Return types added include: `Response`, `Response|null`, `PaginatedInterface`, `Component`, `EntityInterface`, `EntityInterface|false`, `SelectQuery`, `UpdateQuery`, `InsertQuery`, `DeleteQuery`, `ConnectionInterface`, `StatementInterface`, `UploadedFileInterface|null`, `StreamInterface`, `ResponseInterface`, `SimpleXMLElement|DOMDocument`, `ArrayAccess|array`, `iterable`, `iterable|false`

Companion to #8173 which added scalar return types.