### PR TITLE
Fix FrankenPHP Docker example and add local dev tip

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -386,10 +386,11 @@ FROM dunglas/frankenphp
 # Copy your CakePHP application
 COPY . /app
 
-# Set working directory
-WORKDIR /app/webroot
+# FrankenPHP defaults to /app/public as document root.
+# CakePHP uses webroot/ instead, so override it:
+ENV SERVER_ROOT=/app/webroot
 
-# Install dependencies if needed
+# Install dependencies (composer.json lives in /app)
 RUN composer install --no-dev --optimize-autoloader
 
 # Build and run:
@@ -420,6 +421,14 @@ myapp.local {
 }
 ```
 
+:::
+
+::: tip Local Development
+For local development, you can use the built-in CakePHP development server with FrankenPHP support:
+```bash
+bin/cake server --frankenphp
+```
+This requires the `frankenphp` binary to be available in your `PATH`.
 :::
 
 ::: info Why FrankenPHP?


### PR DESCRIPTION
## Summary

- Replace `WORKDIR /app/webroot` with `ENV SERVER_ROOT=/app/webroot` in the Dockerfile example. FrankenPHP's default document root is `/app/public`, and `WORKDIR` only changes the working directory for subsequent Docker commands — it does not change the server's document root. CakePHP uses `webroot/` instead of `public/`, so the `SERVER_ROOT` environment variable is needed.
- Fix `composer install` which previously ran in `webroot/` (due to WORKDIR) but needs to run in `/app` where `composer.json` lives. Removing WORKDIR fixes this since the default is `/app`.
- Add a tip about `bin/cake server --frankenphp` for local development (available since CakePHP 5.3).