### PR TITLE
Add internal link checker for documentation

### DIFF
--- a/.github/linkchecker-baseline.json
+++ b/.github/linkchecker-baseline.json
@@ -1,0 +1,2107 @@
+[
+  {
+    "file": "docs/en/appendices/5-0-migration-guide.md",
+    "link": "../deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/en/deployment.md"
+  },
+  {
+    "file": "docs/en/appendices/5-1-migration-guide.md",
+    "link": "../core-libraries/events#registering-event-listeners",
+    "message": "Anchor '#registering-event-listeners' not found in docs/en/core-libraries/events.md"
+  },
+  {
+    "file": "docs/en/appendices/5-2-migration-guide.md",
+    "link": "../views/helpers/form#customizing-templates",
+    "message": "Anchor '#customizing-templates' not found in docs/en/views/helpers/form.md"
+  },
+  {
+    "file": "docs/en/appendices/5-3-migration-guide.md",
+    "link": "../orm/query-builder#dto-projection",
+    "message": "Anchor '#dto-projection' not found in docs/en/orm/query-builder.md"
+  },
+  {
+    "file": "docs/en/console-commands.md",
+    "link": "plugins#plugin-commands",
+    "message": "Anchor '#plugin-commands' not found in docs/en/plugins.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+  },
+  {
+    "file": "docs/en/contents.md",
+    "link": "appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+  },
+  {
+    "file": "docs/en/contributing/backwards-compatibility.md",
+    "link": "../appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+  },
+  {
+    "file": "docs/en/contributing/code.md",
+    "link": "../orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/contributing/documentation.md",
+    "link": "../path/to/page.md",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/path/to/page.md"
+  },
+  {
+    "file": "docs/en/contributing/documentation.md",
+    "link": "./installation.md",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/installation.md"
+  },
+  {
+    "file": "docs/en/contributing/documentation.md",
+    "link": "./controllers/components.md",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/controllers/components.md"
+  },
+  {
+    "file": "docs/en/contributing/documentation.md",
+    "link": "./other-page.md#section-anchor",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/other-page.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "controllers/request-response#cake-request",
+    "message": "Anchor '#cake-request' not found in docs/en/controllers/request-response.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "development/routing#file-extensions",
+    "message": "Anchor '#file-extensions' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "controllers/request-response#check-the-request",
+    "message": "Anchor '#check-the-request' not found in docs/en/controllers/request-response.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "controllers/components#redirect-component-events",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/controllers.md",
+    "link": "controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+  },
+  {
+    "file": "docs/en/controllers/middleware.md",
+    "link": "/middleware-setup.png",
+    "message": "File not found: /middleware-setup.png.md"
+  },
+  {
+    "file": "docs/en/controllers/middleware.md",
+    "link": "/middleware-request.png",
+    "message": "File not found: /middleware-request.png.md"
+  },
+  {
+    "file": "docs/en/controllers/middleware.md",
+    "link": "../controllers#controller-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/controllers/pagination.md",
+    "link": "../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/controllers/pagination.md",
+    "link": "../views/helpers/paginator#paginator-helper-multiple",
+    "message": "Anchor '#paginator-helper-multiple' not found in docs/en/views/helpers/paginator.md"
+  },
+  {
+    "file": "docs/en/controllers/request-response.md",
+    "link": "../controllers/middleware#body-parser-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/controllers/request-response.md",
+    "link": "../controllers/middleware#body-parser-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/controllers/request-response.md",
+    "link": "../controllers#controller-viewclasses",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/controllers/request-response.md",
+    "link": "../controllers/middleware#encrypted-cookie-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/caching.md",
+    "link": "../orm/query-builder#caching-query-results",
+    "message": "Anchor '#caching-query-results' not found in docs/en/orm/query-builder.md"
+  },
+  {
+    "file": "docs/en/core-libraries/caching.md",
+    "link": "../orm/query-builder#caching-query-results",
+    "message": "Anchor '#caching-query-results' not found in docs/en/orm/query-builder.md"
+  },
+  {
+    "file": "docs/en/core-libraries/email.md",
+    "link": "../core-libraries/logging#logging-levels",
+    "message": "Anchor '#logging-levels' not found in docs/en/core-libraries/logging.md"
+  },
+  {
+    "file": "docs/en/core-libraries/email.md",
+    "link": "../views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/email.md",
+    "link": "../core-libraries/events#registering-event-listeners",
+    "message": "Anchor '#registering-event-listeners' not found in docs/en/core-libraries/events.md"
+  },
+  {
+    "file": "docs/en/core-libraries/events.md",
+    "link": "../orm/table-objects#table-callbacks",
+    "message": "Anchor '#table-callbacks' not found in docs/en/orm/table-objects.md"
+  },
+  {
+    "file": "docs/en/core-libraries/events.md",
+    "link": "../controllers#controller-life-cycle",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/events.md",
+    "link": "../views#view-events",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/events.md",
+    "link": "../orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/events.md",
+    "link": "../controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/events.md",
+    "link": "../views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/internationalization-and-localization.md",
+    "link": "../controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/internationalization-and-localization.md",
+    "link": "../controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/core-libraries/time.md",
+    "link": "../core-libraries/internationalization-and-localization#parsing-localized-dates",
+    "message": "Anchor '#parsing-localized-dates' not found in docs/en/core-libraries/internationalization-and-localization.md"
+  },
+  {
+    "file": "docs/en/core-libraries/validation.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/deployment.md",
+    "link": "security/csrf#csrf-middleware",
+    "message": "Anchor '#csrf-middleware' not found in docs/en/security/csrf.md"
+  },
+  {
+    "file": "docs/en/deployment.md",
+    "link": "installation#url-rewriting",
+    "message": "Anchor '#url-rewriting' not found in docs/en/installation.md"
+  },
+  {
+    "file": "docs/en/deployment.md",
+    "link": "/migrations/",
+    "message": "File not found: /migrations.md"
+  },
+  {
+    "file": "docs/en/development/application.md",
+    "link": "../controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/development/application.md",
+    "link": "../controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/development/application.md",
+    "link": "../console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+  },
+  {
+    "file": "docs/en/development/application.md",
+    "link": "../controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/development/application.md",
+    "link": "../views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/development/application.md",
+    "link": "../development/testing#integration-testing",
+    "message": "Anchor '#integration-testing' not found in docs/en/development/testing.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../controllers/request-response#request-file-uploads",
+    "message": "Anchor '#request-file-uploads' not found in docs/en/controllers/request-response.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../core-libraries/caching#cache-configuration",
+    "message": "Anchor '#cache-configuration' not found in docs/en/core-libraries/caching.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../development/errors#error-configuration",
+    "message": "Anchor '#error-configuration' not found in docs/en/development/errors.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../core-libraries/logging#log-configuration",
+    "message": "Anchor '#log-configuration' not found in docs/en/core-libraries/logging.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../core-libraries/email#email-configuration",
+    "message": "Anchor '#email-configuration' not found in docs/en/core-libraries/email.md"
+  },
+  {
+    "file": "docs/en/development/configuration.md",
+    "link": "../development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/development/rest.md",
+    "link": "../development/routing#resource-routes",
+    "message": "Anchor '#resource-routes' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/development/rest.md",
+    "link": "../controllers#controller-viewclasses",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/development/routing.md",
+    "link": "../controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+  },
+  {
+    "file": "docs/en/development/routing.md",
+    "link": "../controllers/middleware#routing-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/development/routing.md",
+    "link": "../controllers/middleware#routing-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/development/sessions.md",
+    "link": "../core-libraries/caching#caching-redisengine",
+    "message": "Anchor '#caching-redisengine' not found in docs/en/core-libraries/caching.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../development/application#application-bootstrap",
+    "message": "Anchor '#application-bootstrap' not found in docs/en/development/application.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../controllers/middleware#encrypted-cookie-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../controllers/request-response#request-file-uploads",
+    "message": "Anchor '#request-file-uploads' not found in docs/en/controllers/request-response.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../console-commands/commands#console-integration-testing",
+    "message": "Anchor '#console-integration-testing' not found in docs/en/console-commands/commands.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../core-libraries/httpclient#httpclient-testing",
+    "message": "Anchor '#httpclient-testing' not found in docs/en/core-libraries/httpclient.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../core-libraries/email#email-testing",
+    "message": "Anchor '#email-testing' not found in docs/en/core-libraries/email.md"
+  },
+  {
+    "file": "docs/en/development/testing.md",
+    "link": "../core-libraries/logging#log-testing",
+    "message": "Anchor '#log-testing' not found in docs/en/core-libraries/logging.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+  },
+  {
+    "file": "docs/en/epub-contents.md",
+    "link": "appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+  },
+  {
+    "file": "docs/en/index.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+  },
+  {
+    "file": "docs/en/installation.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/en/intro.md",
+    "link": "views#view-templates",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/intro.md",
+    "link": "views#view-elements",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/intro.md",
+    "link": "controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/intro/cakephp-folder-structure.md",
+    "link": "../controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/intro/cakephp-folder-structure.md",
+    "link": "../controllers/middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+  },
+  {
+    "file": "docs/en/intro/conventions.md",
+    "link": "../development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/orm.md",
+    "link": "orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/orm.md",
+    "link": "intro/conventions#model-and-database-conventions",
+    "message": "Anchor '#model-and-database-conventions' not found in docs/en/intro/conventions.md"
+  },
+  {
+    "file": "docs/en/orm.md",
+    "link": "orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/en/orm/associations.md",
+    "link": "../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/orm/associations.md",
+    "link": "../orm/retrieving-data-and-resultsets#eager-loading-associations",
+    "message": "Anchor '#eager-loading-associations' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/orm/behaviors.md",
+    "link": "../orm/table-objects#table-callbacks",
+    "message": "Anchor '#table-callbacks' not found in docs/en/orm/table-objects.md"
+  },
+  {
+    "file": "docs/en/orm/behaviors.md",
+    "link": "../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/orm/database-basics.md",
+    "link": "../orm/table-objects#configuring-table-connections",
+    "message": "Anchor '#configuring-table-connections' not found in docs/en/orm/table-objects.md"
+  },
+  {
+    "file": "docs/en/orm/database-basics.md",
+    "link": "/bake",
+    "message": "File not found: /bake.md"
+  },
+  {
+    "file": "docs/en/orm/deleting-data.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/orm/entities.md",
+    "link": "../bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+  },
+  {
+    "file": "docs/en/orm/query-builder.md",
+    "link": "../orm/database-basics#database-queries",
+    "message": "Anchor '#database-queries' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/orm/query-builder.md",
+    "link": "../orm/retrieving-data-and-resultsets#table-find-list",
+    "message": "Anchor '#table-find-list' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/orm/query-builder.md",
+    "link": "../orm/database-basics#database-query-logging",
+    "message": "Anchor '#database-query-logging' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/orm/query-builder.md",
+    "link": "../orm/retrieving-data-and-resultsets#map-reduce",
+    "message": "Anchor '#map-reduce' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/orm/query-builder.md",
+    "link": "../orm/database-basics#database-data-types",
+    "message": "Anchor '#database-data-types' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/query-builder#query-count",
+    "message": "Anchor '#query-count' not found in docs/en/orm/query-builder.md"
+  },
+  {
+    "file": "docs/en/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/en/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/entities#lazy-load-associations",
+    "message": "Anchor '#lazy-load-associations' not found in docs/en/orm/entities.md"
+  },
+  {
+    "file": "docs/en/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/query-builder#format-results",
+    "message": "Anchor '#format-results' not found in docs/en/orm/query-builder.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/en/orm/entities.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/validation#validating-request-data",
+    "message": "Anchor '#validating-request-data' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/validation#using-different-validators-per-association",
+    "message": "Anchor '#using-different-validators-per-association' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/en/orm/entities.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/validation#validating-request-data",
+    "message": "Anchor '#validating-request-data' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/en/orm/entities.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../views/helpers/form#associated-form-inputs",
+    "message": "Anchor '#associated-form-inputs' not found in docs/en/views/helpers/form.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/en/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/en/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/en/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/associations#has-many-associations",
+    "message": "Anchor '#has-many-associations' not found in docs/en/orm/associations.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/en/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/associations#belongs-to-many-associations",
+    "message": "Anchor '#belongs-to-many-associations' not found in docs/en/orm/associations.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../views/helpers/form#associated-form-inputs",
+    "message": "Anchor '#associated-form-inputs' not found in docs/en/views/helpers/form.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/database-basics#adding-custom-database-types",
+    "message": "Anchor '#adding-custom-database-types' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/orm/saving-data.md",
+    "link": "../orm/query-builder#query-builder-updating-data",
+    "message": "Anchor '#query-builder-updating-data' not found in docs/en/orm/query-builder.md"
+  },
+  {
+    "file": "docs/en/orm/schema-system.md",
+    "link": "../development/testing#test-fixtures",
+    "message": "Anchor '#test-fixtures' not found in docs/en/development/testing.md"
+  },
+  {
+    "file": "docs/en/orm/table-objects.md",
+    "link": "../orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/en/orm/database-basics.md"
+  },
+  {
+    "file": "docs/en/orm/table-objects.md",
+    "link": "../orm/saving-data#before-marshal",
+    "message": "Anchor '#before-marshal' not found in docs/en/orm/saving-data.md"
+  },
+  {
+    "file": "docs/en/orm/table-objects.md",
+    "link": "../orm/retrieving-data-and-resultsets#map-reduce",
+    "message": "Anchor '#map-reduce' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/orm/table-objects.md",
+    "link": "../orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+  },
+  {
+    "file": "docs/en/pdf-contents.md",
+    "link": "appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+  },
+  {
+    "file": "docs/en/plugins.md",
+    "link": "views#view-elements",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/plugins.md",
+    "link": "deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/en/deployment.md"
+  },
+  {
+    "file": "docs/en/plugins.md",
+    "link": "deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/en/deployment.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../tutorials-and-examples/cms/authentication",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/tutorials-and-examples/cms/authentication.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../tutorials-and-examples/cms/tags-and-users",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/tutorials-and-examples/cms/tags-and-users.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/orm.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../core-libraries/validation",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/core-libraries/validation.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/security.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../development/testing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/development/testing.md"
+  },
+  {
+    "file": "docs/en/quickstart.md",
+    "link": "../deployment",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/deployment.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "security/csrf#csrf-middleware",
+    "message": "Anchor '#csrf-middleware' not found in docs/en/security/csrf.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+  },
+  {
+    "file": "docs/en/topics.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../development/routing#named-routes",
+    "message": "Anchor '#named-routes' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../orm/table-objects#table-callbacks",
+    "message": "Anchor '#table-callbacks' not found in docs/en/orm/table-objects.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../orm/validation#validating-request-data",
+    "message": "Anchor '#validating-request-data' not found in docs/en/orm/validation.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/articles-model.md",
+    "link": "../../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/en/orm/entities.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/authorization.md",
+    "link": "../../orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/tags-and-users.md",
+    "link": "../../bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/tags-and-users.md",
+    "link": "../../controllers/request-response#cake-request",
+    "message": "Anchor '#cake-request' not found in docs/en/controllers/request-response.md"
+  },
+  {
+    "file": "docs/en/tutorials-and-examples/cms/tags-and-users.md",
+    "link": "../../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/en/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/en/views.md",
+    "link": "controllers/request-response#cake-response-file",
+    "message": "Anchor '#cake-response-file' not found in docs/en/controllers/request-response.md"
+  },
+  {
+    "file": "docs/en/views.md",
+    "link": "controllers#setting-view_variables",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/views.md",
+    "link": "views/helpers#helper-api",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+  },
+  {
+    "file": "docs/en/views.md",
+    "link": "views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+  },
+  {
+    "file": "docs/en/views/helpers/form.md",
+    "link": "../../views#view-blocks",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/views/helpers/form.md",
+    "link": "../../views#view-blocks",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/views/helpers/html.md",
+    "link": "../../views#view-blocks",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+  },
+  {
+    "file": "docs/en/views/helpers/url.md",
+    "link": "../../views/helpers#aliasing-helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+  },
+  {
+    "file": "docs/en/views/json-and-xml-views.md",
+    "link": "../controllers#controller-viewclasses",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+  },
+  {
+    "file": "docs/en/views/json-and-xml-views.md",
+    "link": "../development/routing#file-extensions",
+    "message": "Anchor '#file-extensions' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/views/json-and-xml-views.md",
+    "link": "../development/routing#file-extensions",
+    "message": "Anchor '#file-extensions' not found in docs/en/development/routing.md"
+  },
+  {
+    "file": "docs/en/views/themes.md",
+    "link": "../plugins#plugin-create-your-own",
+    "message": "Anchor '#plugin-create-your-own' not found in docs/en/plugins.md"
+  },
+  {
+    "file": "docs/en/views/themes.md",
+    "link": "../deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/en/deployment.md"
+  },
+  {
+    "file": "docs/ja/appendices/5-0-migration-guide.md",
+    "link": "../deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/ja/deployment.md"
+  },
+  {
+    "file": "docs/ja/appendices/5-0-migration-guide.md",
+    "link": "../plugins#loading-a-plugin",
+    "message": "Anchor '#loading-a-plugin' not found in docs/ja/plugins.md"
+  },
+  {
+    "file": "docs/ja/appendices/5-1-migration-guide.md",
+    "link": "../core-libraries/events#registering-event-listeners",
+    "message": "Anchor '#registering-event-listeners' not found in docs/ja/core-libraries/events.md"
+  },
+  {
+    "file": "docs/ja/appendices/5-2-migration-guide.md",
+    "link": "../views/helpers/form#customizing-templates",
+    "message": "Anchor '#customizing-templates' not found in docs/ja/views/helpers/form.md"
+  },
+  {
+    "file": "docs/ja/console-commands.md",
+    "link": "plugins#plugin-commands",
+    "message": "Anchor '#plugin-commands' not found in docs/ja/plugins.md"
+  },
+  {
+    "file": "docs/ja/console-commands/shells.md",
+    "link": "../controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/console-commands/shells.md",
+    "link": "../console-commands/input-output#command-helpers",
+    "message": "Anchor '#command-helpers' not found in docs/ja/console-commands/input-output.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/security/index.md"
+  },
+  {
+    "file": "docs/ja/contents.md",
+    "link": "appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+  },
+  {
+    "file": "docs/ja/contributing/backwards-compatibility.md",
+    "link": "../appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+  },
+  {
+    "file": "docs/ja/contributing/code.md",
+    "link": "../orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/contributing/code.md",
+    "link": "../development/testing#running-tests",
+    "message": "Anchor '#running-tests' not found in docs/ja/development/testing.md"
+  },
+  {
+    "file": "docs/ja/controllers.md",
+    "link": "development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/controllers.md",
+    "link": "controllers/request-response#cake-request",
+    "message": "Anchor '#cake-request' not found in docs/ja/controllers/request-response.md"
+  },
+  {
+    "file": "docs/ja/controllers.md",
+    "link": "controllers/components#configuring-components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/controllers.md",
+    "link": "views/helpers#configuring-helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/controllers.md",
+    "link": "controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/controllers.md",
+    "link": "controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/controllers/components/request-handling.md",
+    "link": "../../controllers/middleware#body-parser-middleware",
+    "message": "Anchor '#body-parser-middleware' not found in docs/ja/controllers/middleware.md"
+  },
+  {
+    "file": "docs/ja/controllers/middleware.md",
+    "link": "/middleware-setup.png",
+    "message": "File not found: /middleware-setup.png.md"
+  },
+  {
+    "file": "docs/ja/controllers/middleware.md",
+    "link": "/middleware-request.png",
+    "message": "File not found: /middleware-request.png.md"
+  },
+  {
+    "file": "docs/ja/controllers/middleware.md",
+    "link": "../development/routing#route-scoped-middleware",
+    "message": "Anchor '#route-scoped-middleware' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/controllers/middleware.md",
+    "link": "../controllers#controller-middleware",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/controllers/middleware.md",
+    "link": "../core-libraries/caching#cache-configuration",
+    "message": "Anchor '#cache-configuration' not found in docs/ja/core-libraries/caching.md"
+  },
+  {
+    "file": "docs/ja/controllers/pagination.md",
+    "link": "../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/controllers/pagination.md",
+    "link": "../views/helpers/paginator#paginator-helper-multiple",
+    "message": "Anchor '#paginator-helper-multiple' not found in docs/ja/views/helpers/paginator.md"
+  },
+  {
+    "file": "docs/ja/controllers/pagination.md",
+    "link": "../orm/table-objects#table-registry-usage",
+    "message": "Anchor '#table-registry-usage' not found in docs/ja/orm/table-objects.md"
+  },
+  {
+    "file": "docs/ja/controllers/request-response.md",
+    "link": "../development/routing#route-elements",
+    "message": "Anchor '#route-elements' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/controllers/request-response.md",
+    "link": "../development/routing#route-elements",
+    "message": "Anchor '#route-elements' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/controllers/request-response.md",
+    "link": "../development/routing#passed-arguments",
+    "message": "Anchor '#passed-arguments' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/controllers/request-response.md",
+    "link": "../development/routing#prefix-routing",
+    "message": "Anchor '#prefix-routing' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/controllers/request-response.md",
+    "link": "../controllers/middleware#body-parser-middleware",
+    "message": "Anchor '#body-parser-middleware' not found in docs/ja/controllers/middleware.md"
+  },
+  {
+    "file": "docs/ja/controllers/request-response.md",
+    "link": "../controllers/middleware#encrypted-cookie-middleware",
+    "message": "Anchor '#encrypted-cookie-middleware' not found in docs/ja/controllers/middleware.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/caching.md",
+    "link": "../orm/query-builder#caching-query-results",
+    "message": "Anchor '#caching-query-results' not found in docs/ja/orm/query-builder.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/caching.md",
+    "link": "../orm/query-builder#caching-query-results",
+    "message": "Anchor '#caching-query-results' not found in docs/ja/orm/query-builder.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/email.md",
+    "link": "../core-libraries/logging#logging-levels",
+    "message": "Anchor '#logging-levels' not found in docs/ja/core-libraries/logging.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/email.md",
+    "link": "../core-libraries/logging#logging-scopes",
+    "message": "Anchor '#logging-scopes' not found in docs/ja/core-libraries/logging.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/email.md",
+    "link": "../views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/email.md",
+    "link": "../core-libraries/events#registering-event-listeners",
+    "message": "Anchor '#registering-event-listeners' not found in docs/ja/core-libraries/events.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../orm/table-objects#table-callbacks",
+    "message": "Anchor '#table-callbacks' not found in docs/ja/orm/table-objects.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../controllers#controller-life-cycle",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../views#view-events",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/events.md",
+    "link": "../development/testing#testing-events",
+    "message": "Anchor '#testing-events' not found in docs/ja/development/testing.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/time.md",
+    "link": "../core-libraries/internationalization-and-localization#parsing-localized-dates",
+    "message": "Anchor '#parsing-localized-dates' not found in docs/ja/core-libraries/internationalization-and-localization.md"
+  },
+  {
+    "file": "docs/ja/core-libraries/validation.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/deployment.md",
+    "link": "security/csrf#csrf-middleware",
+    "message": "Anchor '#csrf-middleware' not found in docs/ja/security/csrf.md"
+  },
+  {
+    "file": "docs/ja/deployment.md",
+    "link": "/migrations/",
+    "message": "File not found: /migrations.md"
+  },
+  {
+    "file": "docs/ja/development/application.md",
+    "link": "../console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+  },
+  {
+    "file": "docs/ja/development/application.md",
+    "link": "../development/testing#integration-testing",
+    "message": "Anchor '#integration-testing' not found in docs/ja/development/testing.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../core-libraries/caching#cache-configuration",
+    "message": "Anchor '#cache-configuration' not found in docs/ja/core-libraries/caching.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../development/errors#error-configuration",
+    "message": "Anchor '#error-configuration' not found in docs/ja/development/errors.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../core-libraries/logging#log-configuration",
+    "message": "Anchor '#log-configuration' not found in docs/ja/core-libraries/logging.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../core-libraries/email#email-configuration",
+    "message": "Anchor '#email-configuration' not found in docs/ja/core-libraries/email.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../development/sessions#session-configuration",
+    "message": "Anchor '#session-configuration' not found in docs/ja/development/sessions.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/development/configuration.md",
+    "link": "../core-libraries/inflector#inflection-configuration",
+    "message": "Anchor '#inflection-configuration' not found in docs/ja/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/ja/development/errors.md",
+    "link": "../development/routing#prefix-routing",
+    "message": "Anchor '#prefix-routing' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/development/rest.md",
+    "link": "../development/routing#resource-routes",
+    "message": "Anchor '#resource-routes' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/development/rest.md",
+    "link": "../development/routing#resource-routes",
+    "message": "Anchor '#resource-routes' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/development/routing.md",
+    "link": "../controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/development/routing.md",
+    "link": "../plugins#plugin-routes",
+    "message": "Anchor '#plugin-routes' not found in docs/ja/plugins.md"
+  },
+  {
+    "file": "docs/ja/development/routing.md",
+    "link": "../controllers/middleware#routing-middleware",
+    "message": "Anchor '#routing-middleware' not found in docs/ja/controllers/middleware.md"
+  },
+  {
+    "file": "docs/ja/development/routing.md",
+    "link": "../controllers/middleware#routing-middleware",
+    "message": "Anchor '#routing-middleware' not found in docs/ja/controllers/middleware.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../development/application#application-bootstrap",
+    "message": "Anchor '#application-bootstrap' not found in docs/ja/development/application.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../controllers/middleware#encrypted-cookie-middleware",
+    "message": "Anchor '#encrypted-cookie-middleware' not found in docs/ja/controllers/middleware.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../controllers/request-response#request-file-uploads",
+    "message": "Anchor '#request-file-uploads' not found in docs/ja/controllers/request-response.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../console-commands/commands#console-integration-testing",
+    "message": "Anchor '#console-integration-testing' not found in docs/ja/console-commands/commands.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../development/dependency-injection#mocking-services-in-tests",
+    "message": "Anchor '#mocking-services-in-tests' not found in docs/ja/development/dependency-injection.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../core-libraries/events#tracking-events",
+    "message": "Anchor '#tracking-events' not found in docs/ja/core-libraries/events.md"
+  },
+  {
+    "file": "docs/ja/development/testing.md",
+    "link": "../core-libraries/email#email-testing",
+    "message": "Anchor '#email-testing' not found in docs/ja/core-libraries/email.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "controllers/components/pagination",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/pagination.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/security/index.md"
+  },
+  {
+    "file": "docs/ja/epub-contents.md",
+    "link": "appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "/read-the-book.jpg",
+    "message": "File not found: /read-the-book.jpg.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "../_downloads/en/CakePHPBook.pdf",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/_downloads/en/CakePHPBook.pdf.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "../_downloads/ja/CakePHP.epub",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/_downloads/ja/CakePHP.epub.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "intro#request-cycle",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/index.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/intro.md",
+    "link": "views#view-templates",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/intro.md",
+    "link": "views#view-elements",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/intro/cakephp-folder-structure.md",
+    "link": "../controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/intro/conventions.md",
+    "link": "../development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/intro/where-to-get-help.md",
+    "link": "irc://irc.freenode.net/cakephp",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp.md"
+  },
+  {
+    "file": "docs/ja/intro/where-to-get-help.md",
+    "link": "irc://irc.freenode.net/cakephp-docs",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-docs.md"
+  },
+  {
+    "file": "docs/ja/intro/where-to-get-help.md",
+    "link": "irc://irc.freenode.net/cakephp-bakery",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-bakery.md"
+  },
+  {
+    "file": "docs/ja/intro/where-to-get-help.md",
+    "link": "irc://irc.freenode.net/cakephp-fr",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-fr.md"
+  },
+  {
+    "file": "docs/ja/intro/where-to-get-help.md",
+    "link": "irc://irc.freenode.net/cakephp-es",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-es.md"
+  },
+  {
+    "file": "docs/ja/orm.md",
+    "link": "orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm.md",
+    "link": "intro/conventions#model-and-database-conventions",
+    "message": "Anchor '#model-and-database-conventions' not found in docs/ja/intro/conventions.md"
+  },
+  {
+    "file": "docs/ja/orm.md",
+    "link": "orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/ja/orm/associations.md",
+    "link": "../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/orm/associations.md",
+    "link": "../orm/retrieving-data-and-resultsets#eager-loading-associations",
+    "message": "Anchor '#eager-loading-associations' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/orm/behaviors.md",
+    "link": "../orm/table-objects#table-callbacks",
+    "message": "Anchor '#table-callbacks' not found in docs/ja/orm/table-objects.md"
+  },
+  {
+    "file": "docs/ja/orm/behaviors.md",
+    "link": "../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/orm/behaviors/counter-cache.md",
+    "link": "../../orm/associations#using-the-through-option",
+    "message": "Anchor '#using-the-through-option' not found in docs/ja/orm/associations.md"
+  },
+  {
+    "file": "docs/ja/orm/database-basics.md",
+    "link": "../orm/table-objects#configuring-table-connections",
+    "message": "Anchor '#configuring-table-connections' not found in docs/ja/orm/table-objects.md"
+  },
+  {
+    "file": "docs/ja/orm/database-basics.md",
+    "link": "../orm/saving-data#saving-complex-types",
+    "message": "Anchor '#saving-complex-types' not found in docs/ja/orm/saving-data.md"
+  },
+  {
+    "file": "docs/ja/orm/database-basics.md",
+    "link": "../orm/saving-data#saving-complex-types",
+    "message": "Anchor '#saving-complex-types' not found in docs/ja/orm/saving-data.md"
+  },
+  {
+    "file": "docs/ja/orm/deleting-data.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/orm/entities.md",
+    "link": "../orm/saving-data#saving-entities",
+    "message": "Anchor '#saving-entities' not found in docs/ja/orm/saving-data.md"
+  },
+  {
+    "file": "docs/ja/orm/entities.md",
+    "link": "../bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+  },
+  {
+    "file": "docs/ja/orm/entities.md",
+    "link": "../orm/saving-data#changing-accessible-fields",
+    "message": "Anchor '#changing-accessible-fields' not found in docs/ja/orm/saving-data.md"
+  },
+  {
+    "file": "docs/ja/orm/entities.md",
+    "link": "../orm/saving-data#saving-complex-types",
+    "message": "Anchor '#saving-complex-types' not found in docs/ja/orm/saving-data.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/database-basics#database-queries",
+    "message": "Anchor '#database-queries' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/retrieving-data-and-resultsets#table-find-list",
+    "message": "Anchor '#table-find-list' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/database-basics#database-query-logging",
+    "message": "Anchor '#database-query-logging' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/retrieving-data-and-resultsets#map-reduce",
+    "message": "Anchor '#map-reduce' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/database-basics#database-data-types",
+    "message": "Anchor '#database-data-types' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/database-basics#database-basics-binding-values",
+    "message": "Anchor '#database-basics-binding-values' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/query-builder.md",
+    "link": "../orm/database-basics#running-select-statements",
+    "message": "Anchor '#running-select-statements' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/query-builder#query-count",
+    "message": "Anchor '#query-count' not found in docs/ja/orm/query-builder.md"
+  },
+  {
+    "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/query-builder#adding-joins",
+    "message": "Anchor '#adding-joins' not found in docs/ja/orm/query-builder.md"
+  },
+  {
+    "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/entities#lazy-load-associations",
+    "message": "Anchor '#lazy-load-associations' not found in docs/ja/orm/entities.md"
+  },
+  {
+    "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
+    "link": "../orm/query-builder#format-results",
+    "message": "Anchor '#format-results' not found in docs/ja/orm/query-builder.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/ja/orm/entities.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/validation#validating-request-data",
+    "message": "Anchor '#validating-request-data' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/validation#using-different-validators-per-association",
+    "message": "Anchor '#using-different-validators-per-association' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/ja/orm/entities.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/validation#validating-request-data",
+    "message": "Anchor '#validating-request-data' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/ja/orm/entities.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/validation#application-rules",
+    "message": "Anchor '#application-rules' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../views/helpers/form#associated-form-inputs",
+    "message": "Anchor '#associated-form-inputs' not found in docs/ja/views/helpers/form.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/ja/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/ja/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/ja/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/associations#has-many-associations",
+    "message": "Anchor '#has-many-associations' not found in docs/ja/orm/associations.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../core-libraries/inflector#inflector-methods-summary",
+    "message": "Anchor '#inflector-methods-summary' not found in docs/ja/core-libraries/inflector.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/associations#belongs-to-many-associations",
+    "message": "Anchor '#belongs-to-many-associations' not found in docs/ja/orm/associations.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../views/helpers/form#associated-form-inputs",
+    "message": "Anchor '#associated-form-inputs' not found in docs/ja/views/helpers/form.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/database-basics#adding-custom-database-types",
+    "message": "Anchor '#adding-custom-database-types' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/saving-data.md",
+    "link": "../orm/query-builder#query-builder-updating-data",
+    "message": "Anchor '#query-builder-updating-data' not found in docs/ja/orm/query-builder.md"
+  },
+  {
+    "file": "docs/ja/orm/schema-system.md",
+    "link": "../development/testing#test-fixtures",
+    "message": "Anchor '#test-fixtures' not found in docs/ja/development/testing.md"
+  },
+  {
+    "file": "docs/ja/orm/table-objects.md",
+    "link": "../orm/database-basics#database-configuration",
+    "message": "Anchor '#database-configuration' not found in docs/ja/orm/database-basics.md"
+  },
+  {
+    "file": "docs/ja/orm/table-objects.md",
+    "link": "../orm/saving-data#before-marshal",
+    "message": "Anchor '#before-marshal' not found in docs/ja/orm/saving-data.md"
+  },
+  {
+    "file": "docs/ja/orm/table-objects.md",
+    "link": "../orm/retrieving-data-and-resultsets#map-reduce",
+    "message": "Anchor '#map-reduce' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/orm/table-objects.md",
+    "link": "../orm/behaviors",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+  },
+  {
+    "file": "docs/ja/orm/validation.md",
+    "link": "../core-libraries/validation#creating-validators",
+    "message": "Anchor '#creating-validators' not found in docs/ja/core-libraries/validation.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "intro",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "controllers/components/pagination",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/pagination.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "security",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/security/index.md"
+  },
+  {
+    "file": "docs/ja/pdf-contents.md",
+    "link": "appendices",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+  },
+  {
+    "file": "docs/ja/plugins.md",
+    "link": "views#view-elements",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/plugins.md",
+    "link": "deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/ja/deployment.md"
+  },
+  {
+    "file": "docs/ja/plugins.md",
+    "link": "deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/ja/deployment.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "views",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "security/csrf#csrf-middleware",
+    "message": "Anchor '#csrf-middleware' not found in docs/ja/security/csrf.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "console-commands",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "contributing",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+  },
+  {
+    "file": "docs/ja/topics.md",
+    "link": "tutorials-and-examples",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../controllers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../development/routing#named-routes",
+    "message": "Anchor '#named-routes' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../development/routing#routes-configuration",
+    "message": "Anchor '#routes-configuration' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../views#view-layouts",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
+    "link": "../../views#view-elements",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/bookmarks/intro.md",
+    "link": "../../controllers/request-response#cake-request",
+    "message": "Anchor '#cake-request' not found in docs/ja/controllers/request-response.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/bookmarks/intro.md",
+    "link": "../../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/bookmarks/part-two.md",
+    "link": "../../controllers/components",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/bookmarks/part-two.md",
+    "link": "../../orm",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../development/routing#named-routes",
+    "message": "Anchor '#named-routes' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../orm/retrieving-data-and-resultsets#dynamic-finders",
+    "message": "Anchor '#dynamic-finders' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../orm/table-objects#table-callbacks",
+    "message": "Anchor '#table-callbacks' not found in docs/ja/orm/table-objects.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
+    "link": "../../orm/validation#validating-request-data",
+    "message": "Anchor '#validating-request-data' not found in docs/ja/orm/validation.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/database.md",
+    "link": "../../orm/entities#entities-mass-assignment",
+    "message": "Anchor '#entities-mass-assignment' not found in docs/ja/orm/entities.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/tags-and-users.md",
+    "link": "../../bake",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/tags-and-users.md",
+    "link": "../../controllers/request-response#cake-request",
+    "message": "Anchor '#cake-request' not found in docs/ja/controllers/request-response.md"
+  },
+  {
+    "file": "docs/ja/tutorials-and-examples/cms/tags-and-users.md",
+    "link": "../../orm/retrieving-data-and-resultsets#custom-find-methods",
+    "message": "Anchor '#custom-find-methods' not found in docs/ja/orm/retrieving-data-and-resultsets.md"
+  },
+  {
+    "file": "docs/ja/views.md",
+    "link": "controllers/request-response#cake-response-file",
+    "message": "Anchor '#cake-response-file' not found in docs/ja/controllers/request-response.md"
+  },
+  {
+    "file": "docs/ja/views.md",
+    "link": "controllers#setting-view_variables",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+  },
+  {
+    "file": "docs/ja/views.md",
+    "link": "views/helpers#helper-api",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/views.md",
+    "link": "views/helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/views/cells.md",
+    "link": "../controllers/pagination#paginating-multiple-queries",
+    "message": "Anchor '#paginating-multiple-queries' not found in docs/ja/controllers/pagination.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/form.md",
+    "link": "../../core-libraries/validation#creating-validators",
+    "message": "Anchor '#creating-validators' not found in docs/ja/core-libraries/validation.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/form.md",
+    "link": "../../views#view-blocks",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/form.md",
+    "link": "../../views#view-blocks",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/html.md",
+    "link": "../../views#view-blocks",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/paginator.md",
+    "link": "../../controllers/pagination#control-which-fields-used-for-ordering",
+    "message": "Anchor '#control-which-fields-used-for-ordering' not found in docs/ja/controllers/pagination.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/paginator.md",
+    "link": "../../controllers/pagination#paginating-multiple-queries",
+    "message": "Anchor '#paginating-multiple-queries' not found in docs/ja/controllers/pagination.md"
+  },
+  {
+    "file": "docs/ja/views/helpers/url.md",
+    "link": "../../views/helpers#aliasing-helpers",
+    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+  },
+  {
+    "file": "docs/ja/views/json-and-xml-views.md",
+    "link": "../development/routing#file-extensions",
+    "message": "Anchor '#file-extensions' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/views/json-and-xml-views.md",
+    "link": "../development/routing#file-extensions",
+    "message": "Anchor '#file-extensions' not found in docs/ja/development/routing.md"
+  },
+  {
+    "file": "docs/ja/views/themes.md",
+    "link": "../plugins#plugin-create-your-own",
+    "message": "Anchor '#plugin-create-your-own' not found in docs/ja/plugins.md"
+  },
+  {
+    "file": "docs/ja/views/themes.md",
+    "link": "../deployment#symlink-assets",
+    "message": "Anchor '#symlink-assets' not found in docs/ja/deployment.md"
+  }
+]

--- a/.github/linkchecker-baseline.json
+++ b/.github/linkchecker-baseline.json
@@ -27,57 +27,57 @@
   {
     "file": "docs/en/contents.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+    "message": "File not found: docs/en/intro/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+    "message": "File not found: docs/en/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+    "message": "File not found: docs/en/contributing/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+    "message": "File not found: docs/en/orm/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+    "message": "File not found: docs/en/console-commands/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+    "message": "File not found: docs/en/security/index.md"
   },
   {
     "file": "docs/en/contents.md",
     "link": "appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+    "message": "File not found: docs/en/appendices/index.md"
   },
   {
     "file": "docs/en/contributing/backwards-compatibility.md",
     "link": "../appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+    "message": "File not found: docs/en/appendices/index.md"
   },
   {
     "file": "docs/en/contributing/code.md",
@@ -87,22 +87,22 @@
   {
     "file": "docs/en/contributing/documentation.md",
     "link": "../path/to/page.md",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/path/to/page.md"
+    "message": "File not found: docs/en/path/to/page.md"
   },
   {
     "file": "docs/en/contributing/documentation.md",
     "link": "./installation.md",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/installation.md"
+    "message": "File not found: docs/en/contributing/installation.md"
   },
   {
     "file": "docs/en/contributing/documentation.md",
     "link": "./controllers/components.md",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/controllers/components.md"
+    "message": "File not found: docs/en/contributing/controllers/components.md"
   },
   {
     "file": "docs/en/contributing/documentation.md",
     "link": "./other-page.md#section-anchor",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/other-page.md"
+    "message": "File not found: docs/en/contributing/other-page.md"
   },
   {
     "file": "docs/en/controllers.md",
@@ -127,37 +127,37 @@
   {
     "file": "docs/en/controllers.md",
     "link": "controllers/components#redirect-component-events",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+    "message": "File not found: docs/en/controllers/components/index.md"
   },
   {
     "file": "docs/en/controllers.md",
     "link": "controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+    "message": "File not found: docs/en/controllers/components/index.md"
   },
   {
     "file": "docs/en/controllers.md",
     "link": "controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/controllers.md",
     "link": "controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+    "message": "File not found: docs/en/controllers/components/index.md"
   },
   {
     "file": "docs/en/controllers/middleware.md",
     "link": "/middleware-setup.png",
-    "message": "File not found: /middleware-setup.png.md"
+    "message": "File not found: ../../../../../middleware-setup.png.md"
   },
   {
     "file": "docs/en/controllers/middleware.md",
     "link": "/middleware-request.png",
-    "message": "File not found: /middleware-request.png.md"
+    "message": "File not found: ../../../../../middleware-request.png.md"
   },
   {
     "file": "docs/en/controllers/middleware.md",
     "link": "../controllers#controller-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/controllers/pagination.md",
@@ -172,22 +172,22 @@
   {
     "file": "docs/en/controllers/request-response.md",
     "link": "../controllers/middleware#body-parser-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/controllers/request-response.md",
     "link": "../controllers/middleware#body-parser-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/controllers/request-response.md",
     "link": "../controllers#controller-viewclasses",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/controllers/request-response.md",
     "link": "../controllers/middleware#encrypted-cookie-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/core-libraries/caching.md",
@@ -207,7 +207,7 @@
   {
     "file": "docs/en/core-libraries/email.md",
     "link": "../views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/core-libraries/email.md",
@@ -222,37 +222,37 @@
   {
     "file": "docs/en/core-libraries/events.md",
     "link": "../controllers#controller-life-cycle",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/core-libraries/events.md",
     "link": "../views#view-events",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/core-libraries/events.md",
     "link": "../orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+    "message": "File not found: docs/en/orm/behaviors/index.md"
   },
   {
     "file": "docs/en/core-libraries/events.md",
     "link": "../controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+    "message": "File not found: docs/en/controllers/components/index.md"
   },
   {
     "file": "docs/en/core-libraries/events.md",
     "link": "../views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+    "message": "File not found: docs/en/views/helpers/index.md"
   },
   {
     "file": "docs/en/core-libraries/internationalization-and-localization.md",
     "link": "../controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/core-libraries/internationalization-and-localization.md",
     "link": "../controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/core-libraries/time.md",
@@ -277,32 +277,32 @@
   {
     "file": "docs/en/deployment.md",
     "link": "/migrations/",
-    "message": "File not found: /migrations.md"
+    "message": "File not found: ../../../../../migrations.md"
   },
   {
     "file": "docs/en/development/application.md",
     "link": "../controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/development/application.md",
     "link": "../controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/development/application.md",
     "link": "../console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+    "message": "File not found: docs/en/console-commands/index.md"
   },
   {
     "file": "docs/en/development/application.md",
     "link": "../controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/development/application.md",
     "link": "../views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/development/application.md",
@@ -352,22 +352,22 @@
   {
     "file": "docs/en/development/rest.md",
     "link": "../controllers#controller-viewclasses",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/development/routing.md",
     "link": "../controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+    "message": "File not found: docs/en/controllers/components/index.md"
   },
   {
     "file": "docs/en/development/routing.md",
     "link": "../controllers/middleware#routing-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/development/routing.md",
     "link": "../controllers/middleware#routing-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/development/sessions.md",
@@ -377,7 +377,7 @@
   {
     "file": "docs/en/development/testing.md",
     "link": "../controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/development/testing.md",
@@ -387,7 +387,7 @@
   {
     "file": "docs/en/development/testing.md",
     "link": "../controllers/middleware#encrypted-cookie-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/development/testing.md",
@@ -417,117 +417,117 @@
   {
     "file": "docs/en/epub-contents.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+    "message": "File not found: docs/en/intro/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+    "message": "File not found: docs/en/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+    "message": "File not found: docs/en/contributing/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+    "message": "File not found: docs/en/orm/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+    "message": "File not found: docs/en/bake/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+    "message": "File not found: docs/en/console-commands/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+    "message": "File not found: docs/en/security/index.md"
   },
   {
     "file": "docs/en/epub-contents.md",
     "link": "appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+    "message": "File not found: docs/en/appendices/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+    "message": "File not found: docs/en/intro/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+    "message": "File not found: docs/en/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+    "message": "File not found: docs/en/orm/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+    "message": "File not found: docs/en/security/index.md"
   },
   {
     "file": "docs/en/index.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+    "message": "File not found: docs/en/intro/index.md"
   },
   {
     "file": "docs/en/installation.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+    "message": "File not found: docs/en/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/en/intro.md",
     "link": "views#view-templates",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/intro.md",
     "link": "views#view-elements",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/intro.md",
     "link": "controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/intro/cakephp-folder-structure.md",
     "link": "../controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/intro/cakephp-folder-structure.md",
     "link": "../controllers/middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/middleware/index.md"
+    "message": "File not found: docs/en/controllers/middleware/index.md"
   },
   {
     "file": "docs/en/intro/conventions.md",
@@ -547,7 +547,7 @@
   {
     "file": "docs/en/orm.md",
     "link": "orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+    "message": "File not found: docs/en/orm/behaviors/index.md"
   },
   {
     "file": "docs/en/orm/associations.md",
@@ -577,7 +577,7 @@
   {
     "file": "docs/en/orm/database-basics.md",
     "link": "/bake",
-    "message": "File not found: /bake.md"
+    "message": "File not found: ../../../../../bake.md"
   },
   {
     "file": "docs/en/orm/deleting-data.md",
@@ -587,7 +587,7 @@
   {
     "file": "docs/en/orm/entities.md",
     "link": "../bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+    "message": "File not found: docs/en/bake/index.md"
   },
   {
     "file": "docs/en/orm/query-builder.md",
@@ -622,7 +622,7 @@
   {
     "file": "docs/en/orm/retrieving-data-and-resultsets.md",
     "link": "../orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+    "message": "File not found: docs/en/orm/behaviors/index.md"
   },
   {
     "file": "docs/en/orm/retrieving-data-and-resultsets.md",
@@ -747,62 +747,62 @@
   {
     "file": "docs/en/orm/table-objects.md",
     "link": "../orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/behaviors/index.md"
+    "message": "File not found: docs/en/orm/behaviors/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/intro/index.md"
+    "message": "File not found: docs/en/intro/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+    "message": "File not found: docs/en/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+    "message": "File not found: docs/en/contributing/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+    "message": "File not found: docs/en/orm/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+    "message": "File not found: docs/en/bake/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+    "message": "File not found: docs/en/console-commands/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/security/index.md"
+    "message": "File not found: docs/en/security/index.md"
   },
   {
     "file": "docs/en/pdf-contents.md",
     "link": "appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/appendices/index.md"
+    "message": "File not found: docs/en/appendices/index.md"
   },
   {
     "file": "docs/en/plugins.md",
     "link": "views#view-elements",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/plugins.md",
@@ -817,62 +817,62 @@
   {
     "file": "docs/en/quickstart.md",
     "link": "../tutorials-and-examples/cms/authentication",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/tutorials-and-examples/cms/authentication.md"
+    "message": "File not found: docs/tutorials-and-examples/cms/authentication.md"
   },
   {
     "file": "docs/en/quickstart.md",
     "link": "../tutorials-and-examples/cms/tags-and-users",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/tutorials-and-examples/cms/tags-and-users.md"
+    "message": "File not found: docs/tutorials-and-examples/cms/tags-and-users.md"
   },
   {
     "file": "docs/en/quickstart.md",
     "link": "../orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/orm.md"
+    "message": "File not found: docs/orm.md"
   },
   {
     "file": "docs/en/quickstart.md",
     "link": "../core-libraries/validation",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/core-libraries/validation.md"
+    "message": "File not found: docs/core-libraries/validation.md"
   },
   {
     "file": "docs/en/quickstart.md",
     "link": "../security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/security.md"
+    "message": "File not found: docs/security.md"
   },
   {
     "file": "docs/en/quickstart.md",
     "link": "../development/testing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/development/testing.md"
+    "message": "File not found: docs/development/testing.md"
   },
   {
     "file": "docs/en/quickstart.md",
     "link": "../deployment",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/deployment.md"
+    "message": "File not found: docs/deployment.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/components/index.md"
+    "message": "File not found: docs/en/controllers/components/index.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+    "message": "File not found: docs/en/views/helpers/index.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+    "message": "File not found: docs/en/orm/index.md"
   },
   {
     "file": "docs/en/topics.md",
@@ -882,22 +882,22 @@
   {
     "file": "docs/en/topics.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/console-commands/index.md"
+    "message": "File not found: docs/en/console-commands/index.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/contributing/index.md"
+    "message": "File not found: docs/en/contributing/index.md"
   },
   {
     "file": "docs/en/topics.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/tutorials-and-examples/index.md"
+    "message": "File not found: docs/en/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/en/tutorials-and-examples/cms/articles-controller.md",
     "link": "../../views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+    "message": "File not found: docs/en/views/helpers/index.md"
   },
   {
     "file": "docs/en/tutorials-and-examples/cms/articles-controller.md",
@@ -922,12 +922,12 @@
   {
     "file": "docs/en/tutorials-and-examples/cms/authorization.md",
     "link": "../../orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/orm/index.md"
+    "message": "File not found: docs/en/orm/index.md"
   },
   {
     "file": "docs/en/tutorials-and-examples/cms/tags-and-users.md",
     "link": "../../bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/bake/index.md"
+    "message": "File not found: docs/en/bake/index.md"
   },
   {
     "file": "docs/en/tutorials-and-examples/cms/tags-and-users.md",
@@ -947,42 +947,42 @@
   {
     "file": "docs/en/views.md",
     "link": "controllers#setting-view_variables",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/views.md",
     "link": "views/helpers#helper-api",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+    "message": "File not found: docs/en/views/helpers/index.md"
   },
   {
     "file": "docs/en/views.md",
     "link": "views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+    "message": "File not found: docs/en/views/helpers/index.md"
   },
   {
     "file": "docs/en/views/helpers/form.md",
     "link": "../../views#view-blocks",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/views/helpers/form.md",
     "link": "../../views#view-blocks",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/views/helpers/html.md",
     "link": "../../views#view-blocks",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/index.md"
+    "message": "File not found: docs/en/views/index.md"
   },
   {
     "file": "docs/en/views/helpers/url.md",
     "link": "../../views/helpers#aliasing-helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/views/helpers/index.md"
+    "message": "File not found: docs/en/views/helpers/index.md"
   },
   {
     "file": "docs/en/views/json-and-xml-views.md",
     "link": "../controllers#controller-viewclasses",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/en/controllers/index.md"
+    "message": "File not found: docs/en/controllers/index.md"
   },
   {
     "file": "docs/en/views/json-and-xml-views.md",
@@ -1032,7 +1032,7 @@
   {
     "file": "docs/ja/console-commands/shells.md",
     "link": "../controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/console-commands/shells.md",
@@ -1042,52 +1042,52 @@
   {
     "file": "docs/ja/contents.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+    "message": "File not found: docs/ja/intro/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+    "message": "File not found: docs/ja/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+    "message": "File not found: docs/ja/contributing/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+    "message": "File not found: docs/ja/console-commands/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/security/index.md"
+    "message": "File not found: docs/ja/security/index.md"
   },
   {
     "file": "docs/ja/contents.md",
     "link": "appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+    "message": "File not found: docs/ja/appendices/index.md"
   },
   {
     "file": "docs/ja/contributing/backwards-compatibility.md",
     "link": "../appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+    "message": "File not found: docs/ja/appendices/index.md"
   },
   {
     "file": "docs/ja/contributing/code.md",
@@ -1112,22 +1112,22 @@
   {
     "file": "docs/ja/controllers.md",
     "link": "controllers/components#configuring-components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/controllers.md",
     "link": "views/helpers#configuring-helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/controllers.md",
     "link": "controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/controllers.md",
     "link": "controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/controllers/components/request-handling.md",
@@ -1137,12 +1137,12 @@
   {
     "file": "docs/ja/controllers/middleware.md",
     "link": "/middleware-setup.png",
-    "message": "File not found: /middleware-setup.png.md"
+    "message": "File not found: ../../../../../middleware-setup.png.md"
   },
   {
     "file": "docs/ja/controllers/middleware.md",
     "link": "/middleware-request.png",
-    "message": "File not found: /middleware-request.png.md"
+    "message": "File not found: ../../../../../middleware-request.png.md"
   },
   {
     "file": "docs/ja/controllers/middleware.md",
@@ -1152,7 +1152,7 @@
   {
     "file": "docs/ja/controllers/middleware.md",
     "link": "../controllers#controller-middleware",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/controllers/middleware.md",
@@ -1227,7 +1227,7 @@
   {
     "file": "docs/ja/core-libraries/email.md",
     "link": "../views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/core-libraries/email.md",
@@ -1242,27 +1242,27 @@
   {
     "file": "docs/ja/core-libraries/events.md",
     "link": "../controllers#controller-life-cycle",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/core-libraries/events.md",
     "link": "../views#view-events",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/core-libraries/events.md",
     "link": "../orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+    "message": "File not found: docs/ja/orm/behaviors/index.md"
   },
   {
     "file": "docs/ja/core-libraries/events.md",
     "link": "../controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/core-libraries/events.md",
     "link": "../views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/core-libraries/events.md",
@@ -1287,12 +1287,12 @@
   {
     "file": "docs/ja/deployment.md",
     "link": "/migrations/",
-    "message": "File not found: /migrations.md"
+    "message": "File not found: ../../../../../migrations.md"
   },
   {
     "file": "docs/ja/development/application.md",
     "link": "../console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+    "message": "File not found: docs/ja/console-commands/index.md"
   },
   {
     "file": "docs/ja/development/application.md",
@@ -1357,7 +1357,7 @@
   {
     "file": "docs/ja/development/routing.md",
     "link": "../controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/development/routing.md",
@@ -1412,112 +1412,112 @@
   {
     "file": "docs/ja/epub-contents.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+    "message": "File not found: docs/ja/intro/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+    "message": "File not found: docs/ja/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+    "message": "File not found: docs/ja/contributing/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+    "message": "File not found: docs/ja/bake/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+    "message": "File not found: docs/ja/console-commands/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "controllers/components/pagination",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/pagination.md"
+    "message": "File not found: docs/ja/controllers/components/pagination.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/security/index.md"
+    "message": "File not found: docs/ja/security/index.md"
   },
   {
     "file": "docs/ja/epub-contents.md",
     "link": "appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+    "message": "File not found: docs/ja/appendices/index.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+    "message": "File not found: docs/ja/intro/index.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "/read-the-book.jpg",
-    "message": "File not found: /read-the-book.jpg.md"
+    "message": "File not found: ../../../../../read-the-book.jpg.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "../_downloads/en/CakePHPBook.pdf",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/_downloads/en/CakePHPBook.pdf.md"
+    "message": "File not found: docs/_downloads/en/CakePHPBook.pdf.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "../_downloads/ja/CakePHP.epub",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/_downloads/ja/CakePHP.epub.md"
+    "message": "File not found: docs/_downloads/ja/CakePHP.epub.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "intro#request-cycle",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+    "message": "File not found: docs/ja/intro/index.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/index.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/intro.md",
     "link": "views#view-templates",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/intro.md",
     "link": "views#view-elements",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/intro/cakephp-folder-structure.md",
     "link": "../controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/intro/conventions.md",
@@ -1527,27 +1527,27 @@
   {
     "file": "docs/ja/intro/where-to-get-help.md",
     "link": "irc://irc.freenode.net/cakephp",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp.md"
+    "message": "File not found: docs/ja/intro/irc:/irc.freenode.net/cakephp.md"
   },
   {
     "file": "docs/ja/intro/where-to-get-help.md",
     "link": "irc://irc.freenode.net/cakephp-docs",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-docs.md"
+    "message": "File not found: docs/ja/intro/irc:/irc.freenode.net/cakephp-docs.md"
   },
   {
     "file": "docs/ja/intro/where-to-get-help.md",
     "link": "irc://irc.freenode.net/cakephp-bakery",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-bakery.md"
+    "message": "File not found: docs/ja/intro/irc:/irc.freenode.net/cakephp-bakery.md"
   },
   {
     "file": "docs/ja/intro/where-to-get-help.md",
     "link": "irc://irc.freenode.net/cakephp-fr",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-fr.md"
+    "message": "File not found: docs/ja/intro/irc:/irc.freenode.net/cakephp-fr.md"
   },
   {
     "file": "docs/ja/intro/where-to-get-help.md",
     "link": "irc://irc.freenode.net/cakephp-es",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/irc:/irc.freenode.net/cakephp-es.md"
+    "message": "File not found: docs/ja/intro/irc:/irc.freenode.net/cakephp-es.md"
   },
   {
     "file": "docs/ja/orm.md",
@@ -1562,7 +1562,7 @@
   {
     "file": "docs/ja/orm.md",
     "link": "orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+    "message": "File not found: docs/ja/orm/behaviors/index.md"
   },
   {
     "file": "docs/ja/orm/associations.md",
@@ -1617,7 +1617,7 @@
   {
     "file": "docs/ja/orm/entities.md",
     "link": "../bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+    "message": "File not found: docs/ja/bake/index.md"
   },
   {
     "file": "docs/ja/orm/entities.md",
@@ -1672,7 +1672,7 @@
   {
     "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
     "link": "../orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+    "message": "File not found: docs/ja/orm/behaviors/index.md"
   },
   {
     "file": "docs/ja/orm/retrieving-data-and-resultsets.md",
@@ -1802,7 +1802,7 @@
   {
     "file": "docs/ja/orm/table-objects.md",
     "link": "../orm/behaviors",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/behaviors/index.md"
+    "message": "File not found: docs/ja/orm/behaviors/index.md"
   },
   {
     "file": "docs/ja/orm/validation.md",
@@ -1812,62 +1812,62 @@
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "intro",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/intro/index.md"
+    "message": "File not found: docs/ja/intro/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+    "message": "File not found: docs/ja/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+    "message": "File not found: docs/ja/contributing/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+    "message": "File not found: docs/ja/bake/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+    "message": "File not found: docs/ja/console-commands/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "controllers/components/pagination",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/pagination.md"
+    "message": "File not found: docs/ja/controllers/components/pagination.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "security",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/security/index.md"
+    "message": "File not found: docs/ja/security/index.md"
   },
   {
     "file": "docs/ja/pdf-contents.md",
     "link": "appendices",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/appendices/index.md"
+    "message": "File not found: docs/ja/appendices/index.md"
   },
   {
     "file": "docs/ja/plugins.md",
     "link": "views#view-elements",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/plugins.md",
@@ -1882,27 +1882,27 @@
   {
     "file": "docs/ja/topics.md",
     "link": "controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/topics.md",
     "link": "controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/topics.md",
     "link": "views",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/topics.md",
     "link": "views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/topics.md",
     "link": "orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/topics.md",
@@ -1912,32 +1912,32 @@
   {
     "file": "docs/ja/topics.md",
     "link": "console-commands",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/console-commands/index.md"
+    "message": "File not found: docs/ja/console-commands/index.md"
   },
   {
     "file": "docs/ja/topics.md",
     "link": "contributing",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/contributing/index.md"
+    "message": "File not found: docs/ja/contributing/index.md"
   },
   {
     "file": "docs/ja/topics.md",
     "link": "tutorials-and-examples",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/tutorials-and-examples/index.md"
+    "message": "File not found: docs/ja/tutorials-and-examples/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
     "link": "../../orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
     "link": "../../controllers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
     "link": "../../views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
@@ -1952,12 +1952,12 @@
   {
     "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
     "link": "../../views#view-layouts",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/blog/part-two.md",
     "link": "../../views#view-elements",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/bookmarks/intro.md",
@@ -1972,17 +1972,17 @@
   {
     "file": "docs/ja/tutorials-and-examples/bookmarks/part-two.md",
     "link": "../../controllers/components",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/components/index.md"
+    "message": "File not found: docs/ja/controllers/components/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/bookmarks/part-two.md",
     "link": "../../orm",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/orm/index.md"
+    "message": "File not found: docs/ja/orm/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
     "link": "../../views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/cms/articles-controller.md",
@@ -2012,7 +2012,7 @@
   {
     "file": "docs/ja/tutorials-and-examples/cms/tags-and-users.md",
     "link": "../../bake",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/bake/index.md"
+    "message": "File not found: docs/ja/bake/index.md"
   },
   {
     "file": "docs/ja/tutorials-and-examples/cms/tags-and-users.md",
@@ -2032,17 +2032,17 @@
   {
     "file": "docs/ja/views.md",
     "link": "controllers#setting-view_variables",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/controllers/index.md"
+    "message": "File not found: docs/ja/controllers/index.md"
   },
   {
     "file": "docs/ja/views.md",
     "link": "views/helpers#helper-api",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/views.md",
     "link": "views/helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/views/cells.md",
@@ -2057,17 +2057,17 @@
   {
     "file": "docs/ja/views/helpers/form.md",
     "link": "../../views#view-blocks",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/views/helpers/form.md",
     "link": "../../views#view-blocks",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/views/helpers/html.md",
     "link": "../../views#view-blocks",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/index.md"
+    "message": "File not found: docs/ja/views/index.md"
   },
   {
     "file": "docs/ja/views/helpers/paginator.md",
@@ -2082,7 +2082,7 @@
   {
     "file": "docs/ja/views/helpers/url.md",
     "link": "../../views/helpers#aliasing-helpers",
-    "message": "File not found: /home/josbeir/Sites/cakedocs/cakephp-docs/docs/ja/views/helpers/index.md"
+    "message": "File not found: docs/ja/views/helpers/index.md"
   },
   {
     "file": "docs/ja/views/json-and-xml-views.md",

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -67,3 +67,38 @@ jobs:
           files: 'docs/**/*.md'
           config: '.github/cspell.json'
           incremental_files_only: true
+
+  link-check:
+    name: Check Internal Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Get changed markdown files
+        id: changed-files
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Get files changed in PR
+            FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD | grep '\.md$' || true)
+            if [ -z "$FILES" ]; then
+              echo "No markdown files changed"
+              echo "files=" >> $GITHUB_OUTPUT
+            else
+              # Convert to space-separated list for script
+              echo "files=$(echo $FILES | tr '\n' ' ')" >> $GITHUB_OUTPUT
+              echo "Checking files:"
+              echo "$FILES"
+            fi
+          else
+            # For push events, check all files using glob pattern
+            echo 'files="docs/**/*.md"' >> $GITHUB_OUTPUT
+            echo 'Checking all files: docs/**/*.md'
+          fi
+
+      - name: Check internal links
+        if: steps.changed-files.outputs.files != ''
+        run: node bin/check-links.js --baseline .github/linkchecker-baseline.json ${{ steps.changed-files.outputs.files }}

--- a/bin/check-links.js
+++ b/bin/check-links.js
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+
+/**
+ * Internal Markdown Link Checker
+ *
+ * Validates internal markdown links in documentation files.
+ * Only checks relative links - ignores external URLs.
+ *
+ * Usage:
+ *   node bin/check-links.js <file-or-pattern>...
+ *   node bin/check-links.js --baseline <path> "docs/subfolder/*.md"
+ *   node bin/check-links.js --generate-baseline "docs/subfolder/*.md"
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BASELINE_FILE = '.github/linkchecker-baseline.json';
+
+/**
+ * Simple glob implementation using Node.js built-ins
+ */
+function globSync(pattern, options = {}) {
+  const results = [];
+
+  // Handle simple patterns like "docs/en/**/*.md"
+  if (pattern.includes('**')) {
+    const [basePath, ...rest] = pattern.split('**');
+    const suffix = rest.join('**').replace(/^\//, ''); // Remove leading slash
+    const baseDir = basePath.replace(/\/$/, '') || '.';
+
+    function traverse(dir) {
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+
+          if (entry.isDirectory()) {
+            traverse(fullPath);
+          } else if (entry.isFile() && matchPattern(entry.name, suffix)) {
+            results.push(options.absolute ? path.resolve(fullPath) : fullPath);
+          }
+        }
+      } catch (err) {
+        // Ignore permission errors
+      }
+    }
+
+    traverse(baseDir);
+  } else {
+    // Simple wildcard pattern like "docs/en/*.md"
+    const dir = path.dirname(pattern);
+    const filePattern = path.basename(pattern);
+
+    if (fs.existsSync(dir)) {
+      const entries = fs.readdirSync(dir);
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry);
+        if (fs.statSync(fullPath).isFile() && matchPattern(entry, filePattern)) {
+          results.push(options.absolute ? path.resolve(fullPath) : fullPath);
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function matchPattern(filename, pattern) {
+  const regex = pattern
+    .replace(/\./g, '\\.')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${regex}$`).test(filename) ||
+         new RegExp(regex).test(filename);
+}
+
+class LinkChecker {
+  constructor(options = {}) {
+    this.errors = [];
+    this.checked = new Set();
+    this.headingCache = new Map();
+    this.generateBaseline = options.generateBaseline || false;
+    this.baselinePath = options.baselinePath || null;
+    this.baseline = this.baselinePath ? this.loadBaseline() : [];
+  }
+
+  /**
+   * Load baseline configuration
+   */
+  loadBaseline() {
+    if (!fs.existsSync(this.baselinePath)) {
+      console.warn(`Warning: Baseline file not found: ${this.baselinePath}`);
+      return [];
+    }
+
+    try {
+      const content = fs.readFileSync(this.baselinePath, 'utf8');
+      return JSON.parse(content);
+    } catch (err) {
+      console.warn(`Warning: Could not load baseline file: ${err.message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Save baseline configuration
+   */
+  saveBaseline() {
+    const baselineData = this.errors.map(error => ({
+      file: error.file,
+      link: error.link,
+      message: error.message
+    }));
+
+    const outputPath = this.baselinePath || BASELINE_FILE;
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    fs.writeFileSync(
+      outputPath,
+      JSON.stringify(baselineData, null, 2) + '\n',
+      'utf8'
+    );
+  }
+
+  /**
+   * Check if an error matches baseline
+   */
+  isInBaseline(error) {
+    return this.baseline.some(baselineError =>
+      baselineError.file === error.file &&
+      baselineError.link === error.link &&
+      baselineError.message === error.message
+    );
+  }
+
+  /**
+   * Main entry point - check files matching patterns
+   */
+  async checkFiles(patterns) {
+    const files = await this.resolveFiles(patterns);
+
+    if (files.length === 0) {
+      console.error('No files found matching patterns');
+      return false;
+    }
+
+    console.log(`Checking ${files.length} file(s)...\n`);
+
+    for (const file of files) {
+      this.checkFile(file);
+    }
+
+    return this.reportResults();
+  }
+
+  /**
+   * Resolve glob patterns to actual file paths
+   */
+  async resolveFiles(patterns) {
+    const fileSet = new Set();
+
+    for (const pattern of patterns) {
+      // Check if it's a direct file path
+      if (fs.existsSync(pattern) && fs.statSync(pattern).isFile()) {
+        fileSet.add(path.resolve(pattern));
+      } else {
+        // Treat as glob pattern
+        const matches = globSync(pattern, {
+          absolute: true
+        });
+        matches.forEach(f => fileSet.add(f));
+      }
+    }
+
+    return Array.from(fileSet).sort();
+  }
+
+  /**
+   * Check all links in a single file
+   */
+  checkFile(filePath) {
+    if (this.checked.has(filePath)) {
+      return;
+    }
+    this.checked.add(filePath);
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    const links = this.extractLinks(content);
+    const sourceDir = path.dirname(filePath);
+
+    for (const link of links) {
+      if (this.isExternalLink(link.url)) {
+        continue;
+      }
+
+      const { targetPath, anchor } = this.parseLink(link.url, sourceDir);
+
+      // Check file exists
+      if (!fs.existsSync(targetPath)) {
+        this.addError(filePath, link, `File not found: ${targetPath}`);
+        continue;
+      }
+
+      // Check anchor if present
+      if (anchor) {
+        const headings = this.getHeadings(targetPath);
+        const anchorId = this.slugify(anchor);
+
+        if (!headings.includes(anchorId)) {
+          this.addError(
+            filePath,
+            link,
+            `Anchor '#${anchor}' not found in ${path.relative(process.cwd(), targetPath)}`
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Extract all markdown links from content
+   */
+  extractLinks(content) {
+    const links = [];
+    // Match [text](url) or [text](url "title")
+    const linkRegex = /\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+    let match;
+
+    while ((match = linkRegex.exec(content)) !== null) {
+      links.push({
+        text: match[1],
+        url: match[2],
+        raw: match[0]
+      });
+    }
+
+    return links;
+  }
+
+  /**
+   * Check if a URL is external
+   */
+  isExternalLink(url) {
+    return /^(https?:\/\/|mailto:|#|\/\/)/i.test(url);
+  }
+
+  /**
+   * Parse link URL into target path and anchor
+   */
+  parseLink(url, sourceDir) {
+    const [pathPart, anchor] = url.split('#');
+
+    // Handle anchor-only links (same file)
+    if (!pathPart) {
+      return {
+        targetPath: path.join(sourceDir, path.basename(sourceDir) + '.md'),
+        anchor
+      };
+    }
+
+    let targetPath = path.resolve(sourceDir, pathPart);
+
+    // Add .md extension if missing
+    if (!targetPath.endsWith('.md') && !fs.existsSync(targetPath)) {
+      targetPath += '.md';
+    }
+
+    // If path is directory, look for index.md
+    if (fs.existsSync(targetPath) && fs.statSync(targetPath).isDirectory()) {
+      targetPath = path.join(targetPath, 'index.md');
+    }
+
+    return { targetPath, anchor };
+  }
+
+  /**
+   * Extract headings from a markdown file
+   */
+  getHeadings(filePath) {
+    if (this.headingCache.has(filePath)) {
+      return this.headingCache.get(filePath);
+    }
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    const headings = [];
+
+    // Match ATX headings: # Heading
+    const headingRegex = /^#{1,6}\s+(.+)$/gm;
+    let match;
+
+    while ((match = headingRegex.exec(content)) !== null) {
+      const heading = match[1]
+        .replace(/\{[^}]+\}$/g, '') // Remove {#custom-id}
+        .replace(/\[[^\]]+\]\([^)]+\)/g, '') // Remove links
+        .replace(/`([^`]+)`/g, '$1') // Remove code formatting
+        .trim();
+
+      headings.push(this.slugify(heading));
+    }
+
+    this.headingCache.set(filePath, headings);
+    return headings;
+  }
+
+  /**
+   * Convert heading text to anchor ID (VitePress style)
+   */
+  slugify(text) {
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '') // Remove special chars
+      .replace(/\s+/g, '-') // Spaces to hyphens
+      .replace(/-+/g, '-') // Multiple hyphens to single
+      .replace(/^-|-$/g, ''); // Trim hyphens
+  }
+
+  /**
+   * Add an error to the collection
+   */
+  addError(filePath, link, message) {
+    this.errors.push({
+      file: path.relative(process.cwd(), filePath),
+      link: link.url,
+      text: link.text,
+      message
+    });
+  }
+
+  /**
+   * Report results and return success status
+   */
+  reportResults() {
+    if (this.generateBaseline) {
+      this.saveBaseline();
+      const outputPath = this.baselinePath || BASELINE_FILE;
+      console.log(`✓ Baseline generated with ${this.errors.length} known issue(s)`);
+      console.log(`  Saved to: ${outputPath}\n`);
+      return true;
+    }
+
+    // Filter out baseline errors
+    const newErrors = this.errors.filter(error => !this.isInBaseline(error));
+
+    if (newErrors.length === 0 && this.errors.length === 0) {
+      console.log('✓ All internal links are valid!\n');
+      return true;
+    }
+
+    if (newErrors.length === 0 && this.errors.length > 0) {
+      console.log(`✓ No new broken links (${this.errors.length} known issue(s) in baseline)\n`);
+      return true;
+    }
+
+    console.error(`✗ Found ${newErrors.length} new broken link(s):\n`);
+
+    for (const error of newErrors) {
+      console.error(`  ${error.file}`);
+      console.error(`    Link: [${error.text}](${error.link})`);
+      console.error(`    Error: ${error.message}`);
+      console.error('');
+    }
+
+    if (this.errors.length > newErrors.length) {
+      const baselineCount = this.errors.length - newErrors.length;
+      console.error(`  (${baselineCount} known issue(s) ignored from baseline)\n`);
+    }
+
+    return false;
+  }
+}
+
+// Main execution
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse arguments
+  let generateBaseline = false;
+  let baselinePath = null;
+  const patterns = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--generate-baseline') {
+      generateBaseline = true;
+    } else if (args[i] === '--baseline') {
+      if (i + 1 < args.length) {
+        baselinePath = args[++i];
+      } else {
+        console.error('Error: --baseline requires a path argument');
+        process.exit(1);
+      }
+    } else {
+      patterns.push(args[i]);
+    }
+  }
+
+  if (patterns.length === 0) {
+    console.error('Usage: node bin/check-links.js [--baseline <path>] [--generate-baseline] <file-or-pattern>...');
+    console.error('');
+    console.error('Examples:');
+    console.error('  node bin/check-links.js docs/en/installation.md');
+    console.error('  node bin/check-links.js "docs/**/*.md"');
+    console.error('  node bin/check-links.js docs/en/*.md docs/ja/*.md');
+    console.error('');
+    console.error('With baseline:');
+    console.error('  node bin/check-links.js --baseline .github/linkchecker-baseline.json "docs/**/*.md"');
+    console.error('');
+    console.error('Generate baseline:');
+    console.error('  node bin/check-links.js --generate-baseline "docs/**/*.md"');
+    console.error('  node bin/check-links.js --generate-baseline --baseline custom-baseline.json "docs/**/*.md"');
+    process.exit(1);
+  }
+
+  const checker = new LinkChecker({ generateBaseline, baselinePath });
+  const success = await checker.checkFiles(patterns);
+
+  process.exit(success ? 0 : 1);
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main().catch(error => {
+    console.error('Error:', error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = LinkChecker;

--- a/bin/check-links.js
+++ b/bin/check-links.js
@@ -133,8 +133,7 @@ class LinkChecker {
   isInBaseline(error) {
     return this.baseline.some(baselineError =>
       baselineError.file === error.file &&
-      baselineError.link === error.link &&
-      baselineError.message === error.message
+      baselineError.link === error.link
     );
   }
 
@@ -202,7 +201,7 @@ class LinkChecker {
 
       // Check file exists
       if (!fs.existsSync(targetPath)) {
-        this.addError(filePath, link, `File not found: ${targetPath}`);
+        this.addError(filePath, link, `File not found: ${path.relative(process.cwd(), targetPath)}`);
         continue;
       }
 

--- a/docs/en/contributing/documentation.md
+++ b/docs/en/contributing/documentation.md
@@ -514,6 +514,47 @@ npx markdownlint-cli --config .github/markdownlint.json --fix cs/en/**/*.md"
 The `--fix` flag can automatically correct many formatting issues, but not all. Review changes before committing.
 :::
 
+### Running Link Checker
+
+We use a custom link checker to validate internal markdown links in the documentation:
+
+::: code-group
+
+```bash [Single File]
+# Check a single file
+node bin/check-links.js docs/en/your-file.md
+```
+
+```bash [Directory]
+# Check all files in a directory
+node bin/check-links.js "docs/en/controllers/*.md"
+```
+
+```bash [All Docs]
+# Check all documentation recursively
+node bin/check-links.js "docs/**/*.md"
+```
+
+```bash [With Baseline]
+# Check while ignoring known issues in baseline
+node bin/check-links.js --baseline .github/linkchecker-baseline.json "docs/**/*.md"
+```
+
+:::
+
+The link checker validates:
+- Internal file references (relative links)
+- Anchor links to headings within pages
+- Directory index links
+
+::: info External Links
+The link checker only validates internal markdown links. External URLs (http://, https://) are not checked.
+:::
+
+::: tip Known Issues Baseline
+The repository maintains a baseline of known broken links in `.github/linkchecker-baseline.json`. When you run the checker with `--baseline`, it filters out these known issues and only reports new problems. This is useful when working on specific changes without being overwhelmed by pre-existing issues.
+:::
+
 ### GitHub Actions Validation
 
 When you submit a pull request, our CI pipeline automatically runs:
@@ -522,6 +563,7 @@ When you submit a pull request, our CI pipeline automatically runs:
 2. **JSON validation** - Validates `toc_*.json` files
 3. **Markdown linting** - Checks all markdown files
 4. **Spell checking** - Scans documentation for typos
+5. **Link checking** - Validates internal markdown links
 
 ::: tip Pre-flight Check
 ::: code-group
@@ -530,12 +572,14 @@ When you submit a pull request, our CI pipeline automatically runs:
 # Validate markdown and spelling
 npx markdownlint-cli --config .github/markdownlint.json "docs/**/*.md"
 npx cspell --config .github/cspell.json "docs/**/*.md"
+node bin/check-links.js "docs/**/*.md"
 ```
 
 ```bash [Full Validation]
 # Run all CI checks locally
 npx markdownlint-cli --config .github/markdownlint.json "docs/**/*.md"
 npx cspell --config .github/cspell.json "docs/**/*.md"
+node bin/check-links.js "docs/**/*.md"
 node --check config.js
 jq empty toc_en.json
 ```
@@ -544,6 +588,7 @@ jq empty toc_en.json
 # Check your current file before committing
 npx markdownlint-cli --config .github/markdownlint.json docs/en/your-file.md
 npx cspell --config .github/cspell.json docs/en/your-file.md
+node bin/check-links.js docs/en/your-file.md
 ```
 
 :::e --check config.js


### PR DESCRIPTION
This PR adds automated validation of internal markdown links with baseline support for existing issues.

### Changes

**Link Checker Script** (`bin/check-links.js`)
- Validates internal file references and anchor links
- Zero dependencies (Node.js built-ins only)
- Supports glob patterns: `"docs/**/*.md"`
- Baseline filtering to ignore known issues (opt-in)

**CI Integration** (`.github/workflows/docs-validation.yml`)
- Added link-check job
- PRs: Checks only changed files
- Uses baseline to focus on new issues only

**Baseline** (`.github/linkchecker-baseline.json`)
- 421 existing broken links cataloged
- Opt-in via `--baseline` flag

### Usage

```bash
# Check files
node bin/check-links.js docs/en/installation.md
node bin/check-links.js "docs/**/*.md"

# With baseline
node bin/check-links.js --baseline .github/linkchecker-baseline.json "docs/**/*.md"