### PR TITLE
Fix critical method signature mismatches with 5.x source

### DIFF
--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -290,7 +290,7 @@ This would render **plugins/Users/templates/UserDetails/custom_file.php**
 
 ## Content Type Negotiation
 
-`method` Cake\\Controller\\Controller::**addViewClasses**()
+`method` Cake\\Controller\\Controller::**addViewClasses**(array $viewClasses)
 
 Controllers can define a list of view classes they support. After the
 controller's action is complete CakePHP will use the view list to perform

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -326,7 +326,7 @@ $result = Cache::writeMany([
 
 ### Cache::add()
 
-`static` Cake\\Cache\\Cache::**add**($key, $value $config = 'default')
+`static` Cake\\Cache\\Cache::**add**(string $key, mixed $value, string $config = 'default')
 
 Using `Cache::add()` will let you atomically set a key to a value if the key
 does not already exist in the cache. If the key already exists in the cache

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -1025,7 +1025,7 @@ file extensions
 
 ### Routing File Extensions
 
-`static` Cake\\Routing\\RouteBuilder::**extensions**(stringnull $extensions, $merge = true)
+`method` Cake\\Routing\\RouteBuilder::**setExtensions**(array|string $extensions)
 
 To handle different file extensions in your URLs, you can define the extensions
 using the `Cake\Routing\RouteBuilder::setExtensions()` method:

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -304,7 +304,7 @@ see [Exposing Virtual Fields](#exposing-virtual-fields).
 
 ## Checking if an Entity Has Been Modified
 
-`method` Cake\\ORM\\Entity::**dirty**($field = null, $dirty = null)
+`method` Cake\\ORM\\Entity::**isDirty**(?string $field = null)
 
 You may want to make code conditional based on whether or not fields have
 changed in an entity. For example, you may only want to validate fields when

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -25,7 +25,7 @@ ways to inspect the data returned by the ORM.
 
 ## Getting a Single Entity by Primary Key
 
-`method` Cake\\ORM\\Table::**get**($id, $options = [])
+`method` Cake\\ORM\\Table::**get**(mixed $primaryKey, array|string $finder = 'all', CacheInterface|string|null $cache = null, Closure|string|null $cacheKey = null, mixed ...$args)
 
 It is often convenient to load a single entity from the database when editing or
 viewing entities and their related data. You can do this by using `get()`:
@@ -69,26 +69,17 @@ by using the `finder` option:
 $article = $articles->get($id, 'translations');
 ```
 
-The list of options supported by get() are:
+The parameters supported by `get()` are:
 
-- `cache` cache config.
-- `key` cache key.
-- `finder` custom finder function.
-- `conditions` provide conditions for the WHERE clause of your query.
-- `limit` Set the number of rows you want.
-- `offset` Set the page offset you want. You can also use `page` to make
-  the calculation simpler.
-- `contain` define the associations to eager load.
-- `fields` limit the fields loaded into the entity. Only loading some fields
-  can cause entities to behave incorrectly.
-- `group` add a GROUP BY clause to your query. This is useful when using
-  aggregating functions.
-- `having` add a HAVING clause to your query.
-- `join` define additional custom joins.
+- `$primaryKey` The primary key value to look up.
+- `$finder` The finder to use. Can be a string finder name or an array of finder name and options.
+- `$cache` A cache config name or `CacheInterface` instance to use for read-through caching.
+- `$cacheKey` A custom cache key or `Closure` to generate one.
+- `...$args` Additional arguments passed to the finder.
 
 ## Using Finders to Load Data
 
-`method` Cake\\ORM\\Table::**find**($type, mixed ...$args)
+`method` Cake\\ORM\\Table::**find**(string $type = 'all', mixed ...$args)
 
 Before you can work with entities, you'll need to load them. The easiest way to
 do this is using the `find()` method. The find method provides a short and

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -286,7 +286,7 @@ echo $this->Paginator->meta(['first' => true, 'last' => true]);
 
 #### hasNext()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**(string $model = null)
+`method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**()
 
 #### hasPrev()
 
@@ -302,7 +302,7 @@ echo $this->Paginator->meta(['first' => true, 'last' => true]);
 
 ### Creating a Page Counter
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**counter**(string $format = 'pages', array $options = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**counter**(string $format = 'pages')
 
 Returns a counter string for the paged result set. Using a provided format
 string and a number of options you can create localized and application
@@ -340,7 +340,7 @@ echo $this->Paginator->counter('range');
 
 ### Generating Pagination URLs
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**generateUrl**(array $options = [], ?string $model = null, array $url = [], array $urlOptions = [])
+`method` Cake\\View\\Helper\\PaginatorHelper::**generateUrl**(array $options = [], array $url = [], array $urlOptions = [])
 
 By default returns a full pagination URL string for use in non-standard contexts
 (i.e. JavaScript). :


### PR DESCRIPTION
## Summary

Fixes critical method signature mismatches between the documentation and the actual CakePHP 5.x source code. Relates to #7744.

These are the signatures that were fundamentally wrong (nonexistent methods, extra/missing parameters, syntax errors) — not just missing types.

- **`Entity::dirty()`** → `isDirty()` — `dirty()` does not exist in 5.x, replaced by `isDirty()`/`setDirty()`
- **`Table::get($id, $options = [])`** → `get(mixed $primaryKey, array|string $finder = 'all', ...)` — completely different signature since the `$options` array was replaced by named parameters
- **`Table::find($type, ...)`** → `find(string $type = 'all', ...)` — added type and default
- **`RouteBuilder::extensions()`** → `setExtensions()` — `extensions()` does not exist, split into `setExtensions()`/`addExtensions()`/`getExtensions()`
- **`PaginatorHelper::counter($format, $options)`** → `counter(string $format = 'pages')` — `$options` parameter does not exist
- **`PaginatorHelper::generateUrl(..., $model, ...)`** → removed `$model` — parameter does not exist
- **`PaginatorHelper::hasNext($model)`** → `hasNext()` — no parameters in source
- **`Controller::addViewClasses()`** → `addViewClasses(array $viewClasses)` — was missing required parameter
- **`Cache::add($key, $value $config)`** → `add(string $key, mixed $value, string $config = 'default')` — had syntax error (missing comma) and missing types