### PR TITLE
Fix method signature parameter names to match source code

### DIFF
--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -49,7 +49,7 @@ elements, you can use attribute matching with certain methods. They are `extract
 
 ### Hash::get()
 
-`static` Cake\\Utility\\Hash::**get**(array|ArrayAccess $data, $path, $default = null): mixed
+`static` Cake\\Utility\\Hash::**get**(ArrayAccess|array $data, array|string|int|null $path, mixed $default = null): mixed
 
 `get()` is a simplified version of `extract()`, it only supports direct
 path expressions. Paths with `{n}`, `{s}`, `{*}` or matchers are not
@@ -58,7 +58,7 @@ a matching path is not found the default value will be returned.
 
 ### Hash::extract()
 
-`static` Cake\\Utility\\Hash::**extract**(array|ArrayAccess $data, $path): ArrayAccess|array
+`static` Cake\\Utility\\Hash::**extract**(ArrayAccess|array $data, string $path): ArrayAccess|array
 
 `Hash::extract()` supports all expression, and matcher components of
 [Hash Path Syntax](#hash-path-syntax). You can use extract to retrieve data from arrays
@@ -79,7 +79,7 @@ $results = Hash::extract($users, '{n}.id');
 // [1,2,3,4];
 ```
 
-`static` Hash::**insert**(array $data, $path, $values = null): ArrayAccess|array
+`static` Cake\\Utility\\Hash::**insert**(ArrayAccess|array $data, string $path, mixed $values = null): ArrayAccess|array
 
 Inserts `$values` into an array as defined by `$path`:
 
@@ -130,7 +130,7 @@ $result = Hash::insert($data, '{n}[up].Item[id=4].new', 9);
 
 ### Hash::remove()
 
-`static` Cake\\Utility\\Hash::**remove**(array $data, $path): ArrayAccess|array
+`static` Cake\\Utility\\Hash::**remove**(ArrayAccess|array $data, string $path): ArrayAccess|array
 
 Removes all elements from an array that match `$path`:
 
@@ -175,7 +175,7 @@ $result = Hash::remove($data, '{n}[clear].Item[id=4]');
 
 ### Hash::combine()
 
-`static` Cake\\Utility\\Hash::**combine**(array $data, $keyPath, $valuePath = null, $groupPath = null): array
+`static` Cake\\Utility\\Hash::**combine**(array $data, array|string|null $keyPath, array|string|null $valuePath = null, ?string $groupPath = null): array
 
 Creates an associative array using a `$keyPath` as the path to build its keys,
 and optionally `$valuePath` as path to get the values. If `$valuePath` is not
@@ -322,7 +322,7 @@ $result = Hash::combine(
 
 ### Hash::format()
 
-`static` Cake\\Utility\\Hash::**format**(array $data, array $paths, $format): array|null
+`static` Cake\\Utility\\Hash::**format**(array $data, array $paths, string $format): ?array
 
 Returns a series of values extracted from an array, formatted with a
 format string:
@@ -446,7 +446,7 @@ $result = Hash::check($set, 'My Index 1.First.Seconds.Third.Fourth');
 
 ### Hash::filter()
 
-`static` Cake\\Utility\\Hash::**filter**(array $data, $callback = null): array
+`static` Cake\\Utility\\Hash::**filter**(array $data, ?callable $callback = null): array
 
 Filters empty elements out of array, excluding '0'. You can also supply a
 custom `$callback` to filter the array elements. The callback should
@@ -658,7 +658,7 @@ $result = Hash::maxDimensions($data);
 
 ### Hash::map()
 
-`static` Cake\\Utility\\Hash::**map**(array $data, $path, $function): array
+`static` Cake\\Utility\\Hash::**map**(array $data, string $path, callable $function): array
 
 Creates a new array, by extracting `$path`, and mapping `$function`
 across the results. You can use both expression and matching elements with
@@ -677,7 +677,7 @@ public function noop(array $array)
 
 ### Hash::reduce()
 
-`static` Cake\\Utility\\Hash::**reduce**(array $data, $path, $function): mixed
+`static` Cake\\Utility\\Hash::**reduce**(array $data, string $path, callable $function): mixed
 
 Creates a single value, by extracting `$path`, and reducing the extracted
 results with `$function`. You can use both expression and matching elements
@@ -685,7 +685,7 @@ with this method.
 
 ### Hash::apply()
 
-`static` Cake\\Utility\\Hash::**apply**(array $data, $path, $function): mixed
+`static` Cake\\Utility\\Hash::**apply**(array $data, string $path, callable $function): mixed
 
 Apply a callback to a set of extracted values using `$function`. The function
 will get the extracted values as the first argument:
@@ -707,7 +707,7 @@ $result = Hash::apply($data, '{n}[booked=true].date', 'array_count_values');
 
 ### Hash::sort()
 
-`static` Cake\\Utility\\Hash::**sort**(array $data, $path, $dir, $type = 'regular'): array
+`static` Cake\\Utility\\Hash::**sort**(array $data, string $path, string|int $dir = 'asc', array|string $type = 'regular'): array
 
 Sorts an array by any value, determined by a [Hash Path Syntax](#hash-path-syntax)
 Only expression elements are supported by this method:
@@ -820,7 +820,7 @@ $res = Hash::mergeDiff($array1, $array2);
 
 ### Hash::normalize()
 
-`static` Cake\\Utility\\Hash::**normalize**(array $data, $assoc = true, $default = null): array
+`static` Cake\\Utility\\Hash::**normalize**(array $data, bool $assoc = true, mixed $default = null): array
 
 Normalizes an array. If `$assoc` is `true`, the resulting array will be
 normalized to be an associative array. Numeric keys with values, will be

--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -406,7 +406,7 @@ $result = Hash::contains($b, $a);
 
 ### Hash::check()
 
-`static` Cake\\Utility\\Hash::**check**(array $data, string $path = null): bool
+`static` Cake\\Utility\\Hash::**check**(array $data, string $path): bool
 
 Checks if a particular path is set in an array:
 
@@ -446,7 +446,7 @@ $result = Hash::check($set, 'My Index 1.First.Seconds.Third.Fourth');
 
 ### Hash::filter()
 
-`static` Cake\\Utility\\Hash::**filter**(array $data, $callback = ['Hash', 'filter']): array
+`static` Cake\\Utility\\Hash::**filter**(array $data, $callback = null): array
 
 Filters empty elements out of array, excluding '0'. You can also supply a
 custom `$callback` to filter the array elements. The callback should

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -450,7 +450,7 @@ configured.
 
 ### Log::setConfig()
 
-`static` Cake\\Log\\Log::**setConfig**($key, $config): void
+`static` Cake\\Log\\Log::**setConfig**(array|string $key, $config = null): void
 
 param string \$name
 Name for the logger being connected, used
@@ -474,7 +474,7 @@ Get the names of the configured loggers.
 
 ### Log::drop()
 
-`static` Cake\\Log\\Log::**drop**($name): bool
+`static` Cake\\Log\\Log::**drop**(string $name): bool
 
 param string \$name
 Name of the logger you wish to no longer receive
@@ -482,7 +482,7 @@ messages.
 
 ### Log::write()
 
-`static` Cake\\Log\\Log::**write**($level, $message, $context = []): bool
+`static` Cake\\Log\\Log::**write**(string|int $level, Stringable|string $message, array|string $context = []): bool
 
 Write a message into all the configured loggers.
 `$level` indicates the level of log message being created.
@@ -503,35 +503,35 @@ appropriate log level.
 
 #### Log::emergency()
 
-`static` Cake\\Log\\Log::**emergency**($message, $context = []): bool
+`static` Cake\\Log\\Log::**emergency**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::alert()
 
-`static` Cake\\Log\\Log::**alert**($message, $context = []): bool
+`static` Cake\\Log\\Log::**alert**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::critical()
 
-`static` Cake\\Log\\Log::**critical**($message, $context = []): bool
+`static` Cake\\Log\\Log::**critical**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::error()
 
-`static` Cake\\Log\\Log::**error**($message, $context = []): bool
+`static` Cake\\Log\\Log::**error**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::warning()
 
-`static` Cake\\Log\\Log::**warning**($message, $context = []): bool
+`static` Cake\\Log\\Log::**warning**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::notice()
 
-`static` Cake\\Log\\Log::**notice**($message, $context = []): bool
+`static` Cake\\Log\\Log::**notice**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::info()
 
-`static` Cake\\Log\\Log::**info**($message, $context = []): bool
+`static` Cake\\Log\\Log::**info**(Stringable|string $message, array|string $context = []): bool
 
 #### Log::debug()
 
-`static` Cake\\Log\\Log::**debug**($message, $context = []): bool
+`static` Cake\\Log\\Log::**debug**(Stringable|string $message, array|string $context = []): bool
 
 ## Logging Trait
 

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -482,12 +482,12 @@ messages.
 
 ### Log::write()
 
-`static` Cake\\Log\\Log::**write**($level, $message, $scope = []): bool
+`static` Cake\\Log\\Log::**write**($level, $message, $context = []): bool
 
 Write a message into all the configured loggers.
 `$level` indicates the level of log message being created.
 `$message` is the message of the log entry being written to.
-`$scope` is the scope(s) a log message is being created in.
+`$context` is the scope(s) a log message is being created in.
 
 ### Log::levels()
 
@@ -503,35 +503,35 @@ appropriate log level.
 
 #### Log::emergency()
 
-`static` Cake\\Log\\Log::**emergency**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**emergency**($message, $context = []): bool
 
 #### Log::alert()
 
-`static` Cake\\Log\\Log::**alert**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**alert**($message, $context = []): bool
 
 #### Log::critical()
 
-`static` Cake\\Log\\Log::**critical**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**critical**($message, $context = []): bool
 
 #### Log::error()
 
-`static` Cake\\Log\\Log::**error**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**error**($message, $context = []): bool
 
 #### Log::warning()
 
-`static` Cake\\Log\\Log::**warning**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**warning**($message, $context = []): bool
 
 #### Log::notice()
 
-`static` Cake\\Log\\Log::**notice**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**notice**($message, $context = []): bool
 
 #### Log::info()
 
-`static` Cake\\Log\\Log::**info**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**info**($message, $context = []): bool
 
 #### Log::debug()
 
-`static` Cake\\Log\\Log::**debug**($message, $scope = []): bool
+`static` Cake\\Log\\Log::**debug**($message, $context = []): bool
 
 ## Logging Trait
 

--- a/docs/en/core-libraries/security.md
+++ b/docs/en/core-libraries/security.md
@@ -10,11 +10,11 @@ hashing and encrypting data.
 
 ### Security::encrypt()
 
-`static` Cake\\Utility\\Security::**encrypt**($text, $key, $hmacSalt = null): string
+`static` Cake\\Utility\\Security::**encrypt**(string $plain, string $key, ?string $hmacSalt = null): string
 
 ### Security::decrypt()
 
-`static` Cake\\Utility\\Security::**decrypt**($cipher, $key, $hmacSalt = null): string|null
+`static` Cake\\Utility\\Security::**decrypt**(string $cipher, string $key, ?string $hmacSalt = null): ?string
 
 Encrypt `$text` using AES-256. The `$key` should be a value with a
 lots of variance in the data much like a good password. The returned result
@@ -57,7 +57,7 @@ If the value cannot be decrypted due to changes in the key or HMAC salt
 
 ### Security::hash()
 
-`static` Cake\\Utility\\Security::**hash**($string, $algorithm = null, $salt = false): string
+`static` Cake\\Utility\\Security::**hash**(string $string, ?string $algorithm = null, string|bool $salt = false): string
 
 Create a hash from string using given method. Fallback on next
 available method. If `$salt` is set to `true`, the application's salt
@@ -91,7 +91,7 @@ And any other hash algorithm that PHP's `hash()` function supports.
 
 ### Security::randomBytes()
 
-`static` Cake\\Utility\\Security::**randomBytes**($length): string
+`static` Cake\\Utility\\Security::**randomBytes**(int $length): string
 
 Get `$length` number of bytes from a secure random source. This function draws
 data from one of the following sources:
@@ -104,7 +104,7 @@ will be used for backwards compatibility reasons.
 
 ### Security::randomString()
 
-`static` Cake\\Utility\\Security::**randomString**($length): string
+`static` Cake\\Utility\\Security::**randomString**(int $length = 64): string
 
 Get a random string `$length` long from a secure random source. This method
 draws from the same random source as `randomBytes()` and will encode the data

--- a/docs/en/core-libraries/security.md
+++ b/docs/en/core-libraries/security.md
@@ -57,7 +57,7 @@ If the value cannot be decrypted due to changes in the key or HMAC salt
 
 ### Security::hash()
 
-`static` Cake\\Utility\\Security::**hash**( $string, $type = NULL, $salt = false ): string
+`static` Cake\\Utility\\Security::**hash**($string, $algorithm = null, $salt = false): string
 
 Create a hash from string using given method. Fallback on next
 available method. If `$salt` is set to `true`, the application's salt

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -319,7 +319,7 @@ won't end up breaking the MVC structure CakePHP provides.
 
 ### Writing Configuration data
 
-`static` Cake\\Core\\Configure::**write**($key, $value): void
+`static` Cake\\Core\\Configure::**write**($config, $value = null): void
 
 Use `write()` to store data in the application's configuration:
 
@@ -350,7 +350,7 @@ production modes on the fly.
 
 ### Reading Configuration Data
 
-`static` Cake\\Core\\Configure::**read**($key = null, $default = null): mixed
+`static` Cake\\Core\\Configure::**read**($var = null, $default = null): mixed
 
 Used to read configuration data from the application. If a key is supplied, the
 data is returned. Using our examples from write() above, we can read that data
@@ -373,7 +373,7 @@ Configure::read('Company.nope', 'fallback');
 
 If `$key` is left null, all values in Configure will be returned.
 
-`static` Cake\\Core\\Configure::**readOrFail**($key): mixed
+`static` Cake\\Core\\Configure::**readOrFail**($var): mixed
 
 Reads configuration data just like `Cake\Core\Configure::read()`
 but expects to find a key/value pair. In case the requested pair does not
@@ -391,7 +391,7 @@ Configure::readOrFail('Company');
 
 ### Checking to see if Configuration Data is Defined
 
-`static` Cake\\Core\\Configure::**check**($key): bool
+`static` Cake\\Core\\Configure::**check**($var): bool
 
 Used to check if a key/path exists and has non-null value:
 
@@ -401,7 +401,7 @@ $exists = Configure::check('Company.name');
 
 ### Deleting Configuration Data
 
-`static` Cake\\Core\\Configure::**delete**($key): void
+`static` Cake\\Core\\Configure::**delete**($var): void
 
 Used to delete information from the application's configuration:
 
@@ -411,12 +411,12 @@ Configure::delete('Company.name');
 
 ### Reading & Deleting Configuration Data
 
-`static` Cake\\Core\\Configure::**consume**($key): mixed
+`static` Cake\\Core\\Configure::**consume**($var): mixed
 
 Read and delete a key from Configure. This is useful when you want to
 combine reading and deleting values in a single operation.
 
-`static` Cake\\Core\\Configure::**consumeOrFail**($key): mixed
+`static` Cake\\Core\\Configure::**consumeOrFail**($var): mixed
 
 Consumes configuration data just like `Cake\Core\Configure::consume()`
 but expects to find a key/value pair. In case the requested pair does not

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -319,7 +319,7 @@ won't end up breaking the MVC structure CakePHP provides.
 
 ### Writing Configuration data
 
-`static` Cake\\Core\\Configure::**write**($config, $value = null): void
+`static` Cake\\Core\\Configure::**write**(array|string $config, mixed $value = null): void
 
 Use `write()` to store data in the application's configuration:
 
@@ -350,7 +350,7 @@ production modes on the fly.
 
 ### Reading Configuration Data
 
-`static` Cake\\Core\\Configure::**read**($var = null, $default = null): mixed
+`static` Cake\\Core\\Configure::**read**(?string $var = null, mixed $default = null): mixed
 
 Used to read configuration data from the application. If a key is supplied, the
 data is returned. Using our examples from write() above, we can read that data
@@ -373,7 +373,7 @@ Configure::read('Company.nope', 'fallback');
 
 If `$key` is left null, all values in Configure will be returned.
 
-`static` Cake\\Core\\Configure::**readOrFail**($var): mixed
+`static` Cake\\Core\\Configure::**readOrFail**(string $var): mixed
 
 Reads configuration data just like `Cake\Core\Configure::read()`
 but expects to find a key/value pair. In case the requested pair does not
@@ -391,7 +391,7 @@ Configure::readOrFail('Company');
 
 ### Checking to see if Configuration Data is Defined
 
-`static` Cake\\Core\\Configure::**check**($var): bool
+`static` Cake\\Core\\Configure::**check**(string $var): bool
 
 Used to check if a key/path exists and has non-null value:
 
@@ -401,7 +401,7 @@ $exists = Configure::check('Company.name');
 
 ### Deleting Configuration Data
 
-`static` Cake\\Core\\Configure::**delete**($var): void
+`static` Cake\\Core\\Configure::**delete**(string $var): void
 
 Used to delete information from the application's configuration:
 
@@ -411,12 +411,12 @@ Configure::delete('Company.name');
 
 ### Reading & Deleting Configuration Data
 
-`static` Cake\\Core\\Configure::**consume**($var): mixed
+`static` Cake\\Core\\Configure::**consume**(string $var): mixed
 
 Read and delete a key from Configure. This is useful when you want to
 combine reading and deleting values in a single operation.
 
-`static` Cake\\Core\\Configure::**consumeOrFail**($var): mixed
+`static` Cake\\Core\\Configure::**consumeOrFail**(string $var): mixed
 
 Consumes configuration data just like `Cake\Core\Configure::consume()`
 but expects to find a key/value pair. In case the requested pair does not
@@ -434,7 +434,7 @@ Configure::consumeOrFail('Company');
 
 ## Reading and writing configuration files
 
-`static` Cake\\Core\\Configure::**setConfig**($name, $engine)
+`static` Cake\\Core\\Configure::**config**(string $name, ConfigEngineInterface $engine): void
 
 CakePHP comes with two built-in configuration file engines.
 `Cake\Core\Configure\Engine\PhpConfig` is able to read PHP config
@@ -467,7 +467,7 @@ Configure::configured();
 Configure::configured('default');
 ```
 
-`static` Cake\\Core\\Configure::**drop**($name): bool
+`static` Cake\\Core\\Configure::**drop**(string $name): bool
 
 You can also remove attached engines. `Configure::drop('default')`
 would remove the default engine alias. Any future attempts to load configuration
@@ -481,7 +481,7 @@ Configure::drop('default');
 
 ### Loading Configuration Files
 
-`static` Cake\\Core\\Configure::**load**($key, $config = 'default', $merge = true): bool
+`static` Cake\\Core\\Configure::**load**(string $key, string $config = 'default', bool $merge = true): bool
 
 Once you've attached a config engine to Configure you can load configuration
 files:
@@ -522,7 +522,7 @@ will not ever overwrite the existing configuration.
 
 ### Creating or Modifying Configuration Files
 
-`static` Cake\\Core\\Configure::**dump**($key, $config = 'default', $keys = []): bool
+`static` Cake\\Core\\Configure::**dump**(string $key, string $config = 'default', array $keys = []): bool
 
 Dumps all or some of the data in Configure into a file or storage system
 supported by a config engine. The serialization format is decided by the config
@@ -549,7 +549,7 @@ configuration files that are readable with `Configure::load()`
 
 ### Storing Runtime Configuration
 
-`static` Cake\\Core\\Configure::**store**($name, $cacheConfig = 'default', $data = null): bool
+`static` Cake\\Core\\Configure::**store**(string $name, string $cacheConfig = 'default', ?array $data = null): bool
 
 You can also store runtime configuration values for use in a future request.
 Since configure only remembers values for the current request, you will
@@ -566,7 +566,7 @@ Stored configuration data is persisted in the named cache configuration. See the
 
 ### Restoring Runtime Configuration
 
-`static` Cake\\Core\\Configure::**restore**($name, $cacheConfig = 'default'): bool
+`static` Cake\\Core\\Configure::**restore**(string $name, string $cacheConfig = 'default'): bool
 
 Once you've stored runtime configuration, you'll probably need to restore it
 so you can access it again. `Configure::restore()` does exactly that:


### PR DESCRIPTION
## Summary

- **Log methods**: `$scope` → `$context` (write, emergency, alert, critical, error, warning, notice, info, debug)
- **Security::hash()**: `$type` → `$algorithm`
- **Configure methods**: `$key` → `$var`/`$config` (write, read, readOrFail, check, delete, consume, consumeOrFail)
- **Hash::check()**: remove incorrect `= null` default from required `$path` parameter
- **Hash::filter()**: change callback default from `['Hash', 'filter']` to `null`

These changes align the documented parameter names with the actual CakePHP 5.x source code.

Relates to #7744