### PR TITLE
Add type annotations to method signatures (Cache, Controller, Paginator)

### DIFF
--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -525,7 +525,7 @@ class ArticlesController extends AppController
 
 ## Configuring Components to Load
 
-`method` Cake\\Controller\\Controller::**loadComponent**($name, $config = []): Component
+`method` Cake\\Controller\\Controller::**loadComponent**(string $name, array $config = []): Component
 
 In your Controller's `initialize()` method you can define any components you
 want loaded, and any configuration data for them:
@@ -612,7 +612,7 @@ As of 4.1.0 you can also raise a `RedirectException` to signal a redirect.
 
 ## Controller Middleware
 
-`method` Cake\\Controller\\Controller::**middleware**($middleware, array $options = []): void
+`method` Cake\\Controller\\Controller::**middleware**(MiddlewareInterface|Closure|string $middleware, array $options = []): void
 
 [Middleware](controllers/middleware) can be defined globally, in
 a routing scope or within a controller. To define middleware for a specific

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -41,7 +41,7 @@ Regardless of the CacheEngine you choose to use, your application interacts with
 
 ### Cache::setConfig()
 
-`static` Cake\\Cache\\Cache::**setConfig**($key, $config = null): void
+`static` Cake\\Cache\\Cache::**setConfig**(array|string $key, $config = null): void
 
 Your application can configure any number of 'engines' during its bootstrap
 process. Cache engine configurations are defined in **config/app.php**.
@@ -269,7 +269,7 @@ When there is no fallback cache failures will be raised as exceptions.
 
 ### Cache::drop()
 
-`static` Cake\\Cache\\Cache::**drop**($key): bool
+`static` Cake\\Cache\\Cache::**drop**(string $key): bool
 
 Once a configuration is created you cannot change it. Instead you should drop
 the configuration and re-create it using `Cake\Cache\Cache::drop()` and
@@ -280,7 +280,7 @@ the config and destroy the adapter if it was constructed.
 
 ### Cache::write()
 
-`static` Cake\\Cache\\Cache::**write**($key, $value, $config = 'default'): bool
+`static` Cake\\Cache\\Cache::**write**(string $key, mixed $value, string $config = 'default'): bool
 
 `Cache::write()` will write a \$value to the Cache. You can read or
 delete this value later by referring to it by `$key`. You may
@@ -307,7 +307,7 @@ of trips made to the database to fetch posts.
 
 ### Cache::writeMany()
 
-`static` Cake\\Cache\\Cache::**writeMany**($data, $config = 'default'): bool
+`static` Cake\\Cache\\Cache::**writeMany**(iterable $data, string $config = 'default'): bool
 
 You may find yourself needing to write multiple cache keys at once. While you
 can use multiple calls to `write()`, `writeMany()` allows CakePHP to use
@@ -349,7 +349,7 @@ Cache::delete($lockKey);
 
 ### Cache::remember()
 
-`static` Cake\\Cache\\Cache::**remember**($key, $callable, $config = 'default'): mixed
+`static` Cake\\Cache\\Cache::**remember**(string $key, Closure $callable, string $config = 'default'): mixed
 
 Cache helps with read-through caching. If the named cache key exists,
 it will be returned. If the key does not exist, the callable will be invoked
@@ -374,7 +374,7 @@ class IssueService
 
 ### Cache::read()
 
-`static` Cake\\Cache\\Cache::**read**($key, $config = 'default'): mixed
+`static` Cake\\Cache\\Cache::**read**(string $key, string $config = 'default'): mixed
 
 `Cache::read()` is used to read the cached value stored under
 `$key` from the `$config`. If `$config` is null the default
@@ -419,7 +419,7 @@ return $cloud;
 
 ### Cache::readMany()
 
-`static` Cake\\Cache\\Cache::**readMany**($keys, $config = 'default'): iterable
+`static` Cake\\Cache\\Cache::**readMany**(iterable $keys, string $config = 'default'): iterable
 
 After you've written multiple keys at once, you'll probably want to read them as
 well. While you could use multiple calls to `read()`, `readMany()` allows
@@ -439,7 +439,7 @@ $result = Cache::readMany([
 
 ### Cache::delete()
 
-`static` Cake\\Cache\\Cache::**delete**($key, $config = 'default'): bool
+`static` Cake\\Cache\\Cache::**delete**(string $key, string $config = 'default'): bool
 
 `Cache::delete()` will allow you to completely remove a cached
 object from the store:
@@ -458,7 +458,7 @@ Cache::pool('redis')->deleteAsync('my_key');
 
 ### Cache::deleteMany()
 
-`static` Cake\\Cache\\Cache::**deleteMany**($keys, $config = 'default'): bool
+`static` Cake\\Cache\\Cache::**deleteMany**(iterable $keys, string $config = 'default'): bool
 
 After you've written multiple keys at once, you may want to delete them. While
 you could use multiple calls to `delete()`, `deleteMany()` allows CakePHP to use
@@ -478,7 +478,7 @@ $result = Cache::deleteMany([
 
 ### Cache::clear()
 
-`static` Cake\\Cache\\Cache::**clear**($config = 'default'): bool
+`static` Cake\\Cache\\Cache::**clear**(string $config = 'default'): bool
 
 Destroy all cached values for a cache configuration. In engines like: Apcu,
 Memcached, the cache configuration's prefix is used to remove
@@ -505,11 +505,11 @@ Cache::pool('redis')->clearBlocking();
 
 ### Cache::increment()
 
-`static` Cake\\Cache\\Cache::**increment**($key, $offset = 1, $config = 'default'): int|false
+`static` Cake\\Cache\\Cache::**increment**(string $key, int $offset = 1, string $config = 'default'): int|false
 
 ### Cache::decrement()
 
-`static` Cake\\Cache\\Cache::**decrement**($key, $offset = 1, $config = 'default'): int|false
+`static` Cake\\Cache\\Cache::**decrement**(string $key, int $offset = 1, string $config = 'default'): int|false
 
 Counters in your application are good candidates for storage in a cache. As an
 example, a simple countdown for remaining 'slots' in a contest could be stored
@@ -563,7 +563,7 @@ Cache::setConfig('site_home', [
 
 ### Cache::clearGroup()
 
-`method` Cake\\Cache\\Cache::**clearGroup**($group, $config = 'default'): bool
+`static` Cake\\Cache\\Cache::**clearGroup**(string $group, string $config = 'default'): bool
 
 Let's say you want to store the HTML generated for your homepage in cache, but
 would also want to automatically invalidate this cache every time a comment or
@@ -586,7 +586,7 @@ public function afterSave($event, $entity, $options = [])
 
 ### Cache::groupConfigs()
 
-`static` Cake\\Cache\\Cache::**groupConfigs**($group = null): array
+`static` Cake\\Cache\\Cache::**groupConfigs**(?string $group = null): array
 
 `groupConfigs()` can be used to retrieve mapping between group and
 configurations, i.e.: having the same group:

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -10,7 +10,7 @@ create paginated datasets and do paginated queries.
 
 ## Setting the paginated resultset
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**setPaginated**($paginated, $options): void
+`method` Cake\\View\\Helper\\PaginatorHelper::**setPaginated**(PaginatedInterface $paginated, array $options = []): void
 
 By default the helper uses the first instance of `Cake\Datasource\Paging\PaginatedInterface`
 it finds in the view variables. (Generally the result of `Controller::paginate()`).
@@ -68,7 +68,7 @@ return [
 
 ## Changing Templates at Run-time
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**setTemplates**($templates)
+`method` Cake\\View\\Helper\\PaginatorHelper::**setTemplates**(array $templates): $this
 
 This method allows you to change the templates used by PaginatorHelper at
 runtime. This can be useful when you want to customize templates for a
@@ -112,7 +112,7 @@ PaginatorHelper uses the following templates:
 
 ### Creating Sort Links
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**sort**($key, $title = null, $options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**sort**(string $key, array|string|null $title = null, array $options = []): string
 
 Generates a sorting link. Sets querystring parameters for the sort and
 direction. Links will default to sorting by asc. After the first click, links
@@ -195,7 +195,7 @@ echo $this->Paginator->sort('user_id', null, ['direction' => 'asc', 'lock' => tr
 
 ### Creating Page Number Links
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**numbers**($options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**numbers**(array $options = []): string
 
 Returns a set of numbers for the paged result set. Uses a modulus to
 decide how many numbers to show on each side of the current page By default
@@ -251,19 +251,19 @@ pages in the paged data set.
 
 ### prev()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**prev**($title = '<< Previous', $options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**prev**(string $title = '<< Previous', array $options = []): string
 
 ### next()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**next**($title = 'Next >>', $options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**next**(string $title = 'Next >>', array $options = []): string
 
 ### first()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**first**($first = '<< first', $options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**first**(string|int $first = '<< first', array $options = []): string
 
 ### last()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**last**($last = 'last >>', $options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**last**(string|int $last = 'last >>', array $options = []): string
 
 ### Creating Header Link Tags
 
@@ -286,7 +286,7 @@ echo $this->Paginator->meta(['first' => true, 'last' => true]);
 
 #### hasNext()
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**(string $model = null): bool
+`method` Cake\\View\\Helper\\PaginatorHelper::**hasNext**(): bool
 
 #### hasPrev()
 
@@ -362,7 +362,7 @@ echo $this->Paginator->generateUrl(
 
 ### Creating a Limit Selectbox Control
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**limitControl**(array $limits = [], $default = null, array $options = []): string
+`method` Cake\\View\\Helper\\PaginatorHelper::**limitControl**(array $limits = [], ?int $default = null, array $options = []): string
 
 Create a dropdown control that changes the `limit` query parameter:
 
@@ -419,7 +419,7 @@ automatically use the `maxLimit` value as the only available option.
 
 ### Configuring Pagination Options
 
-`method` Cake\\View\\Helper\\PaginatorHelper::**options**($options = []): void
+`method` Cake\\View\\Helper\\PaginatorHelper::**options**(array $options = []): void
 
 Sets all the options for the PaginatorHelper. Supported options are:
 


### PR DESCRIPTION
## Summary

Adds type annotations to method signatures to match the CakePHP 5.x source code:

**Cache** (14 methods):
- `setConfig`, `drop`, `write`, `writeMany`, `remember`, `read`, `readMany`, `delete`, `deleteMany`, `clear`, `increment`, `decrement`, `clearGroup`, `groupConfigs`

**Controller** (2 methods):
- `loadComponent`, `middleware`

**PaginatorHelper** (11 methods):
- `setPaginated`, `setTemplates`, `sort`, `numbers`, `prev`, `next`, `first`, `last`, `hasNext`, `limitControl`, `options`

Also fixes:
- `clearGroup` was incorrectly marked as `method` instead of `static`
- `hasNext` removed non-existent `$model` parameter

Relates to #7744