### PR TITLE
Add type annotations to helper method signatures (Form, Html, Url)

### DIFF
--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -824,7 +824,7 @@ however, this parameter is used primarily to specify HTML tag attributes
 
 ### Creating Text Inputs
 
-`method` Cake\\View\\Helper\\FormHelper::**text**(string $name, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**text**(string $fieldName, array $options = []): string
 
 - `$name` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array including any of the
@@ -846,7 +846,7 @@ Will output:
 
 ### Creating Password Inputs
 
-`method` Cake\\View\\Helper\\FormHelper::**password**(string $fieldName, array $options)
+`method` Cake\\View\\Helper\\FormHelper::**password**(string $fieldName, array $options = []): string
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$options` - An optional array including any of the
@@ -2136,7 +2136,7 @@ echo $this->Form->button('<em>Submit Form</em>', [
 
 ## Closing the Form
 
-`method` Cake\\View\\Helper\\FormHelper::**end**($secureAttributes = []): string
+`method` Cake\\View\\Helper\\FormHelper::**end**(array $secureAttributes = []): string
 
 - `$secureAttributes` - Optional. Allows you to provide secure attributes
   which will be passed as HTML attributes into the hidden input elements
@@ -2771,7 +2771,7 @@ As mentioned previously when using FormProtectionComponent, you should always cl
 your forms using `Cake\View\Helper\FormHelper::end()`. This will
 ensure that the special `_Token` inputs are generated.
 
-`method` Cake\\View\\Helper\\FormHelper::**unlockField**($name)
+`method` Cake\\View\\Helper\\FormHelper::**unlockField**(string $name): $this
 
 - `$name` - Optional. The dot-separated name for the field.
 

--- a/docs/en/views/helpers/html.md
+++ b/docs/en/views/helpers/html.md
@@ -28,7 +28,7 @@ methods of the HtmlHelper and how to use them.
 
 ### Creating Charset Tags
 
-`method` Cake\\View\\Helper\\HtmlHelper::**charset**($charset=null): string
+`method` Cake\\View\\Helper\\HtmlHelper::**charset**(?string $charset = null): string
 
 Used to create a meta tag specifying the document's character. The default value
 is UTF-8. An example use:
@@ -308,7 +308,7 @@ Will output:
 
 ### Creating Links
 
-`method` Cake\\View\\Helper\\HtmlHelper::**link**($title, $url = null, array $options = []): string
+`method` Cake\\View\\Helper\\HtmlHelper::**link**(array|string $title, array|string|null $url = null, array $options = []): string
 
 General purpose method for creating HTML links. Use `$options` to
 specify attributes for the element and whether or not the
@@ -895,7 +895,7 @@ Output:
 
 ## Changing the Tags Output by HtmlHelper
 
-`method` Cake\\View\\Helper\\HtmlHelper::**setTemplates**(array $templates)
+`method` Cake\\View\\Helper\\HtmlHelper::**setTemplates**(array $templates): $this
 
 Load an array of templates to add/replace templates:
 

--- a/docs/en/views/helpers/url.md
+++ b/docs/en/views/helpers/url.md
@@ -9,7 +9,7 @@ overriding the core helper with an application one. See the
 
 ## Generating URLs
 
-`method` Cake\\View\\Helper\\UrlHelper::**build**($url = null, array $options = []): string
+`method` Cake\\View\\Helper\\UrlHelper::**build**(array|string|null $url = null, array $options = []): string
 
 Returns a URL pointing to a combination of controller and action.
 If `$url` is empty, it returns the `REQUEST_URI`, otherwise it


### PR DESCRIPTION
## Summary

Adds type annotations to method signatures to match the CakePHP 5.x source code:

**FormHelper** (4 methods):
- `text` - added return type `: string`, default `$options = []`
- `password` - added return type `: string`, default `$options = []`
- `end` - added `array` type to `$secureAttributes`
- `unlockField` - added `string` type to `$name`, return type `: $this`

**HtmlHelper** (3 methods):
- `charset` - added `?string` type to `$charset`
- `link` - added `array|string` type to `$title`, `array|string|null` to `$url`
- `setTemplates` - added return type `: $this`

**UrlHelper** (1 method):
- `build` - added `array|string|null` type to `$url`

Relates to #7744