### PR TITLE
Add missing type annotations to core library method signatures

### DIFF
--- a/docs/en/core-libraries/app.md
+++ b/docs/en/core-libraries/app.md
@@ -8,7 +8,7 @@ The App class is responsible for resource location and path management.
 
 ### App::className()
 
-`static` Cake\\Core\\App::**className**($name, $type = '', $suffix = ''): string|null
+`static` Cake\\Core\\App::**className**(string $class, string $type = '', string $suffix = ''): ?string
 
 This method is used to resolve class names throughout CakePHP. It resolves
 the short form names CakePHP uses and returns the fully resolved class name:

--- a/docs/en/core-libraries/collections.md
+++ b/docs/en/core-libraries/collections.md
@@ -70,7 +70,7 @@ application as well.
 
 ### each()
 
-`method` Cake\\Collection\\Collection::**each**($callback)
+`method` Cake\\Collection\\Collection::**each**(callable $callback): CollectionInterface
 
 Collections can be iterated and/or transformed into new collections with the
 `each()` and `map()` methods. The `each()` method will not create a new
@@ -88,7 +88,7 @@ collection immediately applying the callback to each value in the collection.
 
 ### map()
 
-`method` Cake\\Collection\\Collection::**map**($callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**map**(callable $callback): CollectionInterface
 
 The `map()` method will create a new collection based on the output of the
 callback being applied to each object in the original collection:
@@ -113,7 +113,7 @@ the resulting items when iterated.
 
 ### extract()
 
-`method` Cake\\Collection\\Collection::**extract**($path): CollectionInterface
+`method` Cake\\Collection\\Collection::**extract**(callable|string $path): CollectionInterface
 
 One of the most common uses for a `map()` function is to extract a single
 column from a collection. If you are looking to build a list of elements
@@ -188,7 +188,7 @@ Unlike `Cake\Utility\Hash::extract()` this method only supports the
 
 ### combine()
 
-`method` Cake\\Collection\\Collection::**combine**($keyPath, $valuePath, $groupPath = null): CollectionInterface
+`method` Cake\\Collection\\Collection::**combine**(callable|string $keyPath, callable|string $valuePath, callable|string|null $groupPath = null): CollectionInterface
 
 Collections allow you to create a new collection made from keys and values in
 an existing collection. Both the key and value paths can be specified with
@@ -245,7 +245,7 @@ $combined = (new Collection($entities))->combine(
 
 ### stopWhen()
 
-`method` Cake\\Collection\\Collection::**stopWhen**(callable $c): CollectionInterface
+`method` Cake\\Collection\\Collection::**stopWhen**(callable|array $condition): CollectionInterface
 
 You can stop the iteration at any point using the `stopWhen()` method. Calling
 it in a collection will create a new one that will stop yielding results if the
@@ -266,7 +266,7 @@ $result = $new->toList();
 
 ### unfold()
 
-`method` Cake\\Collection\\Collection::**unfold**(callable $callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**unfold**(?callable $callback = null): CollectionInterface
 
 Sometimes the internal items of a collection will contain arrays or iterators
 with more items. If you wish to flatten the internal structure to iterate once
@@ -314,7 +314,7 @@ $result = $new->toList();
 
 ### chunk()
 
-`method` Cake\\Collection\\Collection::**chunk**($chunkSize): CollectionInterface
+`method` Cake\\Collection\\Collection::**chunk**(int $chunkSize): CollectionInterface
 
 When dealing with large amounts of items in a collection, it may make sense to
 process the elements in batches instead of one by one. For splitting
@@ -345,7 +345,7 @@ $collection->map(function ($article) {
 
 ### chunkWithKeys()
 
-`method` Cake\\Collection\\Collection::**chunkWithKeys**($chunkSize): CollectionInterface
+`method` Cake\\Collection\\Collection::**chunkWithKeys**(int $chunkSize, bool $keepKeys = true): CollectionInterface
 
 Much like `chunk()`, `chunkWithKeys()` allows you to slice up
 a collection into smaller batches but with keys preserved. This is useful when
@@ -372,7 +372,7 @@ $result = $chunked->toList();
 
 ### filter()
 
-`method` Cake\\Collection\\Collection::**filter**($callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**filter**(?callable $callback = null): CollectionInterface
 
 Collections allow you to filter and create new collections based on
 the result of callback functions. You can use `filter()` to create a new
@@ -390,7 +390,7 @@ $guys = $collection->filter(function ($person, $key) {
 
 ### reject()
 
-`method` Cake\\Collection\\Collection::**reject**(callable $c): CollectionInterface
+`method` Cake\\Collection\\Collection::**reject**(?callable $callback = null): CollectionInterface
 
 The inverse of `filter()` is `reject()`. This method does a negative filter,
 removing elements that match the filter function:
@@ -404,7 +404,7 @@ $ladies = $collection->reject(function ($person, $key) {
 
 ### every()
 
-`method` Cake\\Collection\\Collection::**every**($callback): bool
+`method` Cake\\Collection\\Collection::**every**(callable $callback): bool
 
 You can do truth tests with filter functions. To see if every element in
 a collection matches a test you can use `every()`:
@@ -418,11 +418,11 @@ $allYoungPeople = $collection->every(function ($person) {
 
 ### any()
 
-`method` Cake\\Collection\\Collection::**any**($callback): bool
+`method` Cake\\Collection\\Collection::**any**(callable $callback): bool
 
 ### some()
 
-`method` Cake\\Collection\\Collection::**some**($callback): bool
+`method` Cake\\Collection\\Collection::**some**(callable $callback): bool
 
 You can see if the collection contains at least one element matching a filter
 function using the `any()` method:
@@ -439,7 +439,7 @@ $hasYoungPeople = $collection->any(function ($person) {
 
 ### match()
 
-`method` Cake\\Collection\\Collection::**match**($conditions): CollectionInterface
+`method` Cake\\Collection\\Collection::**match**(array $conditions): CollectionInterface
 
 If you need to extract a new collection containing only the elements that
 contain a given set of properties, you should use the `match()` method:
@@ -451,7 +451,7 @@ $commentsFromMark = $collection->match(['user.name' => 'Mark']);
 
 ### firstMatch()
 
-`method` Cake\\Collection\\Collection::**firstMatch**($conditions): mixed
+`method` Cake\\Collection\\Collection::**firstMatch**(array $conditions): mixed
 
 The property name can be a dot-separated path. You can traverse into nested
 entities and match the values they contain. When you only need the first
@@ -474,7 +474,7 @@ against.
 
 ### reduce()
 
-`method` Cake\\Collection\\Collection::**reduce**($callback, $initial): mixed
+`method` Cake\\Collection\\Collection::**reduce**(callable $callback, mixed $initial = null): mixed
 
 The counterpart of a `map()` operation is usually a `reduce`. This
 function will help you build a single result out of all the elements in a
@@ -499,7 +499,7 @@ $allTags = $collection->reduce(function ($accumulated, $article) {
 
 ### min()
 
-`method` Cake\\Collection\\Collection::**min**(string|callable $callback, $type = SORT_NUMERIC): mixed
+`method` Cake\\Collection\\Collection::**min**(callable|string $path, int $sort = SORT_NUMERIC): mixed
 
 To extract the minimum value for a collection based on a property, just use the
 `min()` function. This will return the full element from the collection and
@@ -526,7 +526,7 @@ $personWithYoungestDad = $collection->min('dad.age');
 
 ### max()
 
-`method` Cake\\Collection\\Collection::**max**(string|callable $callback, $type = SORT_NUMERIC): mixed
+`method` Cake\\Collection\\Collection::**max**(callable|string $path, int $sort = SORT_NUMERIC): mixed
 
 The same can be applied to the `max()` function, which will return a single
 element from the collection having the highest property value:
@@ -544,7 +544,7 @@ $personWithOldestDad = $collection->max('dad.age');
 
 ### sumOf()
 
-`method` Cake\\Collection\\Collection::**sumOf**($path = null): float|int
+`method` Cake\\Collection\\Collection::**sumOf**(callable|string|null $path = null): float|int
 
 Finally, the `sumOf()` method will return the sum of a property of all
 elements:
@@ -562,7 +562,7 @@ $sumOfDadAges = $collection->sumOf('dad.age');
 
 ### avg()
 
-`method` Cake\\Collection\\Collection::**avg**($path = null): float|int|null
+`method` Cake\\Collection\\Collection::**avg**(callable|string|null $path = null): float|int|null
 
 Calculate the average value of the elements in the collection. Optionally
 provide a matcher path, or function to extract values to generate the average
@@ -580,7 +580,7 @@ $average = (new Collection($items))->avg('invoice.total');
 
 ### median()
 
-`method` Cake\\Collection\\Collection::**median**($path = null): float|int|null
+`method` Cake\\Collection\\Collection::**median**(callable|string|null $path = null): float|int|null
 
 Calculate the median value of a set of elements. Optionally provide a matcher
 path, or function to extract values to generate the median for:
@@ -602,7 +602,7 @@ $median = (new Collection($items))->median('invoice.total');
 
 ### groupBy()
 
-`method` Cake\\Collection\\Collection::**groupBy**($callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**groupBy**(callable|string $path): CollectionInterface
 
 Collection values can be grouped by different keys in a new collection when they
 share the same value for a property:
@@ -644,7 +644,7 @@ $classResults = $students->groupBy(function ($student) {
 
 ### countBy()
 
-`method` Cake\\Collection\\Collection::**countBy**($callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**countBy**(callable|string $path): CollectionInterface
 
 If you only wish to know the number of occurrences per group, you can do so by
 using the `countBy()` method. It takes the same arguments as `groupBy` so it
@@ -661,7 +661,7 @@ $classResults = $students->countBy(function ($student) {
 
 ### indexBy()
 
-`method` Cake\\Collection\\Collection::**indexBy**($callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**indexBy**(callable|string $path): CollectionInterface
 
 There will be certain cases where you know an element is unique for the property
 you want to group by. If you wish a single result per group, you can use the
@@ -691,7 +691,7 @@ $filesByHash = $files->indexBy(function ($file) {
 
 ### zip()
 
-`method` Cake\\Collection\\Collection::**zip**($items): CollectionInterface
+`method` Cake\\Collection\\Collection::**zip**(iterable ...$items): CollectionInterface
 
 The elements of different collections can be grouped together using the
 `zip()` method. It will return a new collection containing an array grouping
@@ -750,7 +750,7 @@ $result = $firstYear->zip($data[0], $data[1])->toList();
 
 ### sortBy()
 
-`method` Cake\\Collection\\Collection::**sortBy**($callback, $order = SORT_DESC, $sort = SORT_NUMERIC): CollectionInterface
+`method` Cake\\Collection\\Collection::**sortBy**(callable|string $path, int $order = SORT_DESC, int $sort = SORT_NUMERIC): CollectionInterface
 
 Collection values can be sorted in ascending or descending order based on
 a column or custom function. To create a new sorted collection out of the values
@@ -818,7 +818,7 @@ $sorted = $collection->sortBy('title', SORT_ASC, SORT_NATURAL);
 
 ### nest()
 
-`method` Cake\\Collection\\Collection::**nest**($idPath, $parentPath, $nestingKey = 'children'): CollectionInterface
+`method` Cake\\Collection\\Collection::**nest**(callable|string $idPath, callable|string $parentPath, string $nestingKey = 'children'): CollectionInterface
 
 Not all data is meant to be represented in a linear way. Collections make it
 easier to construct and flatten hierarchical or nested structures. Creating
@@ -870,7 +870,7 @@ rendering menus or traversing elements up to certain level in the tree.
 
 ### listNested()
 
-`method` Cake\\Collection\\Collection::**listNested**($order = 'desc', $nestingKey = 'children'): CollectionInterface
+`method` Cake\\Collection\\Collection::**listNested**(string|int $order = 'desc', callable|string $nestingKey = 'children'): CollectionInterface
 
 The inverse of `nest()` is `listNested()`. This method allows you to flatten
 a tree structure back into a linear structure. It takes two parameters; the
@@ -961,7 +961,7 @@ $collection->isEmpty();
 
 ### contains()
 
-`method` Cake\\Collection\\Collection::**contains**($value): bool
+`method` Cake\\Collection\\Collection::**contains**(mixed $value): bool
 
 Collections allow you to quickly check if they contain one particular
 value: by using the `contains()` method:
@@ -1020,7 +1020,7 @@ $result = $transpose->toList();
 
 ### sample()
 
-`method` Cake\\Collection\\Collection::**sample**($length = 10): CollectionInterface
+`method` Cake\\Collection\\Collection::**sample**(int $length = 10): CollectionInterface
 
 Shuffling a collection is often useful when doing quick statistical analysis.
 Another common operation when doing this sort of task is withdrawing a few
@@ -1041,7 +1041,7 @@ sample, the full collection in a random order is returned.
 
 ### take()
 
-`method` Cake\\Collection\\Collection::**take**($length, $offset): CollectionInterface
+`method` Cake\\Collection\\Collection::**take**(int $length = 1, int $offset = 0): CollectionInterface
 
 Whenever you want to take a slice of a collection use the `take()` function,
 it will create a new collection with at most the number of values you specify in
@@ -1058,7 +1058,7 @@ Positions are zero-based, therefore the first position number is `0`.
 
 ### skip()
 
-`method` Cake\\Collection\\Collection::**skip**($length): CollectionInterface
+`method` Cake\\Collection\\Collection::**skip**(int $length): CollectionInterface
 
 While the second argument of `take()` can help you skip some elements before
 getting them from the collection, you can also use `skip()` for the same
@@ -1117,7 +1117,7 @@ $myTimeline->filter(function ($tweet) {
 
 ### appendItem()
 
-`method` Cake\\Collection\\Collection::**appendItem**($value, $key): CollectionInterface
+`method` Cake\\Collection\\Collection::**appendItem**(mixed $item, mixed $key = null): CollectionInterface
 
 Allows you to append an item with an optional key to the collection. If you
 specify a key that already exists in the collection, the value will not be
@@ -1130,7 +1130,7 @@ $myTimeline = $cakephpTweets->appendItem($newTweet, 99);
 
 ### prepend()
 
-`method` Cake\\Collection\\Collection::**prepend**($items): CollectionInterface
+`method` Cake\\Collection\\Collection::**prepend**(iterable $items): CollectionInterface
 
 The `prepend()` method will return a new collection containing the values from
 both sources:
@@ -1142,7 +1142,7 @@ $myTimeline = $cakephpTweets->prepend($phpTweets);
 
 ### prependItem()
 
-`method` Cake\\Collection\\Collection::**prependItem**($value, $key): CollectionInterface
+`method` Cake\\Collection\\Collection::**prependItem**(mixed $item, mixed $key = null): CollectionInterface
 
 Allows you to prepend an item with an optional key to the collection. If you
 specify a key that already exists in the collection, the value will not be
@@ -1165,7 +1165,7 @@ $myTimeline = $cakephpTweets->prependItem($newTweet, 99);
 
 ### insert()
 
-`method` Cake\\Collection\\Collection::**insert**($path, $items): CollectionInterface
+`method` Cake\\Collection\\Collection::**insert**(string $path, mixed $values): CollectionInterface
 
 At times, you may have two separate sets of data that you would like to insert
 the elements of one set into each of the elements of the other set. This is
@@ -1287,7 +1287,7 @@ $collection->map(new TotalOrderCalculator)
 
 ### through()
 
-`method` Cake\\Collection\\Collection::**through**($callback): CollectionInterface
+`method` Cake\\Collection\\Collection::**through**(callable $callback): CollectionInterface
 
 Sometimes a chain of collection method calls can become reusable in other parts
 of your application, but only if they are called in that specific order. In
@@ -1410,7 +1410,7 @@ $rewindable = (new Collection(results()))->buffered();
 
 ### compile()
 
-`method` Cake\\Collection\\Collection::**compile**($preserveKeys = true): CollectionInterface
+`method` Cake\\Collection\\Collection::**compile**(bool $keepKeys = true): CollectionInterface
 
 Sometimes you need to get a clone of the elements from another
 collection. This is useful when you need to iterate the same set from different

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -257,7 +257,7 @@ following path:
 
 ### Mailer::setAttachments()
 
-`method` Cake\\Mailer\\Mailer::**setAttachments**($attachments)
+`method` Cake\\Mailer\\Mailer::**setAttachments**(array $attachments): static
 
 You can attach files to email messages as well. There are a few
 different formats depending on what kind of files you have, and how
@@ -310,7 +310,7 @@ You can also add attachments using the `addAttachment()` method.
 
 ### Mailer::setEmailPattern()
 
-`method` Cake\\Mailer\\Mailer::**setEmailPattern**($pattern)
+`method` Cake\\Mailer\\Mailer::**setEmailPattern**(?string $regex): static
 
 If you are having validation issues when sending to non-compliant addresses, you
 can relax the pattern used to validate email addresses. This is sometimes

--- a/docs/en/core-libraries/inflector.md
+++ b/docs/en/core-libraries/inflector.md
@@ -118,11 +118,11 @@ when provided a multi-word argument:
 
 ### Inflector::singularize()
 
-`static` Cake\\Utility\\Inflector::**singularize**($singular): string
+`static` Cake\\Utility\\Inflector::**singularize**(string $word): string
 
 ### Inflector::pluralize()
 
-`static` Cake\\Utility\\Inflector::**pluralize**($singular): string
+`static` Cake\\Utility\\Inflector::**pluralize**(string $word): string
 
 Both `pluralize` and `singularize()` work on most English nouns. If you need
 to support other languages, you can use [Inflection Configuration](#inflection-configuration) to
@@ -148,11 +148,11 @@ echo Inflector::singularize('People');
 
 ### Inflector::camelize()
 
-`static` Cake\\Utility\\Inflector::**camelize**($underscored): string
+`static` Cake\\Utility\\Inflector::**camelize**(string $string, string $delimiter = '_'): string
 
 ### Inflector::underscore()
 
-`static` Cake\\Utility\\Inflector::**underscore**($camelCase): string
+`static` Cake\\Utility\\Inflector::**underscore**(string $string): string
 
 These methods are useful when creating class names, or property names:
 
@@ -172,7 +172,7 @@ underscore.
 
 ### Inflector::humanize()
 
-`static` Cake\\Utility\\Inflector::**humanize**($underscored): string
+`static` Cake\\Utility\\Inflector::**humanize**(string $string, string $delimiter = '_'): string
 
 This method is useful when converting underscored forms into "Title Case" forms
 for human readable values:
@@ -186,15 +186,15 @@ Inflector::humanize('apple_pie');
 
 ### Inflector::classify()
 
-`static` Cake\\Utility\\Inflector::**classify**($underscored): string
+`static` Cake\\Utility\\Inflector::**classify**(string $tableName): string
 
 ### Inflector::dasherize()
 
-`static` Cake\\Utility\\Inflector::**dasherize**($dashed): string
+`static` Cake\\Utility\\Inflector::**dasherize**(string $string): string
 
 ### Inflector::tableize()
 
-`static` Cake\\Utility\\Inflector::**tableize**($camelCase): string
+`static` Cake\\Utility\\Inflector::**tableize**(string $className): string
 
 When generating code, or using CakePHP's conventions you may need to inflect
 table names or class names:
@@ -214,7 +214,7 @@ Inflector::tableize('UserProfileSetting');
 
 ### Inflector::variable()
 
-`static` Cake\\Utility\\Inflector::**variable**($underscored): string
+`static` Cake\\Utility\\Inflector::**variable**(string $string): string
 
 Variable names are often useful when doing meta-programming tasks that involve
 generating code or doing work based on conventions:
@@ -244,7 +244,7 @@ special cases.
 
 ### Inflector::rules()
 
-`static` Cake\\Utility\\Inflector::**rules**($type, $rules, $reset = false): void
+`static` Cake\\Utility\\Inflector::**rules**(string $type, array $rules, bool $reset = false): void
 
 Define new inflection and transliteration rules for Inflector to use. Often,
 this method is used in your **config/bootstrap.php**:

--- a/docs/en/core-libraries/number.md
+++ b/docs/en/core-libraries/number.md
@@ -91,7 +91,7 @@ Number::setDefaultCurrencyFormat(Number::FORMAT_CURRENCY_ACCOUNTING);
 
 ### Number::setDefaultCurrency()
 
-`method` Cake\\I18n\\Number::**setDefaultCurrency**($currency): void
+`static` Cake\\I18n\\Number::**setDefaultCurrency**(?string $currency = null): void
 
 Setter for the default currency. This removes the need to always pass the
 currency to `Cake\I18n\Number::currency()` and change all

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -40,7 +40,7 @@ class UsersController extends AppController
 
 ### Text::transliterate()
 
-`static` Cake\\Utility\\Text::**transliterate**($string, $transliteratorId = null): string
+`static` Cake\\Utility\\Text::**transliterate**(string $string, Transliterator|string|null $transliterator = null): string
 
 Transliterate by default converts all characters in provided string into
 equivalent ASCII characters. The method expects UTF-8 encoding. The character
@@ -428,7 +428,7 @@ Output:
 
 ### Text::toList()
 
-`method` Cake\\Utility\\Text::**toList**(array $list, ?string $and = null, $separator = ', '): string
+`method` Cake\\Utility\\Text::**toList**(array $list, ?string $and = null, string $separator = ', '): string
 
 Creates a comma-separated list where the last two items are joined with 'and':
 

--- a/docs/en/core-libraries/time.md
+++ b/docs/en/core-libraries/time.md
@@ -149,7 +149,7 @@ echo $time->timezoneName; // America/New_York
 
 ### DateTime::setJsonEncodeFormat()
 
-`static` Cake\\I18n\\DateTime::**setJsonEncodeFormat**($format): void
+`static` Cake\\I18n\\DateTime::**setJsonEncodeFormat**(Closure|array|string|int $format): void
 
 This method sets the default format used when converting an object to json:
 
@@ -179,7 +179,7 @@ The `callable` parameter type was added.
 
 ### DateTime::i18nFormat()
 
-`method` Cake\\I18n\\DateTime::**i18nFormat**($format = null, $timezone = null, $locale = null): string|int
+`method` Cake\\I18n\\DateTime::**i18nFormat**(array|string|int|null $format = null, DateTimeZone|string|null $timezone = null, ?string $locale = null): string|int
 
 A very common thing to do with `Time` instances is to print out formatted
 dates. CakePHP makes this a snap:
@@ -415,19 +415,19 @@ $range = $time->toQuarterRange();
 
 ### DateTime::isYesterday()
 
-`method` Cake\\I18n\\DateTime::**isYesterday**()
+`method` Cake\\I18n\\DateTime::**isYesterday**(): bool
 
 ### DateTime::isThisWeek()
 
-`method` Cake\\I18n\\DateTime::**isThisWeek**()
+`method` Cake\\I18n\\DateTime::**isThisWeek**(): bool
 
 ### DateTime::isThisMonth()
 
-`method` Cake\\I18n\\DateTime::**isThisMonth**()
+`method` Cake\\I18n\\DateTime::**isThisMonth**(): bool
 
 ### DateTime::isThisYear()
 
-`method` Cake\\I18n\\DateTime::**isThisYear**()
+`method` Cake\\I18n\\DateTime::**isThisYear**(): bool
 
 You can compare a `DateTime` instance with the present in a variety of ways:
 
@@ -447,7 +447,7 @@ not the `DateTime` instance matches the present.
 
 ### DateTime::isWithinNext()
 
-`method` Cake\\I18n\\DateTime::**isWithinNext**($interval)
+`method` Cake\\I18n\\DateTime::**isWithinNext**(string|int $timeInterval): bool
 
 You can see if a `DateTime` instance falls within a given range using
 `wasWithinLast()` and `isWithinNext()`:
@@ -464,7 +464,7 @@ debug($time->isWithinNext('2 weeks'));
 
 ### DateTime::wasWithinLast()
 
-`method` Cake\\I18n\\DateTime::**wasWithinLast**($interval)
+`method` Cake\\I18n\\DateTime::**wasWithinLast**(string|int $timeInterval): bool
 
 You can also compare a `DateTime` instance within a range in the past:
 

--- a/docs/en/core-libraries/xml.md
+++ b/docs/en/core-libraries/xml.md
@@ -9,7 +9,7 @@ DOMDocument objects, and back into arrays again.
 
 ### Xml::build()
 
-`static` Cake\\Utility\\Xml::**build**($input, array $options = []): SimpleXMLElement|DOMDocument
+`static` Cake\\Utility\\Xml::**build**(object|array|string $input, array $options = []): SimpleXMLElement|DOMDocument
 
 You can load XML-ish data using `Xml::build()`. Depending on your
 `$options` parameter, this method will return a SimpleXMLElement (default)
@@ -79,7 +79,7 @@ can be enabled with the `loadEntities` and `parseHuge` options respectively.
 
 ### Xml::toArray()
 
-`static` Cake\\Utility\\Xml::**toArray**($obj): array
+`static` Cake\\Utility\\Xml::**toArray**(SimpleXMLElement|DOMNode $obj): array
 
 Converting XML strings into arrays is simple with the Xml class as well. By
 default you'll get a SimpleXml object back:


### PR DESCRIPTION
## Summary

- Adds proper type annotations to method signatures across 8 core library documentation files
- Aligns signatures with actual CakePHP 5.x source code
- Covers approximately 50+ method signatures total

### Files updated:
- **app.md**: `className()` - added `string` types for parameters
- **collections.md**: ~33 methods - full type annotations (callable, string, int, mixed, etc.)
- **email.md**: `setAttachments()`, `setEmailPattern()` - added parameter types and return types
- **inflector.md**: 10 methods - verified types match source
- **number.md**: `setDefaultCurrency()` - changed to `static` and added nullable string type
- **text.md**: `transliterate()`, `toList()` - verified types match source
- **time.md**: 8 methods - added Closure/array/string/int types for format params, bool returns for comparison methods
- **xml.md**: `build()`, `toArray()` - verified types match source

## Test plan

- [ ] Verify documentation renders correctly
- [ ] Spot check a few method signatures against CakePHP 5.x source

Refs #7744