### PR TITLE
Fix code block language tags for proper syntax highlighting

### DIFF
--- a/docs/en/appendices/5-0-upgrade-guide.md
+++ b/docs/en/appendices/5-0-upgrade-guide.md
@@ -6,7 +6,7 @@ First, check that your application is running on latest CakePHP 4.x version.
 
 Once your application is running on latest CakePHP 4.x, enable deprecation warnings in **config/app.php**:
 
-``` text
+``` php
 'Error' => [
     'errorLevel' => E_ALL,
 ]
@@ -49,7 +49,7 @@ composer install --no-dev
 With the upgrade tool installed you can now run it on your application or
 plugin:
 
-``` text
+``` bash
 bin/cake upgrade rector --rules cakephp50 <path/to/app/src>
 bin/cake upgrade rector --rules chronos3 <path/to/app/src>
 ```

--- a/docs/en/appendices/5-1-migration-guide.md
+++ b/docs/en/appendices/5-1-migration-guide.md
@@ -10,7 +10,7 @@ The [upgrade tool](../appendices/migration-guides) provides rector rules for
 automating some of the migration work. Run rector before updating your
 `composer.json` dependencies:
 
-``` text
+``` bash
 bin/cake upgrade rector --rules cakephp51 <path/to/app/src>
 ```
 

--- a/docs/en/appendices/5-2-migration-guide.md
+++ b/docs/en/appendices/5-2-migration-guide.md
@@ -10,7 +10,7 @@ The [upgrade tool](../appendices/migration-guides) provides rector rules for
 automating some of the migration work. Run rector before updating your
 `composer.json` dependencies:
 
-``` text
+``` bash
 bin/cake upgrade rector --rules cakephp52 <path/to/app/src>
 ```
 

--- a/docs/en/appendices/5-3-migration-guide.md
+++ b/docs/en/appendices/5-3-migration-guide.md
@@ -10,7 +10,7 @@ The [upgrade tool](../appendices/migration-guides) provides rector rules for
 automating some of the migration work. Run rector before updating your
 `composer.json` dependencies:
 
-``` text
+``` bash
 bin/cake upgrade rector --rules cakephp53 <path/to/app/src>
 ```
 

--- a/docs/en/appendices/glossary.md
+++ b/docs/en/appendices/glossary.md
@@ -56,7 +56,7 @@ columns. Often used in conjunction with the FormHelper.
 HTML attributes
 An array of key =\> values that are composed into HTML attributes. For example:
 
-``` text
+``` php
 // Given
 ['class' => 'my-class', 'target' => '_blank']
 
@@ -67,7 +67,7 @@ class="my-class" target="_blank"
 If an option can be minimized or accepts its name as the value, then `true`
 can be used:
 
-``` text
+``` php
 // Given
 ['checked' => true]
 
@@ -87,7 +87,7 @@ plugin syntax
 Plugin syntax refers to the dot separated class name indicating classes
 are part of a plugin:
 
-``` text
+``` php
 // The plugin is "DebugKit", and the class name is "Toolbar".
 'DebugKit.Toolbar'
 

--- a/docs/en/appendices/migration-guides.md
+++ b/docs/en/appendices/migration-guides.md
@@ -12,7 +12,7 @@ method renames and signature updates.
 
 To use the upgrade tool:
 
-``` text
+``` bash
 # Install the upgrade tool
 git clone https://github.com/cakephp/upgrade
 cd upgrade

--- a/docs/en/console-commands/cache.md
+++ b/docs/en/console-commands/cache.md
@@ -3,7 +3,7 @@
 To help you better manage cached data from a CLI environment, a console command
 is available for clearing cached data your application has:
 
-``` text
+``` bash
 // Clear one cache config
 bin/cake cache clear <configname>
 

--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -91,7 +91,7 @@ CakePHP will use conventions to generate the name your commands use on the
 command line. If you want to overwrite the generated name implement the
 `defaultName()` method in your command:
 
-``` text
+``` php
 public static function defaultName(): string
 {
     return 'oh_hi';

--- a/docs/en/contributing/backwards-compatibility.md
+++ b/docs/en/contributing/backwards-compatibility.md
@@ -272,7 +272,7 @@ locate code that needs to be updated before it breaks. If you wish to disable
 runtime warnings you can do so using the `Error.errorLevel` configuration
 value:
 
-``` text
+``` php
 // in config/app.php
 // ...
 'Error' => [

--- a/docs/en/contributing/cakephp-coding-conventions.md
+++ b/docs/en/contributing/cakephp-coding-conventions.md
@@ -32,7 +32,7 @@ Four spaces will be used for indentation.
 
 So, indentation should look like this:
 
-``` text
+``` php
 // base level
     // level 1
         // level 2
@@ -98,7 +98,7 @@ In short:
 Control structures are for example "`if`", "`for`", "`foreach`",
 "`while`", "`switch`" etc. Below, an example with "`if`":
 
-``` text
+``` php
 if ((expr_1) || (expr_2)) {
     // action_1;
 } elseif (!(expr_3) && (expr_4)) {
@@ -368,7 +368,7 @@ tags:
 PhpDoc tags are very much like JavaDoc tags in Java. Tags are only processed if
 they are the first thing in a DocBlock line, for example:
 
-``` text
+``` php
 /**
  * Tag example.
  *
@@ -377,7 +377,7 @@ they are the first thing in a DocBlock line, for example:
  */
 ```
 
-``` text
+``` php
 /**
  * Example of inline phpDoc tags.
  *
@@ -467,7 +467,7 @@ public function foo()
 `include`, `require`, `include_once` and `require_once` do not have
 parentheses:
 
-``` text
+``` php
 // wrong = parentheses
 require_once('ClassFileName.php');
 require_once ($class);
@@ -491,7 +491,7 @@ The short echo should be used in template files in place of `<?php echo`. It
 should be immediately followed by a single space, the variable or function value
 to `echo`, a single space, and the php closing tag:
 
-``` text
+``` php
 // wrong = semicolon, no spaces
 <td><?=$name;?></td>
 
@@ -593,14 +593,14 @@ of `floatval($var)` when applicable.
 
 Constants should be defined in capital letters:
 
-``` text
+``` php
 define('CONSTANT', 1);
 ```
 
 If a constant name consists of multiple words, they should be separated by an
 underscore character, for example:
 
-``` text
+``` php
 define('LONG_NAMED_CONSTANT', 2);
 ```
 
@@ -608,7 +608,7 @@ define('LONG_NAMED_CONSTANT', 2);
 
 Enum cases are defined in `CamelCase` style:
 
-``` text
+``` php
 enum ArticleStatus: string
 {
     case Published = 'Y';

--- a/docs/en/contributing/code.md
+++ b/docs/en/contributing/code.md
@@ -52,7 +52,7 @@ is for. For example if you are fixing a bug in `3.x` you would want to use the
 `master` branch as the base for your branch. If your change is a bug fix for
 the 2.x release series, you should use the `2.x` branch:
 
-``` text
+``` bash
 # fixing a bug on 3.x
 git fetch upstream
 git checkout -b ticket-1234 upstream/master
@@ -80,7 +80,7 @@ following:
 Once your changes are done and you're ready for them to be merged into CakePHP,
 you'll want to update your branch:
 
-``` text
+``` bash
 # Rebase fix on top of master
 git checkout master
 git fetch upstream
@@ -95,20 +95,20 @@ code. You might encounter a conflict during the `rebase`. If the rebase quits
 early you can see which files are conflicted/un-merged with `git status`.
 Resolve each conflict, and then continue the rebase:
 
-``` text
+``` bash
 git add <filename> # do this for each conflicted file.
 git rebase --continue
 ```
 
 Check that all your tests continue to pass. Then push your branch to your fork:
 
-``` text
+``` bash
 git push origin <branch-name>
 ```
 
 If you've rebased after pushing your branch, you'll need to use force push:
 
-``` text
+``` bash
 git push --force origin <branch-name>
 ```
 

--- a/docs/en/controllers/middleware/rate-limit.md
+++ b/docs/en/controllers/middleware/rate-limit.md
@@ -92,7 +92,7 @@ new RateLimitMiddleware([
 The middleware automatically handles proxy headers. You can configure
 which headers to check using the `ipHeader` option:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'identifier' => RateLimitMiddleware::IDENTIFIER_IP,
     'ipHeader' => ['CF-Connecting-IP', 'X-Forwarded-For'],
@@ -103,7 +103,7 @@ new RateLimitMiddleware([
 
 Track requests per authenticated user:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'identifier' => RateLimitMiddleware::IDENTIFIER_USER,
     'limit' => 1000,
@@ -118,7 +118,7 @@ The middleware checks for users implementing `Authentication\IdentityInterface`.
 
 Apply different limits to different routes:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'identifier' => RateLimitMiddleware::IDENTIFIER_ROUTE,
     'limit' => 10,
@@ -132,7 +132,7 @@ This creates separate limits for each controller/action combination.
 
 Track requests by API key or token:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'identifier' => RateLimitMiddleware::IDENTIFIER_API_KEY,
     'limit' => 5000,
@@ -143,7 +143,7 @@ new RateLimitMiddleware([
 By default, the middleware looks for tokens in the `Authorization` and
 `X-API-Key` headers. You can customize which headers to check:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'identifier' => RateLimitMiddleware::IDENTIFIER_TOKEN,
     'tokenHeaders' => ['Authorization', 'X-API-Key', 'X-Auth-Token'],
@@ -171,7 +171,7 @@ new RateLimitMiddleware([
 The default strategy that provides smooth rate limiting by continuously
 adjusting the window based on request timing:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'strategy' => RateLimitMiddleware::STRATEGY_SLIDING_WINDOW,
 ])
@@ -181,7 +181,7 @@ new RateLimitMiddleware([
 
 Resets the counter at fixed intervals:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'strategy' => RateLimitMiddleware::STRATEGY_FIXED_WINDOW,
 ])
@@ -191,7 +191,7 @@ new RateLimitMiddleware([
 
 Allows for burst capacity while maintaining an average rate:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'strategy' => RateLimitMiddleware::STRATEGY_TOKEN_BUCKET,
     'limit' => 100,    // bucket capacity
@@ -204,7 +204,7 @@ new RateLimitMiddleware([
 You can use a custom rate limiter strategy by specifying the `strategyClass`
 option. Your class must implement `Cake\Http\RateLimiter\RateLimiterInterface`:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'strategyClass' => App\RateLimiter\MyCustomRateLimiter::class,
 ])
@@ -367,7 +367,7 @@ $middlewareQueue->add(new RateLimitMiddleware([
 The rate limiter stores its data in cache. Make sure you have a persistent
 cache configured:
 
-``` text
+``` php
 // In config/app.php
 'Cache' => [
     'rate_limit' => [
@@ -380,7 +380,7 @@ cache configured:
 
 Then use it in the middleware:
 
-``` text
+``` php
 new RateLimitMiddleware([
     'cache' => 'rate_limit',
 ])

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -453,7 +453,7 @@ is useful for debugging. Configuring transports allows you to keep configuration
 data out of your application code and makes deployment simpler as you can simply
 change the configuration data. An example transport configuration looks like:
 
-``` text
+``` php
 // In config/app.php
 'EmailTransport' => [
     // Sample Mail configuration

--- a/docs/en/core-libraries/global-constants-and-functions.md
+++ b/docs/en/core-libraries/global-constants-and-functions.md
@@ -17,7 +17,7 @@ convenience wrappers for other CakePHP functionality, such as debugging and
 translating content. By default only namespaced functions are autoloaded,
 however you can optionally load global aliases by adding:
 
-``` text
+``` php
 require CAKE . 'functions.php';
 ```
 
@@ -32,13 +32,13 @@ This function handles localization in CakePHP applications. The
 `$string_id` identifies the ID for a translation. You can supply
 additional arguments to replace placeholders in your string:
 
-``` text
+``` php
 __('You have {0} unread messages', $number);
 ```
 
 You can also provide a name-indexed array of replacements:
 
-``` text
+``` php
 __('You have {unread} unread messages', ['unread' => $number]);
 ```
 

--- a/docs/en/core-libraries/internationalization-and-localization.md
+++ b/docs/en/core-libraries/internationalization-and-localization.md
@@ -117,7 +117,7 @@ learn more.
 The default locale can be set in your **config/app.php** file by setting
 `App.defaultLocale`:
 
-``` text
+``` php
 'App' => [
     ...
     'defaultLocale' => env('APP_DEFAULT_LOCALE', 'en_US'),
@@ -149,7 +149,7 @@ application. The most frequently used one is `__()`. This function
 is used to retrieve a single translation message or return the same string if no
 translation was found:
 
-``` text
+``` php
 echo __('Popular Articles');
 ```
 
@@ -157,7 +157,7 @@ If you need to group your messages, for example, translations inside a plugin,
 you can use the `__d()` function to fetch messages from another
 domain:
 
-``` text
+``` php
 echo __d('my_plugin', 'Trending right now');
 ```
 
@@ -172,7 +172,7 @@ This can happen if two strings are identical but refer to different things. For
 example, 'letter' has multiple meanings in English. To solve that problem, you
 can use the `__x()` function:
 
-``` text
+``` php
 echo __x('written communication', 'He read the first letter');
 
 echo __x('alphabet learning', 'He read the first letter');
@@ -192,20 +192,20 @@ msgstr "Er las den ersten Brief"
 Translation functions allow you to interpolate variables into the messages using
 special markers defined in the message itself or in the translated string:
 
-``` text
+``` php
 echo __("Hello, my name is {0}, I'm {1} years old", ['Sara', 12]);
 ```
 
 Markers are numeric, and correspond to the keys in the passed array. You can
 also pass variables as independent arguments to the function:
 
-``` text
+``` php
 echo __("Small step for {0}, Big leap for {1}", 'Man', 'Humanity');
 ```
 
 All translation functions support placeholder replacements:
 
-``` text
+``` php
 __d('validation', 'The field {0} cannot be left empty', 'Name');
 
 __x('alphabet', 'He read the letter {0}', 'Z');
@@ -215,13 +215,13 @@ The `'` (single quote) character acts as an escape code in translation
 messages. Any variables between single quotes will not be replaced and is
 treated as literal text. For example:
 
-``` text
+``` php
 __("This variable '{0}' be replaced.", 'will not');
 ```
 
 By using two adjacent quotes your variables will be replaced properly:
 
-``` text
+``` php
 __("This variable ''{0}'' be replaced.", 'will');
 ```
 
@@ -230,7 +230,7 @@ These functions take advantage of the
 so you can translate messages and localize dates, numbers and currency at the
 same time:
 
-``` text
+``` php
 echo __(
     'Hi {0}, your balance on the {1,date} is {2,number,currency}',
     ['Charles', new DateTime('2014-01-13 11:12:00'), 1354.37]
@@ -243,7 +243,7 @@ Hi Charles, your balance on the Jan 13, 2014, 11:12 AM is $ 1,354.37
 Numbers in placeholders can be formatted as well with fine grain control of the
 output:
 
-``` text
+``` php
 echo __(
     'You have traveled {0,number} kilometers in {1,number,integer} weeks',
     [5423.344, 5.1]
@@ -279,7 +279,7 @@ You can also use named placeholders like `{name}` in the message strings.
 When using named placeholders, pass the placeholder and replacement in an array using key/value pairs,
 for example:
 
-``` text
+``` php
 // echos:  Hi. My name is Sara. I'm 12 years old.
 echo __("Hi. My name is {name}. I'm {age} years old.", ['name' => 'Sara', 'age' => 12]);
 ```
@@ -307,7 +307,7 @@ msgstr "{placeholder,plural,=0{Ningún resultado} =1{1 resultado} other{{1} resu
 And in the application use the following code to output either of the
 translations for such string:
 
-``` text
+``` php
 __('{0,plural,=0{No records found }=1{Found 1 record} other{Found # records}}', [0]);
 
 // Returns "Ningún resultado" as the argument {0} is 0
@@ -346,7 +346,7 @@ msgstr "{0,plural,=0{Ningún resultado} =1{1 resultado} other{{1} resultados}}"
 
 Then use the new string in your code:
 
-``` text
+``` php
 __('search.results', [2, 2]);
 
 // Returns: "2 resultados"
@@ -598,14 +598,14 @@ variables in translation messages and selecting the correct plural form.
 If you're dealing with a legacy application, or you don't need the power offered
 by the ICU message formatting, CakePHP also provides the `sprintf` formatter:
 
-``` text
+``` php
 return Package('sprintf', 'fallback_domain', $messages);
 ```
 
 The messages to be translated will be passed to the `sprintf()` function for
 interpolating the variables:
 
-``` text
+``` php
 __('Hello, my name is %s and I am %d years old', 'José', 29);
 ```
 

--- a/docs/en/core-libraries/xml.md
+++ b/docs/en/core-libraries/xml.md
@@ -104,7 +104,7 @@ Your array must have only one element in the "top level" and it can not be
 numeric. If the array is not in this format, Xml will throw an exception.
 Examples of invalid arrays:
 
-``` text
+``` php
 // Top level with numeric key
 [
     ['key' => 'value']

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -277,7 +277,7 @@ Since plugins, view templates and locales are not classes, they cannot have an
 autoloader configured. CakePHP provides three Configure variables to setup additional
 paths for these resources. In your **config/app.php** you can set these variables:
 
-``` text
+``` php
 return [
     // More configuration
     'App' => [

--- a/docs/en/development/debugging.md
+++ b/docs/en/development/debugging.md
@@ -34,7 +34,7 @@ If you have [Psysh](https://psysh.org/) installed you can use this
 function in CLI environments to open an interactive console with the current
 local scope:
 
-``` text
+``` php
 // Some code
 eval(breakpoint());
 ```
@@ -134,7 +134,7 @@ Returns the current stack trace. Each line of the trace includes
 the calling method, including which file and line the call
 originated from:
 
-``` text
+``` php
 // In PostsController::index()
 pr(Debugger::trace());
 
@@ -186,7 +186,7 @@ Exception and error pages can contain URLs that directly open in your editor or
 IDE. CakePHP ships with URL formats for several popular editors, and you can add
 additional editor formats if required during application bootstrap:
 
-``` text
+``` php
 // Generate links for vscode.
 Debugger::setEditor('vscode')
 

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -59,7 +59,7 @@ deprecated. We also recommend this system for use in your plugins and
 application code when useful. You can trigger deprecation warnings with
 `deprecationWarning()`:
 
-``` text
+``` php
 deprecationWarning('5.0', 'The example() method is deprecated. Use getExample() instead.');
 ```
 
@@ -72,7 +72,7 @@ You can temporarily disable deprecation warnings in one of a few ways:
 2.  Using the `Error.ignoredDeprecationPaths` configuration option to ignore
     deprecations with glob compatible expressions. For example:
 
-    ``` text
+    ``` php
     'Error' => [
         'ignoredDeprecationPaths' => [
             'vendors/company/contacts/*',

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -202,7 +202,7 @@ syntax:
 
 Some example string targets are:
 
-``` text
+``` php
 // Application controller
 'Articles::view'
 

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -145,7 +145,7 @@ Cache and Database session handlers use this method for saving sessions.
 Additional settings for the handler should be placed inside the handler array.
 You can then read those values out from inside your handler:
 
-``` text
+``` php
 'Session' => [
     'handler' => [
         'engine' => 'DatabaseSession',
@@ -166,7 +166,7 @@ from inside plugins. By setting the engine to `MyPlugin.PluginSessionHandler`.
 
 If you need to use a database to store your session data, configure as follows:
 
-``` text
+``` php
 'Session' => [
     'defaults' => 'database'
 ]
@@ -189,7 +189,7 @@ You can find a copy of the schema for the sessions table in the [application ske
 
 You can also use your own `Table` class to handle the saving of the sessions:
 
-``` text
+``` php
 'Session' => [
     'defaults' => 'database',
     'handler' => [
@@ -231,7 +231,7 @@ configuration to use. The default cache configuration is `'default'`.
 
 The app skeleton comes preconfigured with a session config like this:
 
-``` text
+``` php
 'Session' => [
     'defaults' => 'php',
 ],
@@ -343,7 +343,7 @@ a `Cake\Cache\Cache` operation. This lets us fetch sessions from
 the fast cache, and not have to worry about what happens when we fill the cache.
 In **config/app.php** make the session block look like:
 
-``` text
+``` php
 'Session' => [
     'defaults' => 'database',
     'handler' => [

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -473,7 +473,7 @@ time-consuming to maintain.
 Each table can define `columns`, `constraints`, and `indexes`.
 An example table would be:
 
-``` text
+``` php
 return [
   'articles' => [
      'columns' => [

--- a/docs/en/orm/behaviors/counter-cache.md
+++ b/docs/en/orm/behaviors/counter-cache.md
@@ -145,7 +145,7 @@ It is possible to use the CounterCache behavior in a `belongsToMany` association
 First, you need to add the `through` and `cascadeCallbacks` options to the
 `belongsToMany` association:
 
-``` text
+``` php
 'through'          => 'CommentsArticles',
 'cascadeCallbacks' => true
 ```

--- a/docs/en/orm/behaviors/translate.md
+++ b/docs/en/orm/behaviors/translate.md
@@ -267,7 +267,7 @@ In the example above you will get a list of entities back that have a
 `_translations` property set. This property will contain a list of translation
 data entities. For example the following properties would be accessible:
 
-``` text
+``` php
 // Outputs 'en'
 echo $article->_translations['en']->locale;
 
@@ -451,7 +451,7 @@ After the entity has been saved, the translated field will be persisted as well,
 one thing to note is that values from the default language that were not
 overridden will be preserved:
 
-``` text
+``` php
 // Outputs 'This is the content'
 echo $article->body;
 

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -311,7 +311,7 @@ Role configurations override the values in the shared connection config. If the 
 and write role configurations are the same, a single connection to the database is used
 for both:
 
-``` text
+``` php
 'default' => [
     'driver' => 'mysql',
     'username' => '...',
@@ -613,7 +613,7 @@ enum ArticleStatus: string implements EnumLabelInterface
 This can be useful if you want to use your enums in `FormHelper` select
 inputs. You can use [bake](../bake) to generate an enum class:
 
-``` text
+``` bash
 # generate an enum class with two cases and stored as an integer
 bin/cake bake enum UserStatus inactive:0,active:1 -i
 
@@ -1200,7 +1200,7 @@ metadata is stored in the `_cake_model_` cache configuration. You can define
 a custom cache configuration using the `cacheMetatdata` option in your
 datasource configuration:
 
-``` text
+``` php
 'Datasources' => [
     'default' => [
         // Other keys go here.

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -1281,7 +1281,7 @@ $mapper = function ($rel, $key, $mr) {
 
 The intermediate array will be like the following:
 
-``` text
+``` php
 [
     1 => [2, 3, 4, 5, -3, -5],
     2 => [-1],
@@ -1327,7 +1327,7 @@ $fakeFriends = $friends->find()
 
 This would return an array similar to this:
 
-``` text
+``` php
 [
     1 => [2, 4],
     3 => [6]

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -1032,7 +1032,7 @@ If you are creating a new entity, and want to add existing records to a has
 many/belongs to many association you need to initialize the association property
 first:
 
-``` text
+``` php
 $article->comments = [];
 ```
 

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -462,7 +462,7 @@ because we don't have a Contact model defined yet.
 If your application includes the default routing CakePHP provides you will be
 able to access your plugin controllers using URLs like:
 
-``` text
+``` php
 // Access the index route of a plugin controller.
 /contact-manager/contacts
 
@@ -565,7 +565,7 @@ right folder inside of the `plugins/[PluginName]/templates/` folder. For our
 ContactManager plugin, we'll need a view for our `ContactsController::index()`
 action, so let's include that as well:
 
-``` text
+``` php
 // plugins/ContactManager/templates/Contacts/index.php:
 <h1>Contacts</h1>
 <p>Following is a sortable list of your contacts</p>

--- a/docs/en/tutorials-and-examples/cms/tags-and-users.md
+++ b/docs/en/tutorials-and-examples/cms/tags-and-users.md
@@ -385,7 +385,7 @@ echo $this->Form->control('tag_string', ['type' => 'text']);
 We'll also need to update the article view template. In
 **templates/Articles/view.php** add the line as shown:
 
-``` text
+``` php
 <!-- File: templates/Articles/view.php -->
 
 <h1><?= h($article->title) ?></h1>

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -573,7 +573,7 @@ the parameter array (in the same way that `Controller::set()` in the
 controller works with template files). In the above example, the
 **templates/element/helpbox.php** file can use the `$helptext` variable:
 
-``` text
+``` php
 // Inside templates/element/helpbox.php
 echo $helptext; // Outputs `Oh, this text is very helpful.`
 ```

--- a/docs/en/views/cells.md
+++ b/docs/en/views/cells.md
@@ -76,7 +76,7 @@ very much like a controller would. We can use the `fetchTable()` and `set()`
 methods just like we would in a controller. In our template file, add the
 following:
 
-``` text
+``` php
 <!-- templates/cell/Inbox/display.php -->
 <div class="notification-icon">
     You have <?= $unread_count ?> unread messages.

--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -373,7 +373,7 @@ methods of FormHelper.
 
 By default the `control()` method will employ the following widget templates:
 
-``` text
+``` html
 'inputContainer' => '<div class="{{constainerClass}} {{type}}{{required}}">{{content}}</div>'
 'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>'
 'requiredClass' => 'required'
@@ -382,7 +382,7 @@ By default the `control()` method will employ the following widget templates:
 
 In case of validation errors it will also use:
 
-``` text
+``` html
 'inputContainerError' => '<div class="{{containerClass}} {{type}}{{required}} error">{{content}}{{error}}</div>'
 ```
 
@@ -899,7 +899,7 @@ Will output:
 
 Creates a textarea control field. The default widget template used is:
 
-``` text
+``` html
 'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>'
 ```
 
@@ -1158,7 +1158,7 @@ $options = $examples->map(function ($value, $key) {
 
 Creates a `checkbox` form element. The widget template used is:
 
-``` text
+``` html
 'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>'
 ```
 
@@ -1235,7 +1235,7 @@ Will output:
 
 Creates a set of radio button inputs. The default widget templates used are:
 
-``` text
+``` html
 'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>'
 'radioWrapper' => '{{label}}'
 ```
@@ -1366,14 +1366,14 @@ rendering the select picker.
 
 By default `select` uses the following widget templates:
 
-``` text
+``` html
 'select' => '<select name="{{name}}"{{attrs}}>{{content}}</select>'
 'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>'
 ```
 
 May also use:
 
-``` text
+``` html
 'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>'
 'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>'
 ```
@@ -1638,7 +1638,7 @@ certain behaviors of the `select()` method.
 Creates a file upload field in the form.
 The widget template used by default is:
 
-``` text
+``` html
 'file' => '<input type="file" name="{{name}}"{{attrs}}>'
 ```
 
@@ -1922,7 +1922,7 @@ provided then the default validation error message for that field will be used.
 
 Uses the following template widgets:
 
-``` text
+``` html
 'error' => '<div class="error-message">{{content}}</div>'
 'errorList' => '<ul>{{content}}</ul>'
 'errorItem' => '<li>{{text}}</li>'
@@ -2003,7 +2003,7 @@ If you want to manually set those events with custom JavaScript, you can set the
 option to `false` and use the special `customValidityMessage` template variable instead. This
 template variable is added when a field is required:
 
-``` text
+``` php
 // example template
 [
     'input' => '<input type="{{type}}" name="{{name}}" data-error-message="{{customValidityMessage}}" {{attrs}}/>',
@@ -2037,7 +2037,7 @@ relative to *webroot/img*.
 
 By default it will use the following widget templates:
 
-``` text
+``` html
 'inputSubmit' => '<input type="{{type}}"{{attrs}}>'
 'submitContainer' => '<div class="submit">{{content}}</div>'
 ```
@@ -2333,7 +2333,7 @@ $this->loadHelper('Form', [
 This would load the tags found in **config/app_form.php**. This file should
 contain an array of templates *indexed by name*:
 
-``` text
+``` php
 // in config/app_form.php
 return [
     'inputContainer' => '<div class="form-control">{{content}}</div>',

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -60,7 +60,7 @@ public function initialize(): void
 Whether your templates are in the primary application or a plugin, your
 templates file should look something like:
 
-``` text
+``` php
 return [
     'number' => '<a href="{{url}}">{{text}}</a>',
 ];

--- a/docs/en/views/helpers/text.md
+++ b/docs/en/views/helpers/text.md
@@ -24,7 +24,7 @@ $linkedText = $this->Text->autoLinkEmails($myText);
 
 Output:
 
-``` text
+``` html
 For more information regarding our world-famous pastries and desserts,
 contact <a href="mailto:info@example.com">info@example.com</a>
 ```


### PR DESCRIPTION
## Summary

- Replace ```` ``` text ```` with appropriate language tags across 34 documentation files for proper syntax highlighting
- PHP code blocks → ```` ``` php ````
- Shell/CLI commands → ```` ``` bash ````  
- HTML template strings → ```` ``` html ````
- Blocks that are genuinely plain text (URL patterns, crontab entries, ICU format syntax, `print_r` output, composer package names) are intentionally left as `text`