### PR TITLE
Fix PHP code style in documentation snippets

### DIFF
--- a/docs/en/appendices/5-0-upgrade-guide.md
+++ b/docs/en/appendices/5-0-upgrade-guide.md
@@ -9,7 +9,7 @@ Once your application is running on latest CakePHP 4.x, enable deprecation warni
 ``` php
 'Error' => [
     'errorLevel' => E_ALL,
-]
+],
 ```
 
 Now that you can see all the warnings, make sure these are fixed before proceeding with the upgrade.

--- a/docs/en/contributing/backwards-compatibility.md
+++ b/docs/en/contributing/backwards-compatibility.md
@@ -277,7 +277,7 @@ value:
 // ...
 'Error' => [
     'errorLevel' => E_ALL ^ E_USER_DEPRECATED,
-]
+],
 // ...
 ```
 

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -484,7 +484,7 @@ TransportFactory::setConfig('gmail', [
     'port' => 465,
     'username' => 'my@gmail.com',
     'password' => 'secret',
-    'className' => 'Smtp'
+    'className' => 'Smtp',
 ]);
 ```
 

--- a/docs/en/core-libraries/internationalization-and-localization.md
+++ b/docs/en/core-libraries/internationalization-and-localization.md
@@ -122,7 +122,7 @@ The default locale can be set in your **config/app.php** file by setting
     ...
     'defaultLocale' => env('APP_DEFAULT_LOCALE', 'en_US'),
     ...
-]
+],
 ```
 
 This will control several aspects of the application, including the default

--- a/docs/en/core-libraries/xml.md
+++ b/docs/en/core-libraries/xml.md
@@ -113,7 +113,7 @@ Examples of invalid arrays:
 // Multiple keys in top level
 [
     'key1' => 'first value',
-    'key2' => 'other value'
+    'key2' => 'other value',
 ];
 ```
 

--- a/docs/en/development/debugging.md
+++ b/docs/en/development/debugging.md
@@ -188,7 +188,7 @@ additional editor formats if required during application bootstrap:
 
 ``` php
 // Generate links for vscode.
-Debugger::setEditor('vscode')
+Debugger::setEditor('vscode');
 
 // Add a custom format
 // Format strings will have the {file} and {line}

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -202,7 +202,7 @@ syntax:
 
 Some example string targets are:
 
-``` php
+``` text
 // Application controller
 'Articles::view'
 

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -168,7 +168,7 @@ If you need to use a database to store your session data, configure as follows:
 
 ``` php
 'Session' => [
-    'defaults' => 'database'
+    'defaults' => 'database',
 ]
 ```
 
@@ -354,7 +354,7 @@ In **config/app.php** make the session block look like:
 ],
 // Make sure to add a apc cache config
 'Cache' => [
-    'apc' => ['engine' => 'Apc']
+    'apc' => ['engine' => 'Apc'],
 ]
 ```
 

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -475,36 +475,36 @@ An example table would be:
 
 ``` php
 return [
-  'articles' => [
-     'columns' => [
-         'id' => [
-             'type' => 'integer',
-         ],
-         'author_id' => [
-             'type' => 'integer',
-             'null' => true,
-         ],
-         'title' => [
-             'type' => 'string',
-             'null' => true,
-         ],
-         'body' => 'text',
-         'published' => [
-             'type' => 'string',
-             'length' => 1,
-             'default' => 'N',
-         ],
-     ],
-     'constraints' => [
-         'primary' => [
-             'type' => 'primary',
-             'columns' => [
-                 'id',
-             ],
-         ],
-     ],
-  ],
-  // More tables
+    'articles' => [
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'author_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'body' => 'text',
+            'published' => [
+                'type' => 'string',
+                'length' => 1,
+                'default' => 'N',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    // More tables
 ];
 ```
 

--- a/docs/en/orm/behaviors/counter-cache.md
+++ b/docs/en/orm/behaviors/counter-cache.md
@@ -146,8 +146,8 @@ First, you need to add the `through` and `cascadeCallbacks` options to the
 `belongsToMany` association:
 
 ``` php
-'through'          => 'CommentsArticles',
-'cascadeCallbacks' => true
+'through' => 'CommentsArticles',
+'cascadeCallbacks' => true,
 ```
 
 Also see [Using The Through Option](../../orm/associations#using-the-through-option) how to configure a custom join table.

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -322,7 +322,7 @@ for both:
     ],
     'write' => [
         'host' => 'write-db.example.com',
-    ]
+    ],
 ];
 ```
 
@@ -1207,7 +1207,7 @@ datasource configuration:
 
         // Use the 'orm_metadata' cache config for metadata.
         'cacheMetadata' => 'orm_metadata',
-    ]
+    ],
 ],
 ```
 

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -462,7 +462,7 @@ because we don't have a Contact model defined yet.
 If your application includes the default routing CakePHP provides you will be
 able to access your plugin controllers using URLs like:
 
-``` php
+``` text
 // Access the index route of a plugin controller.
 /contact-manager/contacts
 


### PR DESCRIPTION
## Summary

Follow-up to #8189. Fixes PHP coding standards issues in code snippets that were re-tagged from `text` to `php`:

- Add missing trailing commas in multi-line arrays (7 files)
- Fix 2-space → 4-space indentation in schema array (`testing.md`)
- Add missing semicolon (`debugging.md`)
- Remove aligned `=>` operators (`counter-cache.md`)
- Revert two non-PHP blocks back to `text` (`routing.md`, `plugins.md`)