### PR TITLE
Fix code quality issues in documentation code snippets

### DIFF
--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -225,7 +225,7 @@ use Cake\Event\EventInterface;
 
 class ErrorController extends AppController
 {
-    protected function missingWidget(MissingWidgetException $exception)
+    protected function missingWidget(MissingWidgetException $exception): void
     {
         // You can prepare additional template context or trap errors.
     }
@@ -259,7 +259,7 @@ use Cake\Error\Renderer\WebExceptionRenderer;
 
 class AppExceptionRenderer extends WebExceptionRenderer
 {
-    public function missingWidget($error)
+    public function missingWidget(\Throwable $error): \Cake\Http\Response
     {
         $response = $this->controller->getResponse();
 

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -749,8 +749,7 @@ class WidgetsTable extends Table
 {
     public function initialize(array $config): void
     {
-        return parent::getSchema()->setColumnType('mutation', 'point_mutation');
-
+        parent::getSchema()->setColumnType('mutation', 'point_mutation');
     }
 }
 ```
@@ -844,11 +843,11 @@ namespace App\Database;
 // Our value object is immutable.
 class Point
 {
-    protected $_lat;
-    protected $_long;
+    protected float|int $_lat;
+    protected float|int $_long;
 
     // Factory method.
-    public static function parse($value)
+    public static function parse(mixed $value): static
     {
         // Parse the WKB data from MySQL.
         $unpacked = unpack('x4/corder/Ltype/dlat/dlong', $value);
@@ -856,18 +855,18 @@ class Point
         return new static($unpacked['lat'], $unpacked['long']);
     }
 
-    public function __construct($lat, $long)
+    public function __construct(float|int $lat, float|int $long)
     {
         $this->_lat = $lat;
         $this->_long = $long;
     }
 
-    public function lat()
+    public function lat(): float|int
     {
         return $this->_lat;
     }
 
-    public function long()
+    public function long(): float|int
     {
         return $this->_long;
     }
@@ -889,12 +888,12 @@ use Cake\Database\Type\ExpressionTypeInterface;
 
 class PointType extends BaseType implements ExpressionTypeInterface
 {
-    public function toPHP($value, Driver $d): mixed
+    public function toPHP(mixed $value, Driver $driver): mixed
     {
         return $value === null ? null : Point::parse($value);
     }
 
-    public function marshal($value): mixed
+    public function marshal(mixed $value): mixed
     {
         if (is_string($value)) {
             $value = explode(',', $value);
@@ -906,21 +905,22 @@ class PointType extends BaseType implements ExpressionTypeInterface
         return null;
     }
 
-    public function toExpression($value): ExpressionInterface
+    public function toExpression(mixed $value): ExpressionInterface
     {
         if ($value instanceof Point) {
             return new FunctionExpression(
                 'POINT',
                 [
                     $value->lat(),
-                    $value->long()
+                    $value->long(),
                 ]
             );
         }
         if (is_array($value)) {
             return new FunctionExpression('POINT', [$value[0], $value[1]]);
         }
-        // Handle other cases.
+
+        throw new \InvalidArgumentException('Cannot convert value to expression.');
     }
 
     public function toDatabase($value, Driver $driver): mixed

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -200,7 +200,7 @@ use Cake\ORM\Entity;
 
 class Article extends Entity
 {
-    protected function _getTitle($title)
+    protected function _getTitle(string $title): string
     {
         return strtoupper($title);
     }
@@ -244,7 +244,7 @@ use Cake\Utility\Text;
 
 class Article extends Entity
 {
-    protected function _setTitle($title)
+    protected function _setTitle(string $title): string
     {
         $this->slug = Text::slug($title);
 
@@ -283,7 +283,7 @@ use Cake\ORM\Entity;
 
 class User extends Entity
 {
-    protected function _getFullName()
+    protected function _getFullName(): string
     {
         return $this->first_name . '  ' . $this->last_name;
     }

--- a/docs/en/orm/validation.md
+++ b/docs/en/orm/validation.md
@@ -113,7 +113,7 @@ used. An example validator for our articles table would be:
 ``` php
 class ArticlesTable extends Table
 {
-    public function validationUpdate($validator)
+    public function validationUpdate(Validator $validator): Validator
     {
         $validator
             ->notEmptyString('title', __('You need to provide a title'))
@@ -682,7 +682,7 @@ In the above example, we'll use a 'custom' validator, which is defined using the
 `validationCustomName()` method:
 
 ``` php
-public function validationCustomName($validator)
+public function validationCustomName(Validator $validator): Validator
 {
     $validator->add(
         // ...
@@ -697,7 +697,7 @@ from any request:
 
 ``` php
 // In src/Model/Table/UsersTable.php
-public function validatePasswords($validator)
+public function validatePasswords(Validator $validator): Validator
 {
     $validator->add('confirm_password', 'no-misspelling', [
         'rule' => ['compareWith', 'password'],

--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -80,7 +80,7 @@ do the following:
 // src/Controller/ArticlesController.php:
 public function edit($id = null)
 {
-    if (empty($id)) {
+    if (!$id) {
         throw new NotFoundException;
     }
     $article = $this->Articles->get($id);


### PR DESCRIPTION
## Summary

Fixes code quality issues found during a 5.x documentation audit:

- **Critical**: Remove `return` from `void` method in `database-basics.md` (`initialize()` had `return parent::getSchema()->...`)
- **Type hints**: Add missing parameter and return type declarations to:
  - `Point` class (`__construct`, `parse`, `lat`, `long`)
  - `PointType` class (`toPHP`, `marshal`, `toExpression`) — also renamed `$d` to `$driver`
  - Validation methods (`validationUpdate`, `validationCustomName`, `validatePasswords`)
  - Entity accessors/mutators (`_getTitle`, `_setTitle`, `_getFullName`)
  - Error handler methods (`missingWidget` in both `ErrorController` and `AppExceptionRenderer`)
- **Missing return path**: Add exception throw for unhandled case in `toExpression()` (previously had only a `// Handle other cases.` comment with no code)
- **Code style**: Replace `empty($id)` with `!$id` for defined parameter in `form.md`

Files changed: `database-basics.md`, `validation.md`, `entities.md`, `errors.md`, `form.md`