### PR TITLE
Add redirect stubs for moved/removed pages

### DIFF
--- a/docs/en/console-and-shells.md
+++ b/docs/en/console-and-shells.md
@@ -1,0 +1,9 @@
+---
+title: Page Moved
+head:
+  - - meta
+    - http-equiv: refresh
+      content: "0;url=console-commands/"
+---
+
+This page has moved to [Console Commands](console-commands/).

--- a/docs/en/controllers/components/cookie.md
+++ b/docs/en/controllers/components/cookie.md
@@ -1,0 +1,10 @@
+---
+title: Page Moved
+head:
+  - - meta
+    - http-equiv: refresh
+      content: "0;url=../request-response.html#setting-cookies"
+---
+
+The Cookie component has been removed. Cookie handling is now done through
+[Request & Response Objects](../request-response.md#setting-cookies).


### PR DESCRIPTION
## Summary

- Add redirect stub pages for old URLs that currently return 404
- Uses `<meta http-equiv="refresh">` for instant client-side redirect with fallback links

### Redirects

| Old URL | Redirects To |
|---------|-------------|
| `console-and-shells.html` | `console-commands/` |
| `controllers/components/cookie.html` | `controllers/request-response.html#setting-cookies` |

### Context

These old URLs are still referenced from external sources (blog posts, Stack Overflow answers, cached IDE docs). The CakePHP source code `@link` annotations have already been updated in cakephp/cakephp#19221 to point to the correct pages directly.