### PR TITLE
Fix RST-to-Markdown conversion artifacts across English docs

### DIFF
--- a/docs/en/404.md
+++ b/docs/en/404.md
@@ -1,6 +1,3 @@
-orphan  
-True
-
 # Not Found
 
 The page you're looking for cannot be found. Try using the search bar to find

--- a/docs/en/appendices/5-0-migration-guide.md
+++ b/docs/en/appendices/5-0-migration-guide.md
@@ -46,7 +46,7 @@ changes made:
 
 ### Auth
 
-- <span class="title-ref">Auth</span> has been removed. Use the [cakephp/authentication](https://book.cakephp.org/authentication/3/en/index.html) and
+- `Auth` has been removed. Use the [cakephp/authentication](https://book.cakephp.org/authentication/3/en/index.html) and
   [cakephp/authorization](https://book.cakephp.org/authorization/3/en/index.html) plugins instead.
 
 ### Cache
@@ -166,7 +166,7 @@ changes made:
 
 ### I18n
 
-- `FrozenDate` was renamed to <span class="title-ref">Date</span> and `FrozenTime` was renamed to <span class="title-ref">DateTime</span>.
+- `FrozenDate` was renamed to `Date` and `FrozenTime` was renamed to `DateTime`.
 - `Time` now extends `Cake\Chronos\ChronosTime` and is therefore immutable.
 - `Date` objects do not extend `DateTimeInterface` anymore - therefore you can't compare them with `DateTime` objects.
   See the [cakephp/chronos release documentation](https://github.com/cakephp/chronos/releases/tag/3.0.2) for more information.

--- a/docs/en/appendices/5-3-migration-guide.md
+++ b/docs/en/appendices/5-3-migration-guide.md
@@ -119,7 +119,7 @@ If you are not running on **PHP 8.2 or higher**, you will need to upgrade PHP be
 ### Core
 
 - Added `Configure` attribute to support injecting `Configure` values into
-  constructor arguments. See ref:\`configure-dependency-injection\`.
+  constructor arguments. See [Configure Dependency Injection](../development/dependency-injection#configure-dependency-injection).
 
 ### Database
 

--- a/docs/en/appendices/glossary.md
+++ b/docs/en/appendices/glossary.md
@@ -54,7 +54,7 @@ A generic term used to describe both entity properties, or database
 columns. Often used in conjunction with the FormHelper.
 
 HTML attributes
-An array of key =\> values that are composed into HTML attributes. For example:
+An array of key => values that are composed into HTML attributes. For example:
 
 ``` php
 // Given

--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -143,7 +143,7 @@ Commands are provided a `ConsoleIo` instance when executed. This object allows
 you to interact with `Cake\Console\ConsoleIo::out()` and
 `Cake\Console\ConsoleIo::err()` to emit on `stdout`, and
 `stderr`. Files can be created with overwrite confirmation with
-`Cake\Console\ConsoleIo::createFile()`. [Command Helpers](../console-commands/command-helpers)
+`Cake\Console\ConsoleIo::createFile()`. [Command Helpers](../console-commands/input-output#command-helpers)
 provide 'macros' for output generation. See the
 [Command Input/Output](../console-commands/input-output) section for more information.
 

--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -143,7 +143,7 @@ Commands are provided a `ConsoleIo` instance when executed. This object allows
 you to interact with `Cake\Console\ConsoleIo::out()` and
 `Cake\Console\ConsoleIo::err()` to emit on `stdout`, and
 `stderr`. Files can be created with overwrite confirmation with
-`Cake\Console\ConsoleIo::createFile()`<span class="title-ref">. :ref:\`command-helpers</span>
+`Cake\Console\ConsoleIo::createFile()`. [Command Helpers](../console-commands/command-helpers)
 provide 'macros' for output generation. See the
 [Command Input/Output](../console-commands/input-output) section for more information.
 

--- a/docs/en/console-commands/cron-jobs.md
+++ b/docs/en/console-commands/cron-jobs.md
@@ -20,7 +20,7 @@ trivial to setup, for example:
 You can see more info here: <https://en.wikipedia.org/wiki/Cron>
 
 > [!TIP]
-> Use `-q` (or <span class="title-ref">--quiet</span>) to silence any output for cronjobs.
+> Use `-q` (or `--quiet`) to silence any output for cronjobs.
 
 ## Cron Jobs on Shared Hosting
 

--- a/docs/en/console-commands/option-parsers.md
+++ b/docs/en/console-commands/option-parsers.md
@@ -76,7 +76,7 @@ The `separator` option was added.
 `method` Cake\\Console\\ConsoleOptionParser::**addArguments**(array $args): static
 
 If you have an array with multiple arguments you can use
-`$parser->addArguments()` to add multiple arguments at once. :
+`$parser->addArguments()` to add multiple arguments at once.
 
 ``` php
 $parser->addArguments([
@@ -167,7 +167,7 @@ The `separator` option was added.
 `method` Cake\\Console\\ConsoleOptionParser::**addOptions**(array $options): static
 
 If you have an array with multiple options you can use `$parser->addOptions()`
-to add multiple options at once. :
+to add multiple options at once.
 
 ``` php
 $parser->addOptions([

--- a/docs/en/contents.md
+++ b/docs/en/contents.md
@@ -73,7 +73,3 @@
 
 - [Constants & Functions](core-libraries/global-constants-and-functions)
 - [Appendices](appendices)
-
-<div class="todolist">
-
-</div>

--- a/docs/en/contributing/cakephp-coding-conventions.md
+++ b/docs/en/contributing/cakephp-coding-conventions.md
@@ -325,8 +325,8 @@ public function foo($array)
 ### Anonymous Functions (Closures)
 
 Defining anonymous functions follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style guide, where they are
-declared with a space after the <span class="title-ref">function</span> keyword, and a space before and after
-the <span class="title-ref">use</span> keyword:
+declared with a space after the `function` keyword, and a space before and after
+the `use` keyword:
 
 ``` php
 $closure = function ($arg1, $arg2) use ($var1, $var2) {
@@ -507,7 +507,7 @@ The short echo tag (`<?=`) is always available regardless of the `short_open_tag
 
 Write all functions in camelBack:
 
-``` javascript
+``` php
 function longFunctionName()
 {
 }

--- a/docs/en/controllers/components.md
+++ b/docs/en/controllers/components.md
@@ -249,7 +249,7 @@ The above would pass the array containing precision and randomGenerator to
 ### Using Other Components in your Component
 
 Sometimes one of your components may need to use another component.
-You can load other components by adding them to the <span class="title-ref">\$components</span> property:
+You can load other components by adding them to the `$components` property:
 
 ``` php
 // src/Controller/Component/CustomComponent.php

--- a/docs/en/controllers/pagination.md
+++ b/docs/en/controllers/pagination.md
@@ -174,7 +174,7 @@ elements and URLs for pagination.
 ### Paginating the Same Model multiple Times
 
 To paginate the same model multiple times within a single controller action you
-need to define an alias for the model.:
+need to define an alias for the model.
 
 ``` php
 // In a controller action
@@ -387,7 +387,7 @@ public function index()
 
 ## Using a paginator class directly
 
-You can also use a paginator directly.:
+You can also use a paginator directly.
 
 ``` php
 // Create a paginator

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -5,12 +5,6 @@ responses. The request object in CakePHP allows you to introspect an incoming
 request, while the response object allows you to effortlessly create HTTP
 responses from your controllers.
 
-<div class="index">
-
-\$this-\>request
-
-</div>
-
 <a id="cake-request"></a>
 
 ## Request
@@ -474,8 +468,8 @@ There are several built-in detectors that you can use:
 - `is('ssl')` Check to see whether the request is via SSL.
 - `is('flash')` Check to see whether the request has a User-Agent of Flash.
 - `is('json')` Check to see whether the request URL has 'json' extension or the
-  <span class="title-ref">Accept</span> header is set to 'application/json'.
-- `is('xml')` Check to see whether the request URL has 'xml' extension or the <span class="title-ref">Accept</span> header is set to
+  `Accept` header is set to 'application/json'.
+- `is('xml')` Check to see whether the request URL has 'xml' extension or the `Accept` header is set to
   'application/xml' or 'text/xml'.
 
 `ServerRequest` also includes methods like
@@ -706,12 +700,6 @@ $query = $uri->getQuery();
 $host = $uri->getHost();
 ```
 
-<div class="index">
-
-\$this-\>response
-
-</div>
-
 ## Response
 
 `class` Cake\\Http\\**Response**
@@ -772,7 +760,7 @@ public function sendFile($id)
 
 As shown in the above example, you must pass the file path to the method.
 CakePHP will send a proper content type header if it's a known file type listed
-in <span class="title-ref">CakeHttpResponse::\$\_mimeTypes</span>. You can add new types prior to calling
+in `Cake\Http\Response::$_mimeTypes`. You can add new types prior to calling
 `Cake\Http\Response::withFile()` by using the
 `Cake\Http\Response::withType()` method.
 
@@ -1118,7 +1106,7 @@ $response = $this->response->withVary('Accept-Language');
 
 Compares the cache headers for the request object with the cache header from the
 response and determines whether it can still be considered fresh. If so, deletes
-the response content, and sends the <span class="title-ref">304 Not Modified</span> header:
+the response content, and sends the `304 Not Modified` header:
 
 ``` php
 // In a controller action.

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -535,7 +535,7 @@ $mailer->setTransport(new \Cake\Mailer\Transport\DebugTransport());
 Configuration options can also be provided as a `DSN` string. This is
 useful when working with environment variables or `PaaS` providers:
 
-``` css
+``` php
 TransportFactory::setConfig('default', [
     'url' => 'smtp://my@gmail.com:secret@smtp.gmail.com:587?tls=true',
 ]);

--- a/docs/en/core-libraries/events.md
+++ b/docs/en/core-libraries/events.md
@@ -381,7 +381,7 @@ You can use this same approach to bind listener objects.
 ### Interacting with Existing Listeners
 
 Assuming several event listeners have been registered the presence or absence
-of a particular event pattern can be used as the basis of some action.:
+of a particular event pattern can be used as the basis of some action.
 
 ``` php
 // Attach listeners to EventManager.
@@ -469,8 +469,8 @@ $this->getEventManager()
 The listeners of the `View.afterRender` callback should have the following
 signature:
 
-``` javascript
-function (EventInterface $event, $viewFileName)
+``` php
+function (EventInterface $event, string $fileName)
 ```
 
 Each value provided to the Event constructor will be converted into function

--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -64,7 +64,7 @@ a matching path is not found the default value will be returned.
 [Hash Path Syntax](#hash-path-syntax). You can use extract to retrieve data from arrays
 or object implementing `ArrayAccess` interface, along arbitrary paths
 quickly without having to loop through the data structures. Instead you
-use path expressions to qualify which elements you want returned :
+use path expressions to qualify which elements you want returned:
 
 ``` php
 // Common Usage:
@@ -777,8 +777,7 @@ $result = Hash::diff($a, $b);
 This function merges two arrays and pushes the differences in
 data to the bottom of the resultant array.
 
-**Example 1**
-:
+**Example 1:**
 
 ``` php
 $array1 = ['ModelOne' => ['id' => 1001, 'field_one' => 'a1.m1.f1', 'field_two' => 'a1.m1.f2']];
@@ -797,8 +796,7 @@ $res = Hash::mergeDiff($array1, $array2);
 */
 ```
 
-**Example 2**
-:
+**Example 2:**
 
 ``` php
 $array1 = ["a" => "b", 1 => 20938, "c" => "string"];

--- a/docs/en/core-libraries/internationalization-and-localization.md
+++ b/docs/en/core-libraries/internationalization-and-localization.md
@@ -107,7 +107,7 @@ msgstr "J'ai {0,number} ans"
 
 ### Extract Pot Files with I18n Shell
 
-To create the pot files from <span class="title-ref">\_\_()</span> and other internationalized types of
+To create the pot files from `__()` and other internationalized types of
 messages that can be found in the application code, you can use the i18n command.
 Please read the [following chapter](../console-commands/i18n) to
 learn more.
@@ -368,7 +368,7 @@ use the ICU matching aliases. Instead of writing:
 
 You can do:
 
-``` css
+``` text
 zero{No Results} one{One result} few{...} many{...} other{...}
 ```
 

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -336,7 +336,7 @@ Log::setConfig('otherFile', [
 
 When configuring a log engine the `className` parameter is used to
 locate and load the log handler. All of the other configuration
-properties are passed to the log engine's constructor as an array. :
+properties are passed to the log engine's constructor as an array.
 
 ``` php
 namespace App\Log\Engine;
@@ -493,12 +493,12 @@ Write a message into all the configured loggers.
 
 `static` Cake\\Log\\Log::**levels**(): array
 
-Call this method without arguments, eg: <span class="title-ref">Log::levels()</span> to obtain current
+Call this method without arguments, eg: `Log::levels()` to obtain current
 level configuration.
 
 ### Convenience Methods
 
-The following convenience methods were added to log <span class="title-ref">\$message</span> with the
+The following convenience methods were added to log `$message` with the
 appropriate log level.
 
 #### Log::emergency()

--- a/docs/en/core-libraries/number.md
+++ b/docs/en/core-libraries/number.md
@@ -116,7 +116,7 @@ retrieve the `intl.default_locale` ini value if set and `'en_US'` if not.
 
 This method displays a number with the specified amount of
 precision (decimal places). It will round in order to maintain the
-level of precision defined. :
+level of precision defined.
 
 ``` php
 // Called as NumberHelper
@@ -142,7 +142,7 @@ echo Number::precision(456.91873645, 2);
 Like `Cake\I18n\Number::precision()`, this method formats a number
 according to the supplied precision (where numbers are rounded to meet the
 given precision). This method also expresses the number as a percentage
-and appends the output with a percent sign. :
+and appends the output with a percent sign.
 
 ``` php
 // Called as NumberHelper. Output: 45.69%

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -101,7 +101,7 @@ options are:
 
 The UUID method is used to generate unique identifiers as per `4122`. The
 UUID is a 128-bit string in the format of
-`485fc381-e790-47a3-9794-1337c0a8fe68`. :
+`485fc381-e790-47a3-9794-1337c0a8fe68`.
 
 ``` php
 Text::uuid(); // 485fc381-e790-47a3-9794-1337c0a8fe68
@@ -407,7 +407,7 @@ Output:
 Extracts an excerpt from `$text` surrounding the `$phrase` with a number
 of characters on each side determined by `$radius`, and prefix/suffix with
 `$ellipsis`. This method is especially handy for search results. The query
-string or keywords can be shown within the resulting document. :
+string or keywords can be shown within the resulting document.
 
 ``` php
 // Called as TextHelper

--- a/docs/en/core-libraries/validation.md
+++ b/docs/en/core-libraries/validation.md
@@ -564,7 +564,7 @@ $validator
     ->notEmptyString('comment', 'You need to give a comment.');
 
 $errors = $validator->validate($this->request->getData());
-if (empty($errors)) {
+if (!$errors) {
     // Send an email.
 }
 ```

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -6,18 +6,6 @@ to configure a few things like your database credentials.
 Additionally, there are optional configuration options that allow you to swap
 out default values & implementations with ones tailored to your application.
 
-<div class="index">
-
-app.php, app_local.example.php
-
-</div>
-
-<div class="index">
-
-configuration
-
-</div>
-
 ## Configuring your Application
 
 Configuration is generally stored in either PHP or INI files, and loaded during
@@ -120,7 +108,7 @@ files too.
 App.base
 The base directory the app resides in. If `false` this
 will be auto detected. If not `false`, ensure your string starts
-with a <span class="title-ref">/</span> and does NOT end with a <span class="title-ref">/</span>. For example, <span class="title-ref">/basedir</span> is a valid
+with a `/` and does NOT end with a `/`. For example, `/basedir` is a valid
 App.base.
 
 App.encoding
@@ -140,7 +128,7 @@ root. This is used when generating absolute URLs. By default this value
 is generated using the `$_SERVER` environment. However, you should define it
 manually to optimize performance or if you are concerned about people
 manipulating the `Host` header.
-In a CLI context (from command) the <span class="title-ref">fullBaseUrl</span> cannot be read from \$\_SERVER,
+In a CLI context (from command) the `fullBaseUrl` cannot be read from $_SERVER,
 as there is no webserver involved. You do need to specify it yourself if
 you do need to generate URLs from a shell (for example, when sending emails).
 
@@ -497,7 +485,7 @@ the existing runtime configuration. By setting `$merge` to `true`, values
 will not ever overwrite the existing configuration.
 
 > [!WARNING]
-> When merging configuration files with <span class="title-ref">\$merge = true</span>, dot notation in keys is
+> When merging configuration files with `$merge = true`, dot notation in keys is
 > not expanded:
 >
 > ``` php

--- a/docs/en/development/debugging.md
+++ b/docs/en/development/debugging.md
@@ -106,7 +106,7 @@ When dumping data with `Debugger` or rendering error pages, you may want to
 hide sensitive keys like passwords or API keys. In your **config/bootstrap.php**
 you can mask specific keys:
 
-``` css
+``` php
 Debugger::setOutputMask([
     'password' => 'xxxxx',
     'awsKey' => 'yyyyy',
@@ -155,7 +155,7 @@ the order of currently running functions (stack frames).
 
 Grab an excerpt from the file at \$path (which is an absolute
 filepath), highlights line number \$line with \$context number of
-lines around it. :
+lines around it.
 
 ``` php
 pr(Debugger::excerpt(ROOT . DS . LIBS . 'debugger.php', 321, 2));

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -328,12 +328,6 @@ $middlewareQueue->add(new ErrorHandlerMiddleware(
 // ...
 ```
 
-<div class="index">
-
-application exceptions
-
-</div>
-
 ## Creating your own Application Exceptions
 
 You can create your own application exceptions using any of the built in [SPL
@@ -455,7 +449,7 @@ use Cake\Http\Exception\NotFoundException;
 public function view($id = null)
 {
     $article = $this->Articles->findById($id)->first();
-    if (empty($article)) {
+    if (!$article) {
         throw new NotFoundException(__('Article not found'));
     }
     $this->set('article', $article);
@@ -477,7 +471,7 @@ use Cake\Network\Exception\NotFoundException;
 public function view($id = null)
 {
     $article = $this->Articles->findById($id)->first();
-    if (empty($article)) {
+    if (!$article) {
         throw new NotFoundException(__('Article not found'));
     }
     $this->set('article', 'article');

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -11,12 +11,6 @@ of parameters can be transformed into a URL string. By using reverse routing,
 you can re-factor your application's URL structure without having to update all
 your code.
 
-<div class="index">
-
-routes.php
-
-</div>
-
 ## Quick Tour
 
 This section will teach you by example the most common uses of the CakePHP
@@ -112,18 +106,6 @@ The above route would match `/blog/` and send it to
 
 The application skeleton comes with a few routes to get you started. Once you've
 added your own routes, you can remove the default routes if you don't need them.
-
-<div class="index">
-
-{controller}, {action}, {plugin}
-
-</div>
-
-<div class="index">
-
-greedy star, trailing star
-
-</div>
 
 <a id="routes-configuration"></a>
 
@@ -436,7 +418,7 @@ CakePHP, and should not be used unless you want the special meaning
 - `_base` Set to `false` to remove the base path from the generated URL. If
   your application is not in the root directory, this can be used to generate
   URLs that are 'cake relative'.
-- `_scheme` Set to create links on different schemes like <span class="title-ref">webcal</span> or <span class="title-ref">ftp</span>.
+- `_scheme` Set to create links on different schemes like `webcal` or `ftp`.
   Defaults to the current scheme.
 - `_host` Set the host to use for the link. Defaults to the current host.
 - `_port` Set the port if you need to create links on non-standard ports.
@@ -697,12 +679,6 @@ Router::url(['_name' => 'contacts:api:ping']);
 Routes connected in named scopes will only have names added if the route is also
 named. Nameless routes will not have the `_namePrefix` applied to them.
 
-<div class="index">
-
-admin routing, prefix routing
-
-</div>
-
 <a id="prefix-routing"></a>
 
 ### Prefix Routing
@@ -819,12 +795,6 @@ echo $this->Html->link(
     ['prefix' => false, 'controller' => 'Articles', 'action' => 'view', 5],
 );
 ```
-
-<div class="index">
-
-plugin routing
-
-</div>
 
 ### Creating Links to Prefix Routes
 
@@ -1014,12 +984,6 @@ echo Router::url([
     '_host' => 'images.example.com',
 ]);
 ```
-
-<div class="index">
-
-file extensions
-
-</div>
 
 <a id="file-extensions"></a>
 
@@ -1306,7 +1270,7 @@ $routes->resources('Articles', [
 ```
 
 In addition to the default routes, this would also connect a route for
-<span class="title-ref">/articles/delete-all</span>. By default the path segment will match the key name. You
+`/articles/delete-all`. By default the path segment will match the key name. You
 can use the 'path' key inside the resource definition to customize the path
 name:
 
@@ -1383,19 +1347,13 @@ $routes->scope('/', function (RouteBuilder $routes) {
 });
 ```
 
-<div class="index">
-
-passed arguments
-
-</div>
-
 <a id="passed-arguments"></a>
 
 ## Passed Arguments
 
 Passed arguments are additional arguments or path segments that are
 used when making a request. They are often used to pass parameters
-to your controller methods. :
+to your controller methods.
 
     http://localhost/calendars/view/recent/mark
 

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -2042,7 +2042,7 @@ would be:
 ## Creating Tests for Plugins
 
 Tests for plugins are created in their own directory inside the plugins
-folder. :
+folder.
 
     /src
     /plugins

--- a/docs/en/epub-contents.md
+++ b/docs/en/epub-contents.md
@@ -1,5 +1,3 @@
-orphan  
-
 # Contents
 
 - [CakePHP at a Glance](intro)
@@ -48,7 +46,3 @@ orphan
 - [Migrations](migrations)
 - [ElasticSearch](elasticsearch)
 - [Appendices](appendices)
-
-<div class="todolist">
-
-</div>

--- a/docs/en/orm/associations.md
+++ b/docs/en/orm/associations.md
@@ -767,7 +767,7 @@ This enables property chains to related tables in the following way:
 $this->MyTableOne->MyTableTwo->find()->...;
 ```
 
-Association properties on entities do not use CamelCase conventions though. Instead for a hasOne/belongsTo relation like "User belongsTo Roles", you would get a <span class="title-ref">role</span> property instead of <span class="title-ref">Role</span> or \`Roles\`:
+Association properties on entities do not use CamelCase conventions though. Instead for a hasOne/belongsTo relation like "User belongsTo Roles", you would get a `role` property instead of `Role` or `Roles`:
 
 ``` php
 // A single entity (or null if not available)

--- a/docs/en/orm/behaviors/counter-cache.md
+++ b/docs/en/orm/behaviors/counter-cache.md
@@ -156,7 +156,7 @@ The `CommentsArticles` is the name of the junction table classname.
 If you don't have it you should create it with the bake CLI tool.
 
 In this `src/Model/Table/CommentsArticlesTable.php` you then need to add the behavior
-with the same code as described above.:
+with the same code as described above.
 
 ``` php
 $this->addBehavior('CounterCache', [
@@ -172,7 +172,7 @@ Finally clear all caches with `bin/cake cache clear_all` and try it out.
 
 The `updateCounterCache()` method allows you to update the counter cache values
 for all records of one or all configured associations in batches. This can be useful,
-for example, to update the counter cache after importing data directly into the database.:
+for example, to update the counter cache after importing data directly into the database.
 
 ``` php
 // Update the counter cache for all configured associations

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -170,7 +170,7 @@ ConnectionManager::setConfig('default', [
 Configuration options can also be provided as a `DSN` string. This is
 useful when working with environment variables or `PaaS` providers:
 
-``` css
+``` php
 ConnectionManager::setConfig('default', [
     'url' => 'mysql://my_app:sekret@localhost/my_app?encoding=utf8&timezone=UTC&cacheMetadata=true',
 ]);
@@ -434,9 +434,9 @@ as some might expect). This is because decimal types are used to represent
 exact numeric values in databases and using float type for them in PHP can
 potentially lead to precision loss.
 
-If you want the values to be <span class="title-ref">float</span> in your PHP code then consider using
-<span class="title-ref">FLOAT</span> or <span class="title-ref">DOUBLE</span> type columns in your database. Also, depending on your use
-case you can explicitly map your decimal columns to <span class="title-ref">float</span> type in your table
+If you want the values to be `float` in your PHP code then consider using
+`FLOAT` or `DOUBLE` type columns in your database. Also, depending on your use
+case you can explicitly map your decimal columns to `float` type in your table
 schema.
 
 boolean

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -219,7 +219,7 @@ echo $article->get('title'); // returns FOO instead of foo
 > [!NOTE]
 > Code in your accessors is executed each time you reference the field. You can
 > use a local variable to cache it if you are performing a resource-intensive
-> operation in your accessor like this: <span class="title-ref">\$myEntityProp = \$entity-\>my_property</span>.
+> operation in your accessor like this: `$myEntityProp = $entity->my_property`.
 
 > [!WARNING]
 > Accessors will be used when saving entities, so be careful when defining methods
@@ -317,7 +317,7 @@ $article->isDirty('title');
 
 You can also flag fields as being modified. This is handy when appending into
 array fields as this wouldn't automatically mark the field as dirty, only
-exchanging completely would.:
+exchanging completely would.
 
 ``` php
 // Add a comment and mark the field as changed.

--- a/docs/en/orm/query-builder.md
+++ b/docs/en/orm/query-builder.md
@@ -343,31 +343,31 @@ You can access existing wrappers for several SQL functions through `SelectQuery:
 Generate a random value between 0 and 1 via SQL.
 
 `sum()`
-Calculate a sum. <span class="title-ref">Assumes arguments are literal values.</span>
+Calculate a sum. `Assumes arguments are literal values.`
 
 `avg()`
-Calculate an average. <span class="title-ref">Assumes arguments are literal values.</span>
+Calculate an average. `Assumes arguments are literal values.`
 
 `min()`
-Calculate the min of a column. <span class="title-ref">Assumes arguments are literal values.</span>
+Calculate the min of a column. `Assumes arguments are literal values.`
 
 `max()`
-Calculate the max of a column. <span class="title-ref">Assumes arguments are literal values.</span>
+Calculate the max of a column. `Assumes arguments are literal values.`
 
 `count()`
-Calculate the count. <span class="title-ref">Assumes arguments are literal values.</span>
+Calculate the count. `Assumes arguments are literal values.`
 
 `cast()`
 Convert a field or expression from one data type to another.
 
 `concat()`
-Concatenate two values together. <span class="title-ref">Assumes arguments are bound parameters.</span>
+Concatenate two values together. `Assumes arguments are bound parameters.`
 
 `coalesce()`
-Coalesce values. <span class="title-ref">Assumes arguments are bound parameters.</span>
+Coalesce values. `Assumes arguments are bound parameters.`
 
 `dateDiff()`
-Get the difference between two dates/times. <span class="title-ref">Assumes arguments are bound parameters.</span>
+Get the difference between two dates/times. `Assumes arguments are bound parameters.`
 
 `now()`
 Defaults to returning date and time, but accepts 'time' or 'date' to return only

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -302,7 +302,7 @@ virtual fields in the results of `find(list)`.
 ### Customize Key-Value Output
 
 Lastly it is possible to use closures to access entity accessor methods in your
-list finds. :
+list finds.
 
 ``` php
 // In your Authors Entity create a virtual field to be used as the displayField:
@@ -314,7 +314,7 @@ protected function _getLabel()
 ```
 
 This example shows using the `_getLabel()` accessor method from
-the Author entity. :
+the Author entity.
 
 ``` php
 // In your finders/controller:
@@ -327,7 +327,7 @@ $query = $articles->find('list',
     ->contain('Authors');
 ```
 
-You can also fetch the label in the list directly using. :
+You can also fetch the label in the list directly using.
 
 ``` php
 // In AuthorsTable::initialize():
@@ -1108,7 +1108,7 @@ $row = $result->skip(4)->first();
 ### Checking if a ResultSet is Empty
 
 You can use the `isEmpty()` method on a ResultSet object to see if it
-has any rows in it.:
+has any rows in it.
 
 ``` php
 // Check results

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -33,7 +33,7 @@ if ($articlesTable->save($article)) {
 
 ### Updating Data
 
-Updating your data is achieved by using the `save()` method :
+Updating your data is achieved by using the `save()` method:
 
 ``` php
 use Cake\ORM\Locator\LocatorAwareTrait;

--- a/docs/en/orm/schema-system.md
+++ b/docs/en/orm/schema-system.md
@@ -60,8 +60,8 @@ the existing features available in Schema files + the fixture schema in 2.x.
 
 ### Accessing Column Data
 
-Columns are either added as constructor arguments, or via <span class="title-ref">addColumn()</span>. Once
-fields are added information can be fetched using <span class="title-ref">column()</span> or \`columns()\`:
+Columns are either added as constructor arguments, or via `addColumn()`. Once
+fields are added information can be fetched using `column()` or `columns()`:
 
 ``` php
 // Get the array of data about a column

--- a/docs/en/pdf-contents.md
+++ b/docs/en/pdf-contents.md
@@ -1,5 +1,3 @@
-orphan  
-
 # Contents
 
 - [CakePHP at a Glance](intro)

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -253,7 +253,7 @@ basic directory structure. It should look like this:
                 /Fixture
             /webroot
 
-Note the name of the plugin folder, '\*\*ContactManager\*\*'. It is important
+Note the name of the plugin folder, '**ContactManager**'. It is important
 that this folder has the same name as the plugin.
 
 Inside the plugin folder, you'll notice it looks a lot like a CakePHP
@@ -773,15 +773,9 @@ Do **not** use the CakePHP namespace (cakephp) as this is reserved to CakePHP
 owned plugins. The convention is to use lowercase letters and dashes as separator.
 
 So if you created a plugin "Logging" with your GitHub account "FooBar", a good
-name would be <span class="title-ref">foo-bar/cakephp-logging</span>.
-And the CakePHP owned "Localized" plugin can be found under <span class="title-ref">cakephp/localized</span>
+name would be `foo-bar/cakephp-logging`.
+And the CakePHP owned "Localized" plugin can be found under `cakephp/localized`
 respectively.
-
-<div class="index">
-
-vendor/cakephp-plugins.php
-
-</div>
 
 ## Plugin Map File
 

--- a/docs/en/security/csrf.md
+++ b/docs/en/security/csrf.md
@@ -18,7 +18,7 @@ CakePHP offers two forms of CSRF protection:
 > [!NOTE]
 > You cannot use both of the following approaches together, you must choose
 > only one. If you use both approaches together, a CSRF token mismatch error
-> will occur on every <span class="title-ref">PUT</span> and <span class="title-ref">POST</span> request
+> will occur on every `PUT` and `POST` request
 
 <a id="csrf-middleware"></a>
 
@@ -95,7 +95,7 @@ The available configuration options are:
 
 The available configuration options are:
 
-- `key` The session key to use. Defaults to <span class="title-ref">csrfToken</span>
+- `key` The session key to use. Defaults to `csrfToken`
 - `field` The form field to check. Changing this will also require configuring
   FormHelper.
 

--- a/docs/en/security/https-enforcer.md
+++ b/docs/en/security/https-enforcer.md
@@ -24,7 +24,7 @@ $https = new HttpsEnforcerMiddleware([
     'headers' => ['X-Https-Upgrade' => 1],
 ]);
 
-// Disable HTTPs enforcement when ``debug`` is on.
+// Disable HTTPs enforcement when `debug` is on.
 $https = new HttpsEnforcerMiddleware([
     'disableOnDebug' => true,
 ]);

--- a/docs/en/tutorials-and-examples/cms/authentication.md
+++ b/docs/en/tutorials-and-examples/cms/authentication.md
@@ -94,7 +94,7 @@ The Plugin will handle the authentication process using 3 different classes:
   this is before your Controllers are processed by the framework, and will pick the
   credentials and process them to check if the user is authenticated.
 
-If you remember, we used <span class="title-ref">AuthComponent</span>
+If you remember, we used `AuthComponent`
 before to handle all these steps. Now the logic is divided into specific classes and
 the authentication process happens before your controller layer. First it checks if the user
 is authenticated (based on the configuration you provided) and injects the user and

--- a/docs/en/tutorials-and-examples/cms/tags-and-users.md
+++ b/docs/en/tutorials-and-examples/cms/tags-and-users.md
@@ -260,7 +260,7 @@ public function findTagged(SelectQuery $query, array $tags = []): SelectQuery
         ->select($columns)
         ->distinct($columns);
 
-    if (empty($tags)) {
+    if (!$tags) {
         // If there are no tags provided, find articles that have no tags.
         $query->leftJoinWith('Tags')
             ->where(['Tags.title IS' => null]);
@@ -357,7 +357,7 @@ protected function _getTagString()
     if (isset($this->_fields['tag_string'])) {
         return $this->_fields['tag_string'];
     }
-    if (empty($this->tags)) {
+    if (!$this->tags) {
         return '';
     }
     $tags = new Collection($this->tags);

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -308,7 +308,7 @@ $this->append('sidebar', $this->element('sidebar/popular_topics'));
 If you need to clear or overwrite a block there are a couple of alternatives.
 The `reset()` method will clear or overwrite a block at any time. The
 `assign()` method with an empty content string can also be used to clear the
-specified block.:
+specified block.
 
 ``` php
 // Clear the previous content from the sidebar block.

--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -1127,14 +1127,14 @@ methods are described in each method's own section.)
 It's possible to use the Collection class to build your options array. This approach is ideal if you already have a
 collection of entities and would like to build a select element from them.
 
-You can use the `combine` method to build a basic options array.:
+You can use the `combine` method to build a basic options array.
 
 ``` php
 $options = $examples->combine('id', 'name');
 ```
 
 It's also possible to add extra attributes by expanding the array. The following will create a data attribute on the
-option element, using the `map` collection method.:
+option element, using the `map` collection method.
 
 ``` php
 $options = $examples->map(function ($value, $key) {
@@ -1713,7 +1713,7 @@ $fileobject->moveTo($destination);
 
 This method will generate an input tag with type "datetime-local".
 
-For example :
+For example:
 
 ``` php
 <?= $this->form->dateTime('registered') ?>
@@ -1727,7 +1727,7 @@ Output:
 
 The value for the input can be any valid datetime string or `DateTime` instance.
 
-For example :
+For example:
 
 ``` php
 <?= $this->form->dateTime('registered', ['value' => new DateTime()]) ?>
@@ -1750,7 +1750,7 @@ Output:
 
 This method will generate an input tag with type "date".
 
-For example :
+For example:
 
 ``` php
 <?= $this->form->date('registered') ?>
@@ -1773,7 +1773,7 @@ Output:
 
 This method will generate an input tag with type "time".
 
-For example :
+For example:
 
 ``` php
 echo $this->Form->time('released');
@@ -1910,7 +1910,7 @@ field errors and when necessary display customized error messages.
 
 - `$fieldName` - A field name in the form `'Modelname.fieldname'`.
 - `$text` - Optional. A string or array providing the error message(s). If an
-  array, then it should be a hash of key names =\> messages. Defaults to
+  array, then it should be a hash of key names => messages. Defaults to
   `null`.
 - `$options` - An optional array that can only contain a boolean with the key
   `'escape'`, which will define whether to HTML escape the

--- a/docs/en/views/helpers/html.md
+++ b/docs/en/views/helpers/html.md
@@ -43,7 +43,7 @@ Will output:
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 ```
 
-Alternatively, :
+Alternatively:
 
 ``` php
 echo $this->Html->charset('ISO-8859-1');
@@ -69,7 +69,7 @@ will be appended to. By default it will append to the `css` block.
 If key 'rel' in `$options` array is set to 'import' the stylesheet will be imported.
 
 This method of CSS inclusion assumes that the CSS file specified
-resides inside the **webroot/css** directory if path doesn't start with a '/'. :
+resides inside the **webroot/css** directory if path doesn't start with a '/'.
 
 ``` php
 echo $this->Html->css('forms');
@@ -81,7 +81,7 @@ Will output:
 <link rel="stylesheet" href="/css/forms.css" />
 ```
 
-The first parameter can be an array to include multiple files. :
+The first parameter can be an array to include multiple files.
 
 ``` php
 echo $this->Html->css(['forms', 'tables', 'menu']);
@@ -117,7 +117,7 @@ echo $this->Html->css('Blog.common.css', ['plugin' => false]);
 
 Builds CSS style definitions based on the keys and values of the
 array passed to the method. Especially handy if your CSS file is
-dynamic. :
+dynamic.
 
 ``` php
 echo $this->Html->style([
@@ -235,7 +235,7 @@ The `csrfToken` type was added.
 `method` Cake\\View\\Helper\\HtmlHelper::**image**(string $path, array $options = []): string
 
 Creates a formatted image tag. The path supplied should be relative
-to **webroot/img/**. :
+to **webroot/img/**.
 
 ``` php
 echo $this->Html->image('cake_logo.png', ['alt' => 'CakePHP']);
@@ -248,7 +248,7 @@ Will output:
 ```
 
 To create an image link specify the link destination using the
-`url` option in `$attributes`. :
+`url` option in `$attributes`.
 
 ``` php
 echo $this->Html->image("recipes/6.jpg", [
@@ -294,7 +294,7 @@ and also wanted to include **webroot/img/Blog.icon.png**, you would:
 echo $this->Html->image('Blog.icon.png', ['plugin' => false]);
 ```
 
-If you would like the prefix of the URL to not be `/img`, you can override this setting by specifying the prefix in the `$options` array :
+If you would like the prefix of the URL to not be `/img`, you can override this setting by specifying the prefix in the `$options` array:
 
 ``` php
 echo $this->Html->image("logo.png", ['pathPrefix' => '']);
@@ -312,7 +312,7 @@ Will output:
 
 General purpose method for creating HTML links. Use `$options` to
 specify attributes for the element and whether or not the
-`$title` should be escaped. :
+`$title` should be escaped.
 
 ``` php
 echo $this->Html->link(
@@ -365,7 +365,7 @@ Will output:
 </a>
 ```
 
-Query strings can also be created with `link()`. :
+Query strings can also be created with `link()`.
 
 ``` php
 echo $this->Html->link('View image', [
@@ -384,7 +384,7 @@ Will output:
 
 HTML special characters in `$title` will be converted to HTML
 entities. To disable this conversion, set the escape option to
-`false` in the `$options` array. :
+`false` in the `$options` array.
 
 ``` php
 echo $this->Html->link(
@@ -404,7 +404,7 @@ Will output:
 
 Setting `escape` to `false` will also disable escaping of attributes of the
 link. You can use the option `escapeTitle` to disable just
-escaping of title and not the attributes. :
+escaping of title and not the attributes.
 
 ``` php
 echo $this->Html->link(
@@ -536,7 +536,7 @@ Will output:
 <script src="https://code.jquery.com/jquery.min.js"></script>
 ```
 
-The first parameter can be an array to include multiple files. :
+The first parameter can be an array to include multiple files.
 
 ``` php
 echo $this->Html->script(['jquery', 'wysiwyg', 'scripts']);
@@ -643,7 +643,7 @@ Support for `script` tags inside `scriptStart()`/`scriptEnd()` was added.
 
 `method` Cake\\View\\Helper\\HtmlHelper::**importmap(array $map, array $options = []): string**()
 
-Creates an <span class="title-ref">importmap</span> script tag for your JavaScript files:
+Creates an `importmap` script tag for your JavaScript files:
 
 ``` php
 // In the head tag of your layout
@@ -749,7 +749,7 @@ Output:
 `method` Cake\\View\\Helper\\HtmlHelper::**tableHeaders**(array $names, array $trOptions = null, array $thOptions = null): string
 
 Creates a row of table header cells to be placed inside of \<table\>
-tags. :
+tags.
 
 ``` php
 echo $this->Html->tableHeaders(['Date', 'Title', 'Active']);
@@ -810,7 +810,7 @@ Output:
 
 Creates table cells, in rows, assigning \<tr\> attributes differently
 for odd- and even-numbered rows. Wrap a single table cell within an
-\[\] for specific \<td\>-attributes. :
+\[\] for specific \<td\>-attributes.
 
 ``` php
 echo $this->Html->tableCells([

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -225,11 +225,11 @@ Supported options are:
 - `last` Whether you want last links generated, set to an integer to define
   the number of 'last' links to generate. Defaults to `false`. Follows the same
   logic as the `first` option. There is a
-  `~PaginatorHelper::last()` method to be used separately as well if
+  `PaginatorHelper::last()` method to be used separately as well if
   you wish.
 
 While this method allows a lot of customization for its output. It is
-also ok to just call the method without any parameters. :
+also ok to just call the method without any parameters.
 
 ``` php
 echo $this->Paginator->numbers();
@@ -343,7 +343,7 @@ echo $this->Paginator->counter('range');
 `method` Cake\\View\\Helper\\PaginatorHelper::**generateUrl**(array $options = [], ?string $model = null, array $url = [], array $urlOptions = []): string
 
 By default returns a full pagination URL string for use in non-standard contexts
-(i.e. JavaScript). :
+(i.e. JavaScript).
 
 ``` php
 // Generates a URL similar to: /articles?sort=title&page=2

--- a/docs/en/views/helpers/text.md
+++ b/docs/en/views/helpers/text.md
@@ -14,7 +14,7 @@ truncating long stretches of text.
 
 Adds links to the well-formed email addresses in \$text, according
 to any options defined in `$options` (see
-`HtmlHelper::link()`). :
+`HtmlHelper::link()`).
 
 ``` php
 $myText = 'For more information regarding our world-famous ' .
@@ -67,7 +67,7 @@ Further options:
 `method` Cake\\View\\Helper\\TextHelper::**autoParagraph**(string $text): string
 
 Adds proper \<p\> around text where double-line returns are found, and \<br\> where
-single-line returns are found. :
+single-line returns are found.
 
 ``` php
 $myText = 'For more information


### PR DESCRIPTION
## Summary

Fixes ~100 RST-to-Markdown conversion artifacts across 45 English documentation files:

- Replace all `<span class="title-ref">` artifacts with backtick inline code (19 files)
- Remove trailing ` :` and `.:` RST directive colons (~40 instances across 19 files)
- Remove `orphan`/`True` RST metadata from `404.md`, `epub-contents.md`, `pdf-contents.md`
- Remove leftover `<div class="index">` and `<div class="todolist">` blocks (14 blocks across 7 files)
- Fix wrong code block language tags — `css`/`javascript` used for PHP code (5 files)
- Fix escaped RST syntax (`\*\*`, `=\>`, `\$`, double backticks)
- Fix broken `:ref:` link in `5-3-migration-guide.md`
- Fix broken RST cross-reference in `console-commands/commands.md`