### PR TITLE
Fix typos, grammar errors, and broken link across docs

### DIFF
--- a/docs/en/appendices/5-1-migration-guide.md
+++ b/docs/en/appendices/5-1-migration-guide.md
@@ -1,6 +1,6 @@
 # 5.1 Migration Guide
 
-The 5.1.0 release is a backwards compatible with 5.0. It adds new functionality
+The 5.1.0 release is backwards compatible with 5.0. It adds new functionality
 and introduces new deprecations. Any functionality deprecated in 5.x will be
 removed in 6.0.0.
 

--- a/docs/en/appendices/5-2-migration-guide.md
+++ b/docs/en/appendices/5-2-migration-guide.md
@@ -1,6 +1,6 @@
 # 5.2 Migration Guide
 
-The 5.2.0 release is a backwards compatible with 5.0. It adds new functionality
+The 5.2.0 release is backwards compatible with 5.0. It adds new functionality
 and introduces new deprecations. Any functionality deprecated in 5.x will be
 removed in 6.0.0.
 

--- a/docs/en/appendices/5-3-migration-guide.md
+++ b/docs/en/appendices/5-3-migration-guide.md
@@ -1,6 +1,6 @@
 # 5.3 Migration Guide
 
-The 5.3.0 release is a backwards compatible with 5.0. It adds new functionality
+The 5.3.0 release is backwards compatible with 5.0. It adds new functionality
 and introduces new deprecations. Any functionality deprecated in 5.x will be
 removed in 6.0.0.
 
@@ -224,7 +224,7 @@ If you are not running on **PHP 8.2 or higher**, you will need to upgrade PHP be
 
 ### Validation
 
-- `ipOrRange()` validation has has been added to check for an IP or a range (subnet).
+- `ipOrRange()` validation has been added to check for an IP or a range (subnet).
 - When validating within CakePHP marshalling context, the entity will be passed
   into the `context` argument for use inside custom validation rules. This can
   be useful when patching partially and then needing to get that data from the

--- a/docs/en/console-commands.md
+++ b/docs/en/console-commands.md
@@ -40,7 +40,7 @@ bin/cake migrations -h
 bin/cake bake.bake -h
 ```
 
-Plugin commands can be invoked without a plugin prefix if the commands's name
+Plugin commands can be invoked without a plugin prefix if the command's name
 does not overlap with an application or framework command. In the case that two
 plugins provide a command with the same name, the first loaded plugin will get
 the short alias. You can always use the `plugin.command` format to

--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -143,7 +143,7 @@ Commands are provided a `ConsoleIo` instance when executed. This object allows
 you to interact with `Cake\Console\ConsoleIo::out()` and
 `Cake\Console\ConsoleIo::err()` to emit on `stdout`, and
 `stderr`. Files can be created with overwrite confirmation with
-`Cake\Console\ConsoleIo::createFile()`<span class="title-ref">. :ref:\`command-helpers</span>
+`Cake\Console\ConsoleIo::createFile()`. [Command Helpers](../console-commands/input-output#command-helpers)
 provide 'macros' for output generation. See the
 [Command Input/Output](../console-commands/input-output) section for more information.
 

--- a/docs/en/console-commands/input-output.md
+++ b/docs/en/console-commands/input-output.md
@@ -325,7 +325,7 @@ $io->verbose('Verbose output');
 
 You can control the output level of commands, by using the `--quiet` and
 `--verbose` options. These options are added by default, and allow you to
-consistently control output levels inside your CakePHP comands.
+consistently control output levels inside your CakePHP commands.
 
 The `--quiet` and `--verbose` options also control how logging data is
 output to stdout/stderr. Normally info and higher log messages are output to

--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -509,7 +509,7 @@ The `fetchModel()` method is useful to load non ORM models or ORM tables that
 are not the controller's default:
 
 ``` php
-// ModelAwareTrait need to be explicity added to your controler first for fetchModel() to work.
+// ModelAwareTrait need to be explicitly added to your controller first for fetchModel() to work.
 use ModelAwareTrait;
 
 // Get an ElasticSearch model

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -1455,7 +1455,7 @@ $cookie = $cookies->remember_me;
 $exists = isset($cookies->remember_me)
 ```
 
-Once you have a `Cookie` object you can interact with it's state and modify
+Once you have a `Cookie` object you can interact with its state and modify
 it. Keep in mind that cookies are immutable, so you'll need to update the
 collection if you modify a cookie:
 

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -340,7 +340,7 @@ A valid message id can help to prevent emails ending up in spam folders.
 
 ## Creating Reusable Emails
 
-Until now we have seen how to directly use the the `Mailer` class to create and
+Until now we have seen how to directly use the `Mailer` class to create and
 send one emails. But main feature of mailer is to allow creating reusable emails
 throughout your application. They can also be used to contain multiple email
 configurations in one location. This helps keep your code DRYer and keeps email

--- a/docs/en/core-libraries/time.md
+++ b/docs/en/core-libraries/time.md
@@ -492,7 +492,7 @@ time and timezones. The `Date` class wraps the `Cake\Chronos\ChronosDate` class.
 
 > [!NOTE]
 > Unlike the `DateTime` class, `Date` does not extends the `DateTimeInterface`.
-> So you cannot cannot directly compare a `Date` instance with a `DateTime` instance.
+> So you cannot directly compare a `Date` instance with a `DateTime` instance.
 > But you can do comparisons like `$dateTime->toNative() > $date->toNative()`.
 
 ### Date::getTimestamp()

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -358,7 +358,7 @@ error code used as an HTTP status code if the error code is between `400` and
 `506`.
 
 The constructor for `Cake\Core\Exception\CakeException` allows you to
-pass in additional data. This additional data is interpolated into the the
+pass in additional data. This additional data is interpolated into the
 `_messageTemplate`. This allows you to create data rich exceptions, that
 provide more context around your errors:
 
@@ -472,7 +472,7 @@ You can throw any of the HTTP related exceptions from your controller actions
 to indicate failure states. For example:
 
 ``` php
-use Cake\Network\Exception\NotFoundException;
+use Cake\Http\Exception\NotFoundException;
 
 public function view($id = null)
 {

--- a/docs/en/development/rest.md
+++ b/docs/en/development/rest.md
@@ -109,7 +109,7 @@ response. Clients could also make a request to `/recipes` with the
 ## Encoding Response Data
 
 In the above controller, we're defining a `viewClasses()` method. This method
-defines which views your controller has available for content-negotitation.
+defines which views your controller has available for content-negotiation.
 We're including CakePHP's `JsonView` which enables JSON based responses. To
 learn more about it and Xml based views see [JSON and XML views](../views/json-and-xml-views). is
 used by CakePHP to select a view class to render a REST response with.

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -432,7 +432,7 @@ CakePHP, and should not be used unless you want the special meaning
 - `action` Used to name the controller action for a route.
 - `plugin` Used to name the plugin a controller is located in.
 - `prefix` Used for [Prefix Routing](#prefix-routing)
-- `_ext` Used for [File extentions routing](#file-extensions).
+- `_ext` Used for [File extensions routing](#file-extensions).
 - `_base` Set to `false` to remove the base path from the generated URL. If
   your application is not in the root directory, this can be used to generate
   URLs that are 'cake relative'.

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -840,7 +840,7 @@ constructor parameters you can provide those to `loadRoutes($constructorArgs)`.
 
 ### Creating Routes in Tests
 
-Sometimes it may be be necessary to dynamically add routes in tests, for example
+Sometimes it may be necessary to dynamically add routes in tests, for example
 when developing plugins, or applications that are extensible.
 
 Just like loading existing application routes, this can be done during `setup()`

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -1330,7 +1330,7 @@ Support for `$callback` as an array of data was added.
 ## Creating with an existing primary key
 
 When handling UUID primary keys you often want to provide an externally generated value, and not have
-an an identifier generated for you.
+an identifier generated for you.
 
 In this case make sure you are not passing the primary key as part of the marshalled data.
 Instead, assign the primary key and then patch in the remaining entity data:

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -111,7 +111,7 @@ appropriate parts of your application. The hooks are:
 - `console` Used to add console commands to an application's command
   collection.
 - `services` Used to register application container service. This is a good
-  opportunity to setup additional objects that need acccess to the container.
+  opportunity to setup additional objects that need access to the container.
 
 By default all plugins hooks are enabled. You can disable hooks by using the
 related options of the `plugin load` command:

--- a/docs/en/release-policy.md
+++ b/docs/en/release-policy.md
@@ -3,7 +3,7 @@
 CakePHP follows Semantic Versioning for all releases. This follows the versioning
 convention of **major.minor.patch**.
 
-The development team tries to guarantee each release follow the restrictions and
+The development team tries to guarantee each release follows the restrictions
 and guarantees below.
 
 ## Major Releases
@@ -21,7 +21,7 @@ code upgrades using rector.
 
 ## Minor Releases
 
-Minor release are generally backwards compatible with the previous minor and patch
+Minor releases are generally backwards compatible with the previous minor and patch
 release.
 
 Features might be deprecated, but they are never removed in a minor release.

--- a/docs/en/tutorials-and-examples/cms/authentication.md
+++ b/docs/en/tutorials-and-examples/cms/authentication.md
@@ -197,7 +197,7 @@ If you visit your site, you'll get an "infinite redirect loop" so let's fix that
 > [!NOTE]
 > If your application serves from both SSL and non-SSL protocols, then you might have problems
 > with sessions being lost, in case your application is on non-SSL protocol. You need to enable
-> access by setting session.cookie_secure to false in your config config/app.php or config/app_local.php.
+> access by setting session.cookie_secure to false in your config/app.php or config/app_local.php.
 > (See [CakePHP’s defaults on session.cookie_secure](../../development/sessions))
 
 In your `UsersController`, add the following code:


### PR DESCRIPTION
## Summary

- Fix doubled words across 8 files (`has has`, `the the`, `cannot cannot`, `be be`, `an an`)
- Fix typos: `comands` → `commands`, `commands's` → `command's`, `explicity`/`controler`, `negotitation`, `extentions`, `acccess`
- Fix grammar: `is a backwards compatible` → `is backwards compatible` (3 migration guides), `it's state` → `its state`, `Minor release are` → `Minor releases are`, `each release follow` → `each release follows`, `config config/` → `config/`
- Fix outdated namespace: `Cake\Network\Exception` → `Cake\Http\Exception` in errors.md
- Fix broken RST conversion artifact and link in commands.md (Command Helpers link)