### PR TITLE
Fix remaining docs issues: grammar, typos, broken content, and RST artifacts

### DIFF
--- a/docs/en/appendices/5-2-migration-guide.md
+++ b/docs/en/appendices/5-2-migration-guide.md
@@ -45,7 +45,7 @@ bin/cake upgrade rector --rules cakephp52 <path/to/app/src>
 ### Event
 
 - Returning values from event listeners / callbacks is deprecated. Use `$event->setResult()`
-  instead or `$event->stopPropogation()` to just stop the event propogation.
+  instead or `$event->stopPropagation()` to just stop the event propagation.
 
 ### View
 

--- a/docs/en/appendices/5-3-migration-guide.md
+++ b/docs/en/appendices/5-3-migration-guide.md
@@ -41,7 +41,7 @@ If you are not running on **PHP 8.2 or higher**, you will need to upgrade PHP be
 
 ### Validation
 
-- The signature of `Validator::validate(array $data, bool $newRecord = true, array $context = [])` has now a additional third parameter `$context`.
+- The signature of `Validator::validate(array $data, bool $newRecord = true, array $context = [])` now has an additional third parameter `$context`.
   It can be used to pass necessary context into the validation when marshalling.
 
 ### View

--- a/docs/en/console-commands.md
+++ b/docs/en/console-commands.md
@@ -141,7 +141,7 @@ command. Then learn more about commands:
 ## Routing in the Console Environment
 
 In command-line interface (CLI), specifically your console commands,
-`env('HTTP_HOST')` and other webbrowser specific environment variables are not
+`env('HTTP_HOST')` and other web browser specific environment variables are not
 set.
 
 If you generate reports or send emails that make use of `Router::url()` those

--- a/docs/en/contributing/code.md
+++ b/docs/en/contributing/code.md
@@ -126,8 +126,8 @@ branch, as you cannot edit it once the pull request is created.
   should choose the branch with the next version number. For example if the
   current stable release is `4.0.0`, the branch accepting new features will
   be `4.next`.
-- If your change is a breaks existing functionality, or APIs then you'll have
-  to choose then next major release. For example, if the current release is
+- If your change breaks existing functionality, or APIs then you'll have
+  to choose the next major release. For example, if the current release is
   `4.0.0` then the next time existing behavior can be broken will be in
   `5.x` so you should target that branch.
 

--- a/docs/en/contributing/documentation.md
+++ b/docs/en/contributing/documentation.md
@@ -512,7 +512,7 @@ npx markdownlint-cli --config .github/markdownlint.json "docs/en/**/*.md"
 
 ```bash [Auto-fix]
 # Automatically fix formatting issues
-npx markdownlint-cli --config .github/markdownlint.json --fix cs/en/**/*.md"
+npx markdownlint-cli --config .github/markdownlint.json --fix "docs/en/**/*.md"
 ```
 
 :::
@@ -599,11 +599,7 @@ npx cspell --config .github/cspell.json docs/en/your-file.md
 node bin/check-links.js docs/en/your-file.md
 ```
 
-:::e --check config.js
-jq empty toc_en.json
-
-```shell
 :::
-```
+:::
 
 If the CI checks fail, review the error messages and fix the issues before requesting a review.

--- a/docs/en/controllers/components.md
+++ b/docs/en/controllers/components.md
@@ -135,7 +135,7 @@ class PostsController extends AppController
 
     public function delete()
     {
-        if ($this->Post->delete($this->request->getData('Post.id')) {
+        if ($this->Post->delete($this->request->getData('Post.id'))) {
             $this->Flash->success('Post deleted.');
 
             return $this->redirect(['action' => 'index']);
@@ -346,7 +346,7 @@ use Cake\Routing\Router;
 
 public function beforeFilter(EventInterface $event): void
 {
-    throw new RedirectException(Router::url('/'))
+    throw new RedirectException(Router::url('/'));
 }
 ```
 

--- a/docs/en/controllers/middleware.md
+++ b/docs/en/controllers/middleware.md
@@ -257,7 +257,7 @@ public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
 If your application has cookies that contain data you want to obfuscate and
 protect against user tampering, you can use CakePHP's encrypted cookie
 middleware to transparently encrypt and decrypt cookie data via middleware.
-Cookie data is encrypted with via OpenSSL using AES:
+Cookie data is encrypted via OpenSSL using AES:
 
 ``` php
 use Cake\Http\Middleware\EncryptedCookieMiddleware;

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -304,7 +304,7 @@ you want the filenames to appear in the recipient's mail client:
 
 You can also add attachments using the `addAttachment()` method.
 
-> \$mailer-\>addAttachment('/full/file/path/file.png');
+> `$mailer->addAttachment('/full/file/path/file.png');`
 
 ### Relaxing Address Validation Rules
 
@@ -398,7 +398,7 @@ class UsersController extends AppController
     {
         $user = $this->Users->newEmptyEntity();
         if ($this->request->is('post')) {
-            $user = $this->Users->patchEntity($user, $this->request->getData())
+            $user = $this->Users->patchEntity($user, $this->request->getData());
             if ($this->Users->save($user)) {
                 $this->getMailer('User')->send('welcome', [$user]);
             }

--- a/docs/en/core-libraries/registry-objects.md
+++ b/docs/en/core-libraries/registry-objects.md
@@ -9,7 +9,7 @@ for Helpers, Behaviors, and Tasks in addition to Components.
 
 ## Loading Objects
 
-Objects can be loaded on-the-fly using add\<registry-object\>()
+Objects can be loaded on-the-fly using `add<registry-object>()`
 Example:
 
 ``` php

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -287,8 +287,8 @@ echo Text::highlight(
 
 Output:
 
-> Highlights \$phrase in \$text \<span class="highlight"\>using\</span\> the
-> \$options\['format'\] string specified or a default string.
+> Highlights `$phrase` in `$text` `<span class="highlight">using</span>` the
+> `$options['format']` string specified or a default string.
 
 ## Truncating Text
 

--- a/docs/en/development/rest.md
+++ b/docs/en/development/rest.md
@@ -111,8 +111,8 @@ response. Clients could also make a request to `/recipes` with the
 In the above controller, we're defining a `viewClasses()` method. This method
 defines which views your controller has available for content-negotiation.
 We're including CakePHP's `JsonView` which enables JSON based responses. To
-learn more about it and Xml based views see [JSON and XML views](../views/json-and-xml-views). is
-used by CakePHP to select a view class to render a REST response with.
+learn more about it and XML based views see [JSON and XML views](../views/json-and-xml-views).
+Content negotiation is used by CakePHP to select a view class to render a REST response with.
 
 Next, we have several methods that expose basic logic to create, edit, view and
 delete recipes. In each of our actions we're using the `serialize` option to
@@ -124,7 +124,7 @@ define the `serialize` option, and instead use template files. We would place
 the REST templates for our RecipesController inside **templates/Recipes/json**.
 
 See the [Controller Viewclasses](../controllers#controller-viewclasses) for more information on how CakePHP's
-response negotiation functionality.
+response negotiation functionality works.
 
 ## Parsing Request Bodies
 

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -352,7 +352,7 @@ In **config/app.php** make the session block look like:
         'cache' => 'apc',
     ],
 ],
-// Make sure to add a apc cache config
+// Make sure to add an apc cache config
 'Cache' => [
     'apc' => ['engine' => 'Apc'],
 ]

--- a/docs/en/orm/schema-system.md
+++ b/docs/en/orm/schema-system.md
@@ -112,7 +112,7 @@ $schema->addConstraint('author_id_idx', [
 ```
 
 If you add a primary key constraint to a single integer column it will automatically
-be converted into a auto-increment/serial column depending on the database
+be converted into an auto-increment/serial column depending on the database
 platform:
 
 ``` php

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -13,7 +13,7 @@ reused with little effort in other applications. The application and the plugin
 operate in their own respective spaces, but share the application's
 configuration data (for example, database connections, email transports)
 
-Plugin should define their own top-level namespace. For example:
+Plugins should define their own top-level namespace. For example:
 `DebugKit`. By convention, plugins use their package name as their namespace.
 If you'd like to use a different namespace, you can configure the plugin
 namespace, when plugins are loaded.
@@ -110,7 +110,7 @@ appropriate parts of your application. The hooks are:
   queue.
 - `console` Used to add console commands to an application's command
   collection.
-- `services` Used to register application container service. This is a good
+- `services` Used to register application container services. This is a good
   opportunity to setup additional objects that need access to the container.
 
 By default all plugins hooks are enabled. You can disable hooks by using the
@@ -634,7 +634,7 @@ To override plugin elements, create an element with the same name in:
     templates/plugin/ContactManager/element/helpbox.php
 
 This file would override
-**plugins/ContactManager/tempaltes/element/helpbox.ctp**.
+**plugins/ContactManager/templates/element/helpbox.ctp**.
 
 If your plugin is in a composer dependency (i.e. 'Company/ContactManager'), the
 path to the 'index' view of the Contacts controller will be:

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -642,7 +642,7 @@ echo $this->element(
 
 echo $this->element(
     'helpbox',
-    ['var' => $differenVar],
+    ['var' => $differentVar],
     ['cache' => ['key' => 'second_use', 'config' => 'view_long']],
 );
 ```

--- a/docs/en/views/helpers/breadcrumbs.md
+++ b/docs/en/views/helpers/breadcrumbs.md
@@ -10,7 +10,7 @@ of a breadcrumbs trail for your app.
 You can add a crumb to the list using the `add()` method. It takes three
 arguments:
 
-- **title** The string to be displayed as a the title of the crumb
+- **title** The string to be displayed as the title of the crumb
 - **url** A string or an array of parameters that will be given to the
   [Url](../../views/helpers/url)
 - **options** An array of attributes for the `item` and `itemWithoutLink`
@@ -101,7 +101,7 @@ precisely where you want to add a breadcrumb.
 After adding crumbs to the trail, you can easily render it using the
 `render()` method. This method accepts two array arguments:
 
-- `$attributes` : An array of attributes that will applied to the `wrapper`
+- `$attributes` : An array of attributes that will be applied to the `wrapper`
   template. This gives you the ability to add attributes to the HTML tag. It
   accepts the special `templateVars` key to allow the insertion of custom
   template variables in the template.


### PR DESCRIPTION
## Summary

Fixes remaining issues found during a thorough review of the English documentation.

**Broken/corrupted content (2 files):**
- `development/rest.md` — Fix broken sentence fragment (`. is` dangling after link) and incomplete sentence (missing verb "works")
- `contributing/documentation.md` — Fix wrong path `cs/en/` → `docs/en/`, fix corrupted code-group block

**RST conversion artifacts (3 files):**
- `core-libraries/text.md` — Fix escaped `\$phrase`, `\<span\>` in blockquote → inline code
- `core-libraries/email.md` — Fix escaped `\$mailer-\>` in blockquote → inline code
- `core-libraries/registry-objects.md` — Fix escaped `add\<registry-object\>()` → inline code

**Grammar errors (8 files):**
- `contributing/code.md` — `is a breaks` → `breaks`, `then next` → `the next`
- `controllers/middleware.md` — `encrypted with via` → `encrypted via`
- `plugins.md` — `Plugin should` → `Plugins should`, `container service` → `services`
- `views/helpers/breadcrumbs.md` — `as a the title` → `as the title`, `will applied` → `will be applied`
- `development/sessions.md` — `a apc` → `an apc`
- `orm/schema-system.md` — `a auto-increment` → `an auto-increment`

**Typos (4 files):**
- `appendices/5-2-migration-guide.md` — `stopPropogation` → `stopPropagation`
- `appendices/5-3-migration-guide.md` — `has now a additional` → `now has an additional`
- `views.md` — `$differenVar` → `$differentVar`
- `console-commands.md` — `webbrowser` → `web browser`

**Wrong path:**
- `plugins.md` — `tempaltes` → `templates`

**Code syntax in examples (2 files):**
- `controllers/components.md` — Missing closing `)` in `delete()`, missing `;` in `beforeFilter()`
- `core-libraries/email.md` — Missing `;` after `getData()`