### PR TITLE
Fix remaining RST escape artifacts and grammar issues

### DIFF
--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -32,7 +32,7 @@ class HelloCommand extends Command
 ```
 
 Command classes must implement an `execute()` method that does the bulk of
-their work. This method is called when a command is invoked. Lets call our first
+their work. This method is called when a command is invoked. Let's call our first
 command application directory, run:
 
 ``` bash

--- a/docs/en/console-commands/completion.md
+++ b/docs/en/console-commands/completion.md
@@ -135,7 +135,7 @@ complete -F _cake cake bin/cake
 
 ## Using autocompletion
 
-Once enabled, the autocompletion can be used the same way than for other
+Once enabled, the autocompletion can be used the same way as for other
 built-in commands, using the **TAB** key.
 Three type of autocompletion are provided. The following output are from a fresh CakePHP install.
 

--- a/docs/en/contributing/tickets.md
+++ b/docs/en/contributing/tickets.md
@@ -27,7 +27,7 @@ the best bug report possible:
 
 If you've found a security issue in CakePHP, please use the following procedure
 instead of the normal bug reporting system. Instead of using the bug tracker,
-mailing list or IRC please send an email to **security \[at\] cakephp.org**.
+mailing list or IRC please send an email to **security [at] cakephp.org**.
 Emails sent to this address go to the CakePHP core team on a private mailing
 list.
 

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -296,7 +296,7 @@ If your requests contain XML or JSON request content, you should consider using
 types making the parsed data available in `$request->getData()` and
 `$request->getParsedBody()`.
 
-### Environment Variables (from \$\_SERVER and \$\_ENV)
+### Environment Variables (from $_SERVER and $_ENV)
 
 `method` Cake\\Http\\ServerRequest::**getEnv**($key, $default = null): string|null
 

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -219,7 +219,7 @@ automatically handle key distribution and failover across the cluster nodes.
   them as a pool.
 - `duration` Be aware that any duration greater than 30 days will be treated as real
   Unix time value rather than an offset from current time.
-- `options` Additional options for the memcached client. Should be an array of option =\> value.
+- `options` Additional options for the memcached client. Should be an array of option => value.
   Use the `\Memcached::OPT_*` constants as keys.
 
 <a id="cache-configuration-fallback"></a>
@@ -282,7 +282,7 @@ the config and destroy the adapter if it was constructed.
 
 `static` Cake\\Cache\\Cache::**write**(string $key, mixed $value, string $config = 'default'): bool
 
-`Cache::write()` will write a \$value to the Cache. You can read or
+`Cache::write()` will write a `$value` to the Cache. You can read or
 delete this value later by referring to it by `$key`. You may
 specify an optional configuration to store the cache in as well. If
 no `$config` is specified, default will be used. `Cache::write()`

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -231,7 +231,7 @@ Log::warning('This is a warning', 'payments');
 As its name implies `FileLog` writes log messages to files. The level of log
 message being written determines the name of the file the message is stored in.
 If a level is not supplied, `LOG_ERR` is used which writes to the
-error log. The default log location is **logs/\$level.log**:
+error log. The default log location is **logs/`$level.log`**:
 
 ``` php
 // Executing this inside a CakePHP class
@@ -452,11 +452,11 @@ configured.
 
 `static` Cake\\Log\\Log::**setConfig**(array|string $key, $config = null): void
 
-param string \$name
+param string `$name`
 Name for the logger being connected, used
 to drop a logger later on.
 
-param array \$config
+param array `$config`
 Array of configuration information and
 constructor arguments for the logger.
 
@@ -476,7 +476,7 @@ Get the names of the configured loggers.
 
 `static` Cake\\Log\\Log::**drop**(string $name): bool
 
-param string \$name
+param string `$name`
 Name of the logger you wish to no longer receive
 messages.
 

--- a/docs/en/core-libraries/number.md
+++ b/docs/en/core-libraries/number.md
@@ -57,7 +57,7 @@ that represents the amount of money you are expressing. The second
 parameter is a string used to choose a predefined currency formatting
 scheme:
 
-| \$currency | 1234.56, formatted by currency type |
+| `$currency` | 1234.56, formatted by currency type |
 |------------|-------------------------------------|
 | EUR        | €1.234,56                           |
 | GBP        | £1,234.56                           |

--- a/docs/en/development/debugging.md
+++ b/docs/en/development/debugging.md
@@ -153,8 +153,8 @@ the order of currently running functions (stack frames).
 
 `static` Cake\\Error\\Debugger::**excerpt**($file, $line, $context): array
 
-Grab an excerpt from the file at \$path (which is an absolute
-filepath), highlights line number \$line with \$context number of
+Grab an excerpt from the file at `$path` (which is an absolute
+filepath), highlights line number `$line` with `$context` number of
 lines around it.
 
 ``` php

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -32,7 +32,7 @@ options are supported:
 - `extraFatalErrorMemory` - int - Set to the number of megabytes to increase
   the memory limit by when a fatal error is encountered. This allows breathing
   room to complete logging or error handling.
-- `logger` (prior to 4.4.0 use `errorLogger`) -`Cake\Error\ErrorLoggerInterface` - The class responsible for logging
+- `logger` (prior to 4.4.0 use `errorLogger`) - `Cake\Error\ErrorLoggerInterface` - The class responsible for logging
   errors and unhandled exceptions. Defaults to `Cake\Error\ErrorLogger`.
 - `errorRenderer` - `Cake\Error\ErrorRendererInterface` - The class responsible
   for rendering errors. Default is chosen based on PHP SAPI.
@@ -515,7 +515,7 @@ In addition, CakePHP uses the following exceptions:
 : The requested controller action could not be found.
 
 `Cake\Controller\Exception\PrivateActionException`
-: Accessing private/protected/\_ prefixed actions.
+: Accessing private/protected/_ prefixed actions.
 
 `Cake\Console\Exception\ConsoleException`
 : A console library class encounter an error.

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -621,7 +621,7 @@ echo $this->element('Contacts.sidebar/helpbox');
 You can override any plugin views from inside your app using special paths. If
 you have a plugin called 'ContactManager' you can override the template files of the
 plugin with application specific view logic by creating files using the
-following template **templates/plugin/\[Plugin\]/\[Controller\]/\[view\].php**. For the
+following template **templates/plugin/`[Plugin]/[Controller]/[view]`.php**. For the
 Contacts controller you could make the following file:
 
     templates/plugin/ContactManager/Contacts/index.php

--- a/docs/en/views/helpers/html.md
+++ b/docs/en/views/helpers/html.md
@@ -140,9 +140,9 @@ background:#633; border-bottom:1px solid #000; padding:10px;
 This method is handy for linking to external resources like RSS/Atom feeds
 and favicons. Like css(), you can specify whether or not you'd like this tag
 to appear inline or appended to the `meta` block by setting the 'block'
-key in the \$attributes parameter to `true`, ie - `['block' => true]`.
+key in the `$attributes` parameter to `true`, ie - `['block' => true]`.
 
-If you set the "type" attribute using the \$attributes parameter,
+If you set the "type" attribute using the `$attributes` parameter,
 CakePHP contains a few shortcuts:
 
 | type      | translated value       |
@@ -499,7 +499,7 @@ If you wish to override which block name is used, you can do so by setting
 not you want to include this script once per request or more than
 once. This defaults to `true`.
 
-You can use \$options to set additional properties to the
+You can use `$options` to set additional properties to the
 generated script tag. If an array of script tags is used, the
 attributes will be applied to all of the generated script tags.
 
@@ -748,7 +748,7 @@ Output:
 
 `method` Cake\\View\\Helper\\HtmlHelper::**tableHeaders**(array $names, array $trOptions = null, array $thOptions = null): string
 
-Creates a row of table header cells to be placed inside of \<table\>
+Creates a row of table header cells to be placed inside of `<table>`
 tags.
 
 ``` php
@@ -808,9 +808,9 @@ Output:
 
 `method` Cake\\View\\Helper\\HtmlHelper::**tableCells**(array $data, array $oddTrOptions = null, array $evenTrOptions = null, $useCount = false, $continueOddEven = true): string
 
-Creates table cells, in rows, assigning \<tr\> attributes differently
+Creates table cells, in rows, assigning `<tr>` attributes differently
 for odd- and even-numbered rows. Wrap a single table cell within an
-\[\] for specific \<td\>-attributes.
+`[]` for specific `<td>`-attributes.
 
 ``` php
 echo $this->Html->tableCells([

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -89,7 +89,7 @@ $this->Paginator->setTemplates([
 > attention, you should prefix this character with another percentage so it
 > looks like `%%`. The reason is that internally templates are compiled to
 > be used with `sprintf()`.
-> Example: '\<div style="width:{{size}}%%"\>{{content}}\</div\>'
+> Example: `'<div style="width:{{size}}%%">{{content}}</div>'`
 
 ## Template Names
 

--- a/docs/en/views/helpers/text.md
+++ b/docs/en/views/helpers/text.md
@@ -12,7 +12,7 @@ truncating long stretches of text.
 
 `method` Cake\\View\\Helper\\TextHelper::**autoLinkEmails**(string $text, array $options = []): string
 
-Adds links to the well-formed email addresses in \$text, according
+Adds links to the well-formed email addresses in `$text`, according
 to any options defined in `$options` (see
 `HtmlHelper::link()`).
 
@@ -66,7 +66,7 @@ Further options:
 
 `method` Cake\\View\\Helper\\TextHelper::**autoParagraph**(string $text): string
 
-Adds proper \<p\> around text where double-line returns are found, and \<br\> where
+Adds proper `<p>` around text where double-line returns are found, and `<br>` where
 single-line returns are found.
 
 ``` php


### PR DESCRIPTION
## Summary

Fixes remaining RST-to-Markdown conversion escape artifacts and grammar issues found during a deeper review.

**RST escape artifacts (10 files):**

Replaced RST-style escaped syntax (`\$var`, `\<tag\>`, `\[\]`, `=\>`) with proper markdown inline code across:

- `views/helpers/text.md` — `\$text`, `\<p\>`, `\<br\>`
- `views/helpers/html.md` — `\$attributes`, `\$options`, `\<table\>`, `\<tr\>`, `\<td\>`, `\[\]`
- `views/helpers/paginator.md` — `\<div\>...\</div\>`
- `development/debugging.md` — `\$path`, `\$line`, `\$context`
- `controllers/request-response.md` — `\$_SERVER`, `\$_ENV` in heading
- `core-libraries/logging.md` — `\$level.log`, `\$name`, `\$config`
- `core-libraries/number.md` — `\$currency` in table header
- `core-libraries/caching.md` — `=\>`, `\$value`
- `plugins.md` — `\[Plugin\]/\[Controller\]/\[view\]`
- `contributing/tickets.md` — `\[at\]`
- `development/errors.md` — `\_` prefix

**Grammar fixes (3 files):**

- `console-commands/completion.md` — `the same way than` → `the same way as`
- `console-commands/commands.md` — `Lets call` → `Let's call`
- `development/errors.md` — missing space after dash in list item