### PR TITLE
Fix code block indentation in docs

### DIFF
--- a/docs/en/controllers.md
+++ b/docs/en/controllers.md
@@ -495,10 +495,9 @@ the controller's default one:
 ``` php
 // In a controller method.
 $recentArticles = $this->fetchTable('Articles')->find('all',
-        limit: 5,
-        order: 'Articles.created DESC',
-    )
-    ->all();
+    limit: 5,
+    order: 'Articles.created DESC',
+)->all();
 ```
 
 ### fetchModel()

--- a/docs/en/core-libraries/collections.md
+++ b/docs/en/core-libraries/collections.md
@@ -1245,19 +1245,19 @@ imagine a lengthy closure like this one:
 
 ``` php
 $collection
-        ->map(function ($row, $key) {
-            if (!empty($row['items'])) {
-                $row['total'] = collection($row['items'])->sumOf('price');
-            }
+    ->map(function ($row, $key) {
+        if (!empty($row['items'])) {
+            $row['total'] = collection($row['items'])->sumOf('price');
+        }
 
-            if (!empty($row['total'])) {
-                $row['tax_amount'] = $row['total'] * 0.25;
-            }
+        if (!empty($row['total'])) {
+            $row['tax_amount'] = $row['total'] * 0.25;
+        }
 
-            // More code here...
+        // More code here...
 
-            return $modifiedRow;
-        });
+        return $modifiedRow;
+    });
 ```
 
 This can be refactored by creating another class:
@@ -1265,20 +1265,20 @@ This can be refactored by creating another class:
 ``` php
 class TotalOrderCalculator
 {
-        public function __invoke($row, $key)
-        {
-            if (!empty($row['items'])) {
-                $row['total'] = collection($row['items'])->sumOf('price');
-            }
-
-            if (!empty($row['total'])) {
-                $row['tax_amount'] = $row['total'] * 0.25;
-            }
-
-            // More code here...
-
-            return $modifiedRow;
+    public function __invoke($row, $key)
+    {
+        if (!empty($row['items'])) {
+            $row['total'] = collection($row['items'])->sumOf('price');
         }
+
+        if (!empty($row['total'])) {
+            $row['tax_amount'] = $row['total'] * 0.25;
+        }
+
+        // More code here...
+
+        return $modifiedRow;
+    }
 }
 
 // Use the logic in your map() call

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -158,12 +158,12 @@ application. Mailer views can also use layouts and elements just like normal vie
 ``` php
 $mailer = new Mailer();
 $mailer
-            ->setEmailFormat('html')
-            ->setTo('bob@example.com')
-            ->setFrom('app@domain.com')
-            ->viewBuilder()
-                ->setTemplate('welcome')
-                ->setLayout('fancy');
+    ->setEmailFormat('html')
+    ->setTo('bob@example.com')
+    ->setFrom('app@domain.com')
+    ->viewBuilder()
+        ->setTemplate('welcome')
+        ->setLayout('fancy');
 
 $mailer->deliver();
 ```
@@ -175,12 +175,12 @@ send multipart templated email messages as well:
 ``` php
 $mailer = new Mailer();
 $mailer
-            ->setEmailFormat('both')
-            ->setTo('bob@example.com')
-            ->setFrom('app@domain.com')
-            ->viewBuilder()
-                ->setTemplate('welcome')
-                ->setLayout('fancy');
+    ->setEmailFormat('both')
+    ->setTo('bob@example.com')
+    ->setFrom('app@domain.com')
+    ->viewBuilder()
+        ->setTemplate('welcome')
+        ->setLayout('fancy');
 
 $mailer->deliver();
 ```

--- a/docs/en/orm/associations.md
+++ b/docs/en/orm/associations.md
@@ -42,8 +42,8 @@ class ArticlesTable extends Table
     public function initialize(array $config): void
     {
         $this->belongsTo('Authors', [
-                'className' => 'Publishing.Authors',
-            ])
+            'className' => 'Publishing.Authors',
+        ])
             ->setForeignKey('author_id')
             ->setProperty('author');
     }
@@ -81,8 +81,8 @@ class ArticlesTable extends Table
             ->setFinder('approved');
 
         $this->hasMany('UnapprovedComments', [
-                'className' => 'Comments',
-            ])
+            'className' => 'Comments',
+        ])
             ->setFinder('unapproved')
             ->setProperty('unapproved_comments');
     }
@@ -195,15 +195,15 @@ class UsersTable extends Table
     public function initialize(array $config): void
     {
         $this->hasOne('HomeAddresses', [
-                'className' => 'Addresses',
-            ])
+            'className' => 'Addresses',
+        ])
             ->setProperty('home_address')
             ->setConditions(['HomeAddresses.label' => 'Home'])
             ->setDependent(true);
 
         $this->hasOne('WorkAddresses', [
-                'className' => 'Addresses',
-            ])
+            'className' => 'Addresses',
+        ])
             ->setProperty('work_address')
             ->setConditions(['WorkAddresses.label' => 'Work'])
             ->setDependent(true);

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -319,11 +319,11 @@ the Author entity.
 ``` php
 // In your finders/controller:
 $query = $articles->find('list',
-        keyField: 'id',
-        valueField: function ($article) {
-            return $article->author->get('label');
-        }
-    )
+    keyField: 'id',
+    valueField: function ($article) {
+        return $article->author->get('label');
+    },
+)
     ->contain('Authors');
 ```
 


### PR DESCRIPTION
## Summary

Fixes PHP code block indentation in top-level code examples that used incorrect 8- or 12-space indentation instead of the CakePHP standard 4-space convention.

**Note:** Only top-level code blocks were affected. Code inside class method bodies (where 12-space = 8 base + 4 chain) was already correct and left unchanged.

**Files fixed:**

- **`core-libraries/email.md`** — Mailer chained calls at top level had 12-space indent → fixed to 4 (with 8 for nested `viewBuilder()` chains)
- **`core-libraries/collections.md`** — `->map()` chain and `TotalOrderCalculator` class body had 8-space indent → fixed to 4
- **`controllers.md`** — `fetchTable()->find()` arguments had 8-space indent → fixed to 4
- **`orm/associations.md`** — Array arguments in `belongsTo()`, `hasMany()`, `hasOne()` had 16-space indent → fixed to 12 (inside method body)
- **`orm/retrieving-data-and-resultsets.md`** — `find('list',` arguments had 8-space indent → fixed to 4, added trailing comma