### PR TITLE
Remove 72 redundant anchor tags

### DIFF
--- a/docs/en/console-commands/completion.md
+++ b/docs/en/console-commands/completion.md
@@ -72,8 +72,6 @@ Save the file, then restart your console.
 > The target directory for the **cake** file will be
 > **/usr/local/etc/bash_completion.d/**.
 
-<a id="bash-completion-file-content"></a>
-
 ### Bash Completion file content
 
 This is the code you need to put inside the **cake** file in the correct location

--- a/docs/en/console-commands/input-output.md
+++ b/docs/en/console-commands/input-output.md
@@ -5,8 +5,6 @@
 CakePHP provides the `ConsoleIo` object to commands so that they can
 interactively read user input and output information to the user.
 
-<a id="command-helpers"></a>
-
 ## Command Helpers
 
 Formatting console output can be tedious and lead to maintenance issues. To

--- a/docs/en/contributing/backwards-compatibility.md
+++ b/docs/en/contributing/backwards-compatibility.md
@@ -283,8 +283,6 @@ value:
 
 Will disable runtime deprecation warnings.
 
-<a id="experimental-features"></a>
-
 ## Experimental Features
 
 Experimental features are **not included** in the above backwards compatibility

--- a/docs/en/controllers/components.md
+++ b/docs/en/controllers/components.md
@@ -15,8 +15,6 @@ chapter for each component:
 - [Form Protection Component](../controllers/components/form-protection)
 - [Checking HTTP Cache](../controllers/components/check-http-cache)
 
-<a id="configuring-components"></a>
-
 ## Configuring Components
 
 Many of the core components require configuration. One example would be
@@ -151,8 +149,6 @@ class PostsController extends AppController
 ::: info Changed in version 5.1.0
 Components are able to use [Dependency Injection](../development/dependency-injection) to receive services.
 :::
-
-<a id="creating-a-component"></a>
 
 ## Creating a Component
 

--- a/docs/en/controllers/middleware.md
+++ b/docs/en/controllers/middleware.md
@@ -59,8 +59,6 @@ CakePHP provides several middleware to handle common tasks in web applications:
   provides configurable rate limiting to protect against abuse and ensure fair
   usage of resources.
 
-<a id="using-middleware"></a>
-
 ## Using Middleware
 
 Middleware can be applied to your application globally, to individual
@@ -234,8 +232,6 @@ class Application
 }
 ```
 
-<a id="routing-middleware"></a>
-
 ## Routing Middleware
 
 Routing middleware is responsible for applying your application's routes and
@@ -249,8 +245,6 @@ public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     $middlewareQueue->add(new RoutingMiddleware($this));
 }
 ```
-
-<a id="encrypted-cookie-middleware"></a>
 
 ## Encrypted Cookie Middleware
 
@@ -277,8 +271,6 @@ $middlewareQueue->add($cookies);
 
 The encryption algorithms and padding style used by the cookie middleware are
 backwards compatible with `CookieComponent` from earlier versions of CakePHP.
-
-<a id="body-parser-middleware"></a>
 
 ## Body Parser Middleware
 

--- a/docs/en/controllers/pagination.md
+++ b/docs/en/controllers/pagination.md
@@ -141,8 +141,6 @@ class ArticlesController extends AppController
 When using the `SimplePaginator` you will not be able to generate page
 numbers, counter data, links to the last page, or total record count controls.
 
-<a id="paginating-multiple-queries"></a>
-
 ## Paginating Multiple Queries
 
 You can paginate multiple models in a single controller action, using the
@@ -212,8 +210,6 @@ $unpublishedArticles = $this->paginate(
         ->where(['published' => false]),
 );
 ```
-
-<a id="control-which-fields-used-for-ordering"></a>
 
 ## Control which Fields Used for Ordering
 

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -37,8 +37,6 @@ CakePHP's request object implements the [PSR-7
 ServerRequestInterface](https://www.php-fig.org/psr/psr-7/) making it easier to
 use libraries from outside of CakePHP.
 
-<a id="request-parameters"></a>
-
 ### Request Parameters
 
 The request exposes routing parameters through the `getParam()` method:
@@ -1352,8 +1350,6 @@ $this->response = $this->response->withHeader('X-CakePHP', 'yes!');
 `CookieCollection` objects are accessible from the request and response objects.
 They let you interact with groups of cookies using immutable patterns, which
 allow the immutability of the request and response to be preserved.
-
-<a id="creating-cookies"></a>
 
 ### Creating Cookies
 

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -686,8 +686,6 @@ The required API for a CacheEngine is
 
 `method` Cake\\Cache\\CacheEngine::**increment**($key, $offset = 1): int|false
 
-<a id="cache-events"></a>
-
 ## Cache Events
 
 ::: info Added in version 5.3.0

--- a/docs/en/core-libraries/events.md
+++ b/docs/en/core-libraries/events.md
@@ -124,8 +124,6 @@ object along. The listeners will handle all the extra logic around the
 possibly in separate objects and even delegating it to offline tasks if you have
 the need.
 
-<a id="tracking-events"></a>
-
 ### Tracking Events
 
 To keep a list of events that are fired on a particular `EventManager`, you
@@ -526,8 +524,6 @@ be an argument of any type, we recommend passing an associative array.
 
 The `Cake\Event\EventManager::dispatch()` method accepts an event
 object as an argument and notifies all subscribed listeners.
-
-<a id="stopping-events"></a>
 
 ### Stopping Events
 

--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -10,8 +10,6 @@ to do just that.
 CakePHP's Hash class can be called from any model or controller in
 the same way Inflector is called. Example: `Hash::combine()`.
 
-<a id="hash-path-syntax"></a>
-
 ## Hash Path Syntax
 
 The path syntax described below is used by all the methods in `Hash`. Not all

--- a/docs/en/core-libraries/inflector.md
+++ b/docs/en/core-libraries/inflector.md
@@ -224,8 +224,6 @@ generating code or doing work based on conventions:
 Inflector::variable('apple_pie');
 ```
 
-<a id="inflection-configuration"></a>
-
 ## Inflection Configuration
 
 CakePHP's naming conventions can be really nice - you can name your database

--- a/docs/en/core-libraries/internationalization-and-localization.md
+++ b/docs/en/core-libraries/internationalization-and-localization.md
@@ -516,8 +516,6 @@ I18n::setTranslator(
 );
 ```
 
-<a id="creating-generic-translators"></a>
-
 ### Creating Generic Translators
 
 Configuring translators by calling `I18n::setTranslator()` for each domain and

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -94,8 +94,6 @@ values in your **config/app.php** file. Errors will be displayed when debug is
 `log` option to `true`. See [Configuration](../development/configuration) for more
 information.
 
-<a id="writing-to-logs"></a>
-
 ## Writing to Logs
 
 Writing to the log files can be done in two different ways. The first
@@ -170,8 +168,6 @@ exception.
 > [!NOTE]
 > When `levels` is set to an empty value in a logger's configuration, it
 > will take messages of any level.
-
-<a id="logging-scopes"></a>
 
 ### Logging Scopes
 
@@ -360,8 +356,6 @@ class DatabaseLog extends BaseLog
 CakePHP requires that all logging engine implement `Psr\Log\LoggerInterface`.
 The class `Cake\Log\Engine\BaseLog` is an easy way to satisfy the
 interface as it only requires you to implement the `log()` method.
-
-<a id="logging-formatters"></a>
 
 ## Logging Formatters
 

--- a/docs/en/core-libraries/validation.md
+++ b/docs/en/core-libraries/validation.md
@@ -4,8 +4,6 @@ The validation package in CakePHP provides features to build validators that can
 validate arbitrary arrays of data with ease. You can find a [list of available
 Validation rules in the API](https://api.cakephp.org/5.x/class-Cake.Validation.Validation.html).
 
-<a id="creating-validators"></a>
-
 ## Creating Validators
 
 `class` Cake\\Validation\\**Validator**
@@ -244,8 +242,6 @@ $validator->add('length', 'custom', [
 ]);
 ```
 
-<a id="conditional-validation"></a>
-
 ### Conditional Validation
 
 When defining validation rules, you can use the `on` key to define when
@@ -373,8 +369,6 @@ public function validationDefault(Validator $validator): Validator
 When enabled all fields will stop validation on the first failing rule instead
 of checking all possible rules. In this case only a single error message will
 appear under the form field.
-
-<a id="adding-validation-providers"></a>
 
 ### Adding Validation Providers
 

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -38,8 +38,6 @@ Configure::load('app', 'default', false);
 Configure::load('other_config', 'default');
 ```
 
-<a id="environment-variables"></a>
-
 ## Environment Variables
 
 Many modern cloud providers, like Heroku, let you define environment
@@ -77,8 +75,6 @@ $debug = env('APP_DEBUG', false);
 
 The second value passed to the env function is the default value. This value
 will be used if no environment variable exists for the given key.
-
-<a id="general-configuration"></a>
 
 ### General Configuration
 
@@ -228,8 +224,6 @@ handling in CakePHP.
 
 See the [Routes Configuration](../development/routing#routes-configuration) for more information
 on configuring routing and creating routes for your application.
-
-<a id="additional-class-paths"></a>
 
 ## Additional Class Paths
 
@@ -464,8 +458,6 @@ files with that engine would fail:
 ``` php
 Configure::drop('default');
 ```
-
-<a id="loading-configuration-files"></a>
 
 ### Loading Configuration Files
 

--- a/docs/en/development/dependency-injection.md
+++ b/docs/en/development/dependency-injection.md
@@ -725,8 +725,6 @@ class BillingServiceProvider extends ServiceProvider
 }
 ```
 
-<a id="mocking-services-in-tests"></a>
-
 ## Mocking Services in Tests
 
 In tests that use `ConsoleIntegrationTestTrait` or `IntegrationTestTrait`

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -50,8 +50,6 @@ message, file and line (`debug` enabled).
 > If you use a custom error handler, the supported options will
 > depend on your handler.
 
-<a id="deprecation-warnings"></a>
-
 ## Deprecation Warnings
 
 CakePHP uses deprecation warnings to indicate when features have been
@@ -235,8 +233,6 @@ class ErrorController extends AppController
 ::: info Added in version 5.2.0
 Exception specific controller methods and templates were added.
 :::
-
-<a id="custom-exceptionrenderer"></a>
 
 ## Custom ExceptionRenderer
 

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -288,8 +288,6 @@ will go to the 'update' action. There are HTTP helper methods for:
 All of these methods return the route instance allowing you to leverage the
 [fluent setters](#route-fluent-methods) to further configure your route.
 
-<a id="route-elements"></a>
-
 ### Route Elements
 
 You can specify your own route elements and doing so gives you the
@@ -679,8 +677,6 @@ Router::url(['_name' => 'contacts:api:ping']);
 Routes connected in named scopes will only have names added if the route is also
 named. Nameless routes will not have the `_namePrefix` applied to them.
 
-<a id="prefix-routing"></a>
-
 ### Prefix Routing
 
 `static` Cake\\Routing\\RouteBuilder::**prefix**($name, $callback)
@@ -1035,8 +1031,6 @@ $this->Html->link(
 );
 ```
 
-<a id="route-scoped-middleware"></a>
-
 ## Route Scoped Middleware
 
 While Middleware can be applied to your entire application, applying middleware
@@ -1347,8 +1341,6 @@ $routes->scope('/', function (RouteBuilder $routes) {
 });
 ```
 
-<a id="passed-arguments"></a>
-
 ## Passed Arguments
 
 Passed arguments are additional arguments or path segments that are
@@ -1644,8 +1636,6 @@ To generate asset URLs for files in plugins use `plugin syntax`:
 $img = Asset::imageUrl('DebugKit.cake.png');
 ```
 
-<a id="redirect-routing"></a>
-
 ## Redirect Routing
 
 Redirect routing allows you to issue HTTP status 30x redirects for
@@ -1683,8 +1673,6 @@ $routes->scope('/', function (RouteBuilder $routes) {
 
 This would redirect `/articles/*` to `http://google.com` with a
 HTTP status of 302.
-
-<a id="entity-routing"></a>
 
 ## Entity Routing
 
@@ -1758,8 +1746,6 @@ class MyRedirectRoute extends Route
 ::: info Added in version 5.3.0
 `RedirectTrait` was added.
 :::
-
-<a id="custom-route-classes"></a>
 
 ## Custom Route Classes
 

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -6,8 +6,6 @@ requests and store persistent data for specific users. Unlike Cookies, session
 data is not available on the client side. Usage of `$_SESSION` is generally
 avoided in CakePHP, and instead usage of the Session classes is preferred.
 
-<a id="session-configuration"></a>
-
 ## Session Configuration
 
 Session configuration is generally defined in **/config/app.php**. The available

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -225,8 +225,6 @@ the creation of new bugs.
 > multiple tests at once, you will lose your event listeners that were
 > registered in config/bootstrap.php as the bootstrap is only executed once.
 
-<a id="running-tests"></a>
-
 ## Running Tests
 
 Once you have PHPUnit installed and some test cases written, you'll want to run
@@ -1910,8 +1908,6 @@ indicating 1 pass and 4 assertions.
 
 When you are testing a Helper which uses other helpers, be sure to mock the
 View clases `loadHelpers` method.
-
-<a id="testing-events"></a>
 
 ## Testing Events
 

--- a/docs/en/orm/associations.md
+++ b/docs/en/orm/associations.md
@@ -656,8 +656,6 @@ INNER JOIN articles_tags ON (
 );
 ```
 
-<a id="using-the-through-option"></a>
-
 ### Using the 'through' Option
 
 If you plan on adding extra information to the join/pivot table, or if you need

--- a/docs/en/orm/behaviors/translate.md
+++ b/docs/en/orm/behaviors/translate.md
@@ -481,8 +481,6 @@ Setting the language directly in the table is useful when you need to both
 retrieve and save entities for the same language or when you need to save
 multiple entities at once.
 
-<a id="saving-multiple-translations"></a>
-
 ## Saving Multiple Translations
 
 It is a common requirement to be able to add or edit multiple translations to

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -30,8 +30,6 @@ $connection = ConnectionManager::get('default');
 > [!NOTE]
 > For supported databases, see [installation notes](../installation).
 
-<a id="running-select-statements"></a>
-
 ### Running Select Statements
 
 Running raw SQL queries is a breeze:
@@ -306,8 +304,6 @@ pastry_stores, and savory_cakes.
 > 'flags' => [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8']
 > ```
 
-<a id="read-and-write-connections"></a>
-
 ## Read and Write Connections
 
 Connections can have separate read and write roles. Read
@@ -518,8 +514,6 @@ The `nativeuuid` type was added.
 The `inet`, `cidr`, `macaddr`, and `year` types were added.
 :::
 
-<a id="datetime-type"></a>
-
 ### DateTime Type
 
 `class` Cake\\Database\\**DateTimeType**
@@ -562,8 +556,6 @@ use Cake\Database\Type\DateTimeTimezoneType;
 // Overwrite the default datetime type with a more precise one.
 TypeFactory::map('datetime', DateTimeTimezoneType::class);
 ```
-
-<a id="enum-type"></a>
 
 ### Enum Type
 
@@ -847,8 +839,6 @@ no value for the current database driver:
 - `length` The length of a column if available..
 - `precision` The precision of the column if available.
 - `scale` Can be included for SQLServer connections.
-
-<a id="mapping-custom-datatypes-to-sql-expressions"></a>
 
 ### Mapping Custom Datatypes to SQL Expressions
 
@@ -1189,8 +1179,6 @@ Log::setConfig('queries', [
 > Query logging is only intended for debugging/development uses. You should
 > never leave query logging on in production as it will negatively impact the
 > performance of your application.
-
-<a id="identifier-quoting"></a>
 
 ## Identifier Quoting
 

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -509,13 +509,13 @@ your associations, there may be times when you need to lazily load associated
 data. Before we get into how to lazy load associations, we should discuss the
 differences between eager loading and lazy loading associations:
 
-Eager loading  
+Eager loading
 Eager loading uses joins (where possible) to fetch data from the
 database in as *few* queries as possible. When a separate query is required,
 like in the case of a HasMany association, a single query is emitted to
 fetch *all* the associated data for the current set of objects.
 
-Lazy loading  
+Lazy loading
 Lazy loading defers loading association data until it is absolutely
 required. While this can save CPU time because possibly unused data is not
 hydrated into objects, it can result in many more queries being emitted to
@@ -598,8 +598,6 @@ When converting an entity to an JSON, the virtual & hidden field lists are
 applied. Entities are recursively converted to JSON as well. This means that if you
 eager loaded entities and their associations CakePHP will correctly handle
 converting the associated data into the correct format.
-
-<a id="exposing-virtual-fields"></a>
 
 ### Exposing Virtual Fields
 

--- a/docs/en/orm/query-builder.md
+++ b/docs/en/orm/query-builder.md
@@ -312,8 +312,6 @@ $query->selectAllExcept($articlesTable, ['published']);
 You can also pass an `Association` object when working with contained
 associations.
 
-<a id="using-sql-functions"></a>
-
 ### Using SQL Functions
 
 CakePHP's ORM offers abstraction for some commonly used SQL functions. Using the
@@ -1797,8 +1795,6 @@ to fetch associated data from other tables is called **eager loading**.
 ### Filtering by Associated Data
 
 <!--@include: ./retrieving-data-and-resultsets.md{727,938}-->
-
-<a id="adding-joins"></a>
 
 ### Adding Joins
 

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -336,8 +336,6 @@ $this->setDisplayField('label'); // Will utilize Author::_getLabel()
 $query = $authors->find('list'); // Will utilize AuthorsTable::getDisplayField()
 ```
 
-<a id="finding-threaded-data"></a>
-
 ## Finding Threaded Data
 
 The `find('threaded')` finder returns nested entities that are threaded
@@ -412,8 +410,6 @@ methods can also be defined on [Behaviors](../orm/behaviors).
 If you need to modify the results after they have been fetched you should use
 a [Map Reduce](#map-reduce) function to modify the results. The map reduce features
 replace the 'afterFind' callback found in previous versions of CakePHP.
-
-<a id="dynamic-finders"></a>
 
 ## Dynamic Finders
 
@@ -552,7 +548,7 @@ You can select fields from all associations with multiple `contain()`
 statements:
 
 ``` php
-$query = $this->find()->select([
+$query = $products->find()->select([
     'Realestates.id',
     'Realestates.title',
     'Realestates.description',
@@ -1115,8 +1111,6 @@ has any rows in it.
 $results = $query->all();
 $results->isEmpty();
 ```
-
-<a id="loading-additional-associations"></a>
 
 ### Loading Additional Associations
 

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -390,8 +390,6 @@ $articles->saveMany($entities);
 $articles->saveManyOrFail($entities);
 ```
 
-<a id="changing-accessible-fields"></a>
-
 ### Changing Accessible Fields
 
 It's also possible to allow `newEntity()` to write into non accessible fields.
@@ -790,8 +788,6 @@ $this->save($entity);
 ::: info Added in version 5.3.0
 The `strictFields` option was added in 5.3.0.
 :::
-
-<a id="saving-entities"></a>
 
 ## Saving Entities
 
@@ -1197,8 +1193,6 @@ manipulate entities, marshall request data, and create form fields.
 ::: info Added in version 5.2.0
 Custom junction property names were added.
 :::
-
-<a id="saving-complex-types"></a>
 
 ### Saving Complex Types
 

--- a/docs/en/orm/validation.md
+++ b/docs/en/orm/validation.md
@@ -295,8 +295,6 @@ before entities are persisted. Some example application rules are:
 
 Application rules are checked when calling the Table `save()` and `delete()` methods.
 
-<a id="creating-a-rules-checker"></a>
-
 ### Creating a Rules Checker
 
 Rules checker classes are generally defined by the `buildRules()` method in your
@@ -629,8 +627,6 @@ public function buildRules(RulesChecker $rules): RulesChecker
 ```
 
 See the core rules for examples on how to create such rules.
-
-<a id="creating-custom-rule-objects"></a>
 
 ### Creating Custom Rule Objects
 

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -73,8 +73,6 @@ before running the above composer command:
 }
 ```
 
-<a id="loading-a-plugin"></a>
-
 ## Loading a Plugin
 
 If you want to use a plugin's routes, console commands, middlewares, event
@@ -369,8 +367,6 @@ class ContactManagerPlugin extends BasePlugin
 }
 ```
 
-<a id="plugin-routes"></a>
-
 ## Plugin Routes
 
 Plugins can provide routes files containing their routes. Each plugin can
@@ -480,8 +476,6 @@ also connect routes that use the following pattern:
 
 See the section on [Plugin Configuration](#plugin-configuration) for information on how to load
 plugin specific route files.
-
-<a id="plugin-models"></a>
 
 ## Plugin Models
 
@@ -649,8 +643,6 @@ in your application template overrides. For example, if the 'ContactManager'
 plugin implemented an 'Admin' prefix the overriding path would be:
 
     templates/plugin/ContactManager/Admin/ContactManager/index.php
-
-<a id="plugin-assets"></a>
 
 ## Plugin Assets
 

--- a/docs/en/security/https-enforcer.md
+++ b/docs/en/security/https-enforcer.md
@@ -1,5 +1,3 @@
-<a id="https-enforcer-middleware"></a>
-
 # HTTPS Enforcer Middleware
 
 If you want your application to only be available via HTTPS connections you can

--- a/docs/en/security/security-headers.md
+++ b/docs/en/security/security-headers.md
@@ -1,5 +1,3 @@
-<a id="security-header-middleware"></a>
-
 # Security Header Middleware
 
 The `SecurityHeaderMiddleware` layer allows you to apply security related

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -54,8 +54,6 @@ class AppView extends View
 }
 ```
 
-<a id="view-templates"></a>
-
 ## View Templates
 
 The view layer of CakePHP is how you speak to your users. Most of the time your
@@ -171,8 +169,6 @@ $this->set('activeMenuButton', 'posts');
 
 Then, in your layout, the `$activeMenuButton` variable will be available and
 contain the value 'posts'.
-
-<a id="extending-views"></a>
 
 ### Extending Views
 
@@ -715,8 +711,6 @@ echo $this->cache(function () use ($user, $article) {
 
 By default, cached view content will go into the `View::$elementCache` cache
 config, but you can use the `config` option to change this.
-
-<a id="view-events"></a>
 
 ## View Events
 

--- a/docs/en/views/helpers.md
+++ b/docs/en/views/helpers.md
@@ -21,8 +21,6 @@ helpers included in CakePHP, check out the chapter for each helper:
 - [Time](../views/helpers/time)
 - [Url](../views/helpers/url)
 
-<a id="configuring-helpers"></a>
-
 ## Configuring Helpers
 
 You configure helpers in CakePHP by declaring them in a view class. An `AppView`
@@ -163,8 +161,6 @@ class PostsController extends AppController
     }
 }
 ```
-
-<a id="aliasing-helpers"></a>
 
 ### Aliasing Helpers
 


### PR DESCRIPTION
## Summary
- Remove `<a id="..."></a>` tags where the anchor ID is identical to what the heading auto-generates
- For example, `<a id="saving-entities"></a>` before `## Saving Entities` is redundant since the heading produces the same `#saving-entities` anchor
- 72 anchors removed across 33 files
- 131 anchors with differing IDs are preserved for legacy link compatibility (e.g. `<a id="table-find-list"></a>` before `## Finding Key/Value Pairs`)

## Test plan
- [ ] Verify documentation builds without errors
- [ ] Spot-check that internal cross-references still resolve correctly