### PR TITLE
Add missing types to code examples

### DIFF
--- a/docs/en/appendices/5-0-migration-guide.md
+++ b/docs/en/appendices/5-0-migration-guide.md
@@ -113,7 +113,7 @@ changes made:
 ### Database
 
 - The `DateTimeType` and `DateType` now always return immutable objects.
-  Additionally the interface for `Date` objects reflects the `ChronosDate`
+  Additionally, the interface for `Date` objects reflects the `ChronosDate`
   interface which lacks all the time related methods that were present in
   CakePHP 4.x.
 - `DateType::setLocaleFormat()` no longer accepts an array.

--- a/docs/en/appendices/5-0-migration-guide.md
+++ b/docs/en/appendices/5-0-migration-guide.md
@@ -364,7 +364,7 @@ Table finders can now have typed arguments as required instead of an options arr
 For e.g. a finder for fetching posts by category or user:
 
 ``` php
-public function findByCategoryOrUser(SelectQuery $query, array $options)
+public function findByCategoryOrUser(SelectQuery $query, array $options): SelectQuery
 {
     if (isset($options['categoryId'])) {
         $query->where(['category_id' => $options['categoryId']]);
@@ -380,7 +380,7 @@ public function findByCategoryOrUser(SelectQuery $query, array $options)
 can now be written as:
 
 ``` php
-public function findByCategoryOrUser(SelectQuery $query, ?int $categoryId = null, ?int $userId = null)
+public function findByCategoryOrUser(SelectQuery $query, ?int $categoryId = null, ?int $userId = null): SelectQuery
 {
     if ($categoryId) {
         $query->where(['category_id' => $categoryId]);

--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -170,7 +170,7 @@ use Cake\Console\ConsoleOptionParser;
 class UserCommand extends Command
 {
     // Define the default table. This allows you to use `fetchTable()` without any argument.
-    protected $defaultTable = 'Users';
+    protected string $defaultTable = 'Users';
 
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
@@ -485,7 +485,7 @@ class UpdateTableCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 
-    protected $fixtures = [
+    protected array $fixtures = [
         // assumes you have a UsersFixture
         'app.Users',
     ];

--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -170,7 +170,7 @@ use Cake\Console\ConsoleOptionParser;
 class UserCommand extends Command
 {
     // Define the default table. This allows you to use `fetchTable()` without any argument.
-    protected string $defaultTable = 'Users';
+    protected ?string $defaultTable = 'Users';
 
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
@@ -207,7 +207,7 @@ to terminate execution:
 public function execute(Arguments $args, ConsoleIo $io): int
 {
     $name = $args->getArgument('name');
-    if (strlen($name) < 5) {
+    if (mb_strlen($name) < 5) {
         // Halt execution, output to stderr, and set exit code to 1
         $io->error('Name must be at least 4 characters long.');
         $this->abort();
@@ -223,7 +223,7 @@ You can also use `abort()` on the `$io` object to emit a message and code:
 public function execute(Arguments $args, ConsoleIo $io): int
 {
     $name = $args->getArgument('name');
-    if (strlen($name) < 5) {
+    if (mb_strlen($name) < 5) {
         // Halt execution, output to stderr, and set exit code to 99
         $io->abort('Name must be at least 4 characters long.', 99);
     }

--- a/docs/en/console-commands/option-parsers.md
+++ b/docs/en/console-commands/option-parsers.md
@@ -92,7 +92,7 @@ can be used as part of a fluent method chain.
 
 When creating positional arguments, you can use the `required` flag, to
 indicate that an argument must be present when a shell is called.
-Additionally you can use `choices` to force an argument to be from a list of
+Additionally, you can use `choices` to force an argument to be from a list of
 valid choices:
 
 ``` php

--- a/docs/en/contributing/cakephp-coding-conventions.md
+++ b/docs/en/contributing/cakephp-coding-conventions.md
@@ -224,7 +224,7 @@ As you can see above there should be one space on both sides of equals sign (=).
 Example of a method definition:
 
 ``` php
-public function someFunction($arg1, $arg2 = '')
+public function someFunction(string $arg1, string $arg2 = ''): mixed
 {
     if (expr) {
         statement;
@@ -239,7 +239,7 @@ Try to make your functions return something, at least `true` or `false`, so
 it can be determined whether the function call was successful:
 
 ``` php
-public function connection($dns, $persistent = false)
+public function connection(string|array $dns, bool $persistent = false): bool
 {
     if (is_array($dns)) {
         $dnsInfo = $dns;
@@ -262,7 +262,7 @@ There are spaces on both side of the equals sign.
 Try to avoid unnecessary nesting by bailing early:
 
 ``` php
-public function run(array $data)
+public function run(array $data): bool
 {
     ...
     if (!$success) {
@@ -272,7 +272,7 @@ public function run(array $data)
     ...
 }
 
-public function check(array $data)
+public function check(array $data): void
 {
     ...
     if (!$success) {
@@ -299,7 +299,7 @@ We only typehint public methods, though, as typehinting is not cost-free:
  * @param callable $callback Some callback.
  * @param bool $boolean Some boolean value.
  */
-public function foo(Table $table, array $array, callable $callback, $boolean)
+public function foo(Table $table, array $array, callable $callback, bool $boolean): void
 {
 }
 ```
@@ -317,7 +317,7 @@ type:
  *
  * @param array|\ArrayObject $array Some array value.
  */
-public function foo($array)
+public function foo(array|\ArrayObject $array): void
 {
 }
 ```
@@ -456,7 +456,7 @@ instead:
  *
  * @return $this
  */
-public function foo()
+public function foo(): static
 {
     return $this;
 }
@@ -650,7 +650,7 @@ class Thing
 {
     private $property; // Defined
 
-    public function readProperty()
+    public function readProperty(): void
     {
         // Not recommended as the property is defined in the class
         if (!isset($this->property)) {

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -361,7 +361,7 @@ For example, you often want to cache remote service call results. You could use
 ``` php
 class IssueService
 {
-    public function allIssues($repo)
+    public function allIssues(string $repo): mixed
     {
         return Cache::remember($repo . '-issues', function () use ($repo) {
             return $this->fetchAll($repo);
@@ -576,7 +576,7 @@ remove all entries associated to the `article` group:
 
 ``` php
 // src/Model/Table/ArticlesTable.php
-public function afterSave($event, $entity, $options = [])
+public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 {
     if ($entity->isNew()) {
         Cache::clearGroup('article', 'site_home');
@@ -598,7 +598,7 @@ configurations, i.e.: having the same group:
  * A variation of previous example that clears all Cache configurations
  * having the same group
  */
-public function afterSave($event, $entity, $options = [])
+public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
 {
     if ($entity->isNew()) {
         $configs = Cache::groupConfigs('article');

--- a/docs/en/core-libraries/collections.md
+++ b/docs/en/core-libraries/collections.md
@@ -1265,7 +1265,7 @@ This can be refactored by creating another class:
 ``` php
 class TotalOrderCalculator
 {
-    public function __invoke($row, $key)
+    public function __invoke(array $row, string $key): array
     {
         if (!empty($row['items'])) {
             $row['total'] = collection($row['items'])->sumOf('price');
@@ -1309,7 +1309,7 @@ be repeated every time:
 ``` php
 class FinalCheckOutRowProcessor
 {
-    public function __invoke($collection)
+    public function __invoke(CollectionInterface $collection): CollectionInterface
     {
         return $collection
             ->map(new ShippingCostCalculator)
@@ -1396,7 +1396,7 @@ The `buffered()` method is also useful for converting non-rewindable iterators
 into collections that can be iterated more than once:
 
 ``` php
-public function results()
+public function results(): Generator
 {
     ...
     foreach ($transientElements as $e) {

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -358,7 +358,7 @@ use Cake\Mailer\Mailer;
 
 class UserMailer extends Mailer
 {
-    public function welcome($user)
+    public function welcome(User $user): void
     {
         $this
             ->setTo($user->email)
@@ -367,7 +367,7 @@ class UserMailer extends Mailer
                 ->setTemplate('welcome_mail'); // By default, template with same name as method name is used.
     }
 
-    public function resetPassword($user)
+    public function resetPassword(User $user): void
     {
         $this
             ->setTo($user->email)

--- a/docs/en/core-libraries/events.md
+++ b/docs/en/core-libraries/events.md
@@ -56,7 +56,7 @@ use Cake\ORM\Table;
 
 class OrdersTable extends Table
 {
-    public function place($order)
+    public function place(Order $order): bool
     {
         if ($this->save($order)) {
             $this->Cart->remove($order);
@@ -536,7 +536,7 @@ In order to stop events you can either return `false` in your callbacks or
 call the `stopPropagation()` method on the event object:
 
 ``` php
-public function doSomething(EventInterface $event)
+public function doSomething(EventInterface $event): bool
 {
     // ...
     return false; // Stops the event
@@ -559,7 +559,7 @@ To check if an event was stopped, you call the `isStopped()` method in the
 event object:
 
 ``` php
-public function place($order)
+public function place(Order $order): bool
 {
     $event = new Event('Order.beforePlace', $this, ['order' => $order]);
     $this->getEventManager()->dispatch($event);
@@ -588,7 +588,7 @@ directly or returning the value in the callback itself:
 
 ``` php
 // A listener callback
-public function doSomething(EventInterface $event)
+public function doSomething(EventInterface $event): mixed
 {
     // ...
     $alteredData = $event->getData('order') + $moreData;
@@ -604,7 +604,7 @@ public function doSomethingElse(EventInterface $event): void
 }
 
 // Using the event result
-public function place($order)
+public function place(Order $order): bool
 {
     $event = new Event('Order.beforePlace', $this, ['order' => $order]);
     $this->getEventManager()->dispatch($event);

--- a/docs/en/core-libraries/events.md
+++ b/docs/en/core-libraries/events.md
@@ -550,7 +550,7 @@ public function updateBuyStatistic(EventInterface $event): void
 ```
 
 Stopping an event will prevent any additional callbacks from being called.
-Additionally the code triggering the event may behave differently based on the
+Additionally, the code triggering the event may behave differently based on the
 event being stopped or not. Generally it does not make sense to stop 'after'
 events, but stopping 'before' events is often used to prevent the entire
 operation from occurring.

--- a/docs/en/core-libraries/form.md
+++ b/docs/en/core-libraries/form.md
@@ -200,7 +200,7 @@ invalidate the fields accordingly to the feedback from the remote server:
 
 ``` php
 // in src/Form/ContactForm.php
-public function setErrors($errors)
+public function setErrors(array $errors): void
 {
     $this->_errors = $errors;
 }

--- a/docs/en/core-libraries/hash.md
+++ b/docs/en/core-libraries/hash.md
@@ -666,7 +666,7 @@ this method:
 // Call the noop function $this->noop() on every element of $data
 $result = Hash::map($data, "{n}", [$this, 'noop']);
 
-public function noop(array $array)
+public function noop(array $array): array
 {
     // Do stuff to array and return the result
     return $array;

--- a/docs/en/core-libraries/internationalization-and-localization.md
+++ b/docs/en/core-libraries/internationalization-and-localization.md
@@ -487,7 +487,7 @@ namespace App\I18n\Parser;
 
 class YamlFileParser
 {
-    public function parse($file)
+    public function parse(string $file): array
     {
         return yaml_parse_file($file);
     }

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -346,7 +346,7 @@ class DatabaseLog extends BaseLog
         // ...
     }
 
-    public function log($level, string $message, array $context = [])
+    public function log($level, string $message, array $context = []): void
     {
         // Write to the database.
     }

--- a/docs/en/development/application.md
+++ b/docs/en/development/application.md
@@ -55,7 +55,7 @@ use Cake\Http\BaseApplication;
 
 class Application extends BaseApplication
 {
-    public function bootstrap()
+    public function bootstrap(): void
     {
         // Call the parent to `require_once` config/bootstrap.php
         parent::bootstrap();

--- a/docs/en/development/dependency-injection.md
+++ b/docs/en/development/dependency-injection.md
@@ -687,7 +687,7 @@ class BillingServiceProvider extends ServiceProvider
 ```
 
 Service providers use their `services()` method to define all the services they
-will provide. Additionally those services **must be** defined in the `$provides`
+will provide. Additionally, those services **must be** defined in the `$provides`
 property. Failing to include a service in the `$provides` property will result
 in it not be loadable from the container.
 

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -287,7 +287,7 @@ use Cake\Error\Renderer\WebExceptionRenderer;
 
 class AppExceptionRenderer extends WebExceptionRenderer
 {
-    public function notFound($error)
+    public function notFound(NotFoundException $error): void
     {
         // Do something with NotFoundException objects.
     }
@@ -358,10 +358,10 @@ use Cake\Core\Exception\CakeException;
 class MissingWidgetException extends CakeException
 {
     // Context data is interpolated into this format string.
-    protected $_messageTemplate = 'Seems that %s is missing.';
+    protected string $_messageTemplate = 'Seems that %s is missing.';
 
     // You can set a default exception code as well.
-    protected $_defaultCode = 404;
+    protected int $_defaultCode = 404;
 }
 
 throw new MissingWidgetException(['widget' => 'Pointy']);

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -292,7 +292,7 @@ use Cake\Http\Session\DatabaseSession;
 
 class ComboSession extends DatabaseSession
 {
-    protected $cacheKey;
+    protected string $cacheKey;
 
     public function __construct()
     {

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -216,7 +216,7 @@ incorrect.
 By using test cases you can describe the relationship between a set of
 known inputs and their expected output. This helps you be more confident of the
 code you're writing as you can ensure that the code you wrote fulfills the
-expectations and assertions your tests make. Additionally because tests are
+expectations and assertions your tests make. Additionally, because tests are
 code, they can be re-run whenever you make a change. This helps prevent
 the creation of new bugs.
 
@@ -548,19 +548,19 @@ class ArticlesFixture extends TestFixture
 {
         // Optional. Set this property to load fixtures
         // to a different test datasource
-        public $connection = 'test';
+        public string $connection = 'test';
 
         // Optional. Lets you define which table alias is used when
         // reflecting schema and inserting rows. Inferred from the
         // class name by default. Added in 5.3.0
-        public $tableAlias = 'Articles';
+        public string $tableAlias = 'Articles';
 
         // Optional. Lets you define the table name for a fixture.
         // If defined, this table name will be camelized to create
         // $tableAlias.
-        public $table = 'articles';
+        public string $table = 'articles';
 
-        public $records = [
+        public array $records = [
             [
                 'title' => 'First Article',
                 'body' => 'First Article Body',
@@ -617,7 +617,7 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class ArticlesFixture extends TestFixture
 {
-    protected $strictFields = true;
+    protected bool $strictFields = true;
 
     // rest of fixture
 }
@@ -671,7 +671,7 @@ you define the `$fixtures` property in your model:
 ``` php
 class ArticlesTest extends TestCase
 {
-    protected $fixtures = ['app.Articles', 'app.Comments'];
+    protected array $fixtures =['app.Articles', 'app.Comments'];
 }
 ```
 
@@ -694,7 +694,7 @@ Fixture directory. You can also load fixtures from CakePHP core, or plugins:
 ``` php
 class ArticlesTest extends TestCase
 {
-    protected $fixtures = [
+    protected array $fixtures =[
         'plugin.DebugKit.Articles',
         'plugin.MyVendorName/MyPlugin.Messages',
         'core.Comments',
@@ -713,7 +713,7 @@ name:
 ``` php
 class ArticlesTest extends CakeTestCase
 {
-    protected $fixtures = ['app.Blog/Articles', 'app.Blog/Comments'];
+    protected array $fixtures =['app.Blog/Articles', 'app.Blog/Comments'];
 }
 ```
 
@@ -926,7 +926,7 @@ use Cake\TestSuite\TestCase;
 
 class ArticlesTableTest extends TestCase
 {
-    protected $fixtures = ['app.Articles'];
+    protected array $fixtures =['app.Articles'];
 }
 ```
 
@@ -948,7 +948,7 @@ use Cake\TestSuite\TestCase;
 
 class ArticlesTableTest extends TestCase
 {
-    protected $fixtures = ['app.Articles'];
+    protected array $fixtures =['app.Articles'];
 
     public function setUp(): void
     {
@@ -1100,7 +1100,7 @@ class ArticlesControllerTest extends TestCase
 {
     use IntegrationTestTrait;
 
-    protected $fixtures = ['app.Articles'];
+    protected array $fixtures =['app.Articles'];
 
     public function testIndex(): void
     {
@@ -1976,7 +1976,7 @@ use Cake\TestSuite\TestCase;
 
 class OrdersTableTest extends TestCase
 {
-    protected $fixtures = ['app.Orders'];
+    protected array $fixtures =['app.Orders'];
 
     public function setUp(): void
     {
@@ -2062,7 +2062,7 @@ use Cake\TestSuite\TestCase;
 class BlogPostsTableTest extends TestCase
 {
     // Plugin fixtures located in /plugins/Blog/tests/Fixture/
-    protected $fixtures = ['plugin.Blog.BlogPosts'];
+    protected array $fixtures =['plugin.Blog.BlogPosts'];
 
     public function testSomething(): void
     {
@@ -2073,7 +2073,7 @@ class BlogPostsTableTest extends TestCase
 
 If you want to use plugin fixtures in the app tests you can
 reference them using `plugin.pluginName.fixtureName` syntax in the
-`$fixtures` array. Additionally if you use vendor plugin name or fixture
+`$fixtures` array. Additionally, if you use vendor plugin name or fixture
 directories you can use the following: `plugin.vendorName/pluginName.folderName/fixtureName`.
 
 Before you can use fixtures you should ensure you have the [fixture

--- a/docs/en/development/testing.md
+++ b/docs/en/development/testing.md
@@ -136,7 +136,7 @@ use Cake\View\Helper;
 
 class ProgressHelper extends Helper
 {
-    public function bar($value)
+    public function bar(int|float $value): string
     {
         $width = round($value / 100, 2) * 100;
 
@@ -1742,9 +1742,9 @@ controllers that use it. Here is our example component located in
 ``` php
 class PagematronComponent extends Component
 {
-    public $controller = null;
+    public ?Controller $controller = null;
 
-    public function setController($controller)
+    public function setController(Controller $controller): void
     {
         $this->controller = $controller;
         // Make sure the controller is using pagination
@@ -1792,8 +1792,8 @@ use Cake\TestSuite\TestCase;
 
 class PagematronComponentTest extends TestCase
 {
-    protected $component;
-    protected $controller;
+    protected PagematronComponent $component;
+    protected Controller $controller;
 
     public function setUp(): void
     {
@@ -1872,7 +1872,7 @@ use Cake\View\View;
 
 class CurrencyRendererHelperTest extends TestCase
 {
-    public $helper = null;
+    public ?CurrencyRendererHelper $helper = null;
 
     // Here we instantiate our helper
     public function setUp(): void
@@ -1940,7 +1940,7 @@ class OrdersTable extends Table
 
 class CartsTable extends Table
 {
-    public function initialize()
+    public function initialize(): void
     {
         // Models don't share the same event manager instance,
         // so we need to use the global instance to listen to

--- a/docs/en/orm/behaviors.md
+++ b/docs/en/orm/behaviors.md
@@ -100,7 +100,7 @@ to the table. For example, if our SluggableBehavior defined the following
 method:
 
 ``` php
-public function slug($value)
+public function slug(string $value): string
 {
     return Text::slug($value, $this->_config['replacement']);
 }
@@ -124,7 +124,7 @@ public methods as mixin methods. In these cases you can use the
 example if we wanted to prefix our slug() method we could do the following:
 
 ``` php
-protected $_defaultConfig = [
+protected array $_defaultConfig = [
     'implementedMethods' => [
         'superSlug' => 'slug',
     ]
@@ -174,7 +174,7 @@ class SluggableBehavior extends Behavior
         'replacement' => '-',
     ];
 
-    public function slug(EntityInterface $entity)
+    public function slug(EntityInterface $entity): void
     {
         $config = $this->getConfig();
         $value = $entity->get($config['field']);
@@ -273,7 +273,7 @@ marshalled by implementing the `Cake\ORM\PropertyMarshalInterface`. This
 interface requires a single method to be implemented:
 
 ``` php
-public function buildMarshalMap($marshaller, $map, $options)
+public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array
 {
     return [
         'custom_behavior_field' => function ($value, $entity) {

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -557,7 +557,7 @@ namespace SoftDelete\Model\Entity;
 
 trait SoftDeleteTrait
 {
-    public function softDelete()
+    public function softDelete(): void
     {
         $this->set('deleted', true);
     }
@@ -637,7 +637,7 @@ use Cake\ORM\Entity;
 
 class User extends Entity
 {
-    protected $_hidden = ['password'];
+    protected array $_hidden = ['password'];
 }
 ```
 

--- a/docs/en/orm/retrieving-data-and-resultsets.md
+++ b/docs/en/orm/retrieving-data-and-resultsets.md
@@ -386,7 +386,7 @@ use Cake\ORM\Table;
 
 class ArticlesTable extends Table
 {
-    public function findOwnedBy(SelectQuery $query, User $user)
+    public function findOwnedBy(SelectQuery $query, User $user): SelectQuery
     {
         return $query->where(['author_id' => $user->id]);
     }
@@ -1352,17 +1352,17 @@ This is particularly useful for building custom finder methods as described in t
 [Custom Find Methods](#custom-find-methods) section:
 
 ``` php
-public function findPublished(SelectQuery $query)
+public function findPublished(SelectQuery $query): SelectQuery
 {
     return $query->where(['published' => true]);
 }
 
-public function findRecent(SelectQuery $query)
+public function findRecent(SelectQuery $query): SelectQuery
 {
     return $query->where(['created >=' => new DateTime('1 day ago')]);
 }
 
-public function findCommonWords(SelectQuery $query)
+public function findCommonWords(SelectQuery $query): SelectQuery
 {
     // Same as in the common words example in the previous section
     $mapper = ...;

--- a/docs/en/orm/table-objects.md
+++ b/docs/en/orm/table-objects.md
@@ -142,13 +142,13 @@ more detail on how to use the events subsystem:
 $articles->save($article, ['customVariable1' => 'yourValue1']);
 
 // In ArticlesTable.php
-public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
+public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options): void
 {
     $customVariable = $options['customVariable1'];  // 'yourValue1'
     $options['customVariable2'] = 'yourValue2';
 }
 
-public function afterSaveCommit(Event $event, EntityInterface $entity, ArrayObject $options)
+public function afterSaveCommit(Event $event, EntityInterface $entity, ArrayObject $options): void
 {
     $customVariable = $options['customVariable1'];  // 'yourValue1'
     $customVariable = $options['customVariable2'];  // 'yourValue2'

--- a/docs/en/orm/validation.md
+++ b/docs/en/orm/validation.md
@@ -641,7 +641,7 @@ use Cake\Datasource\EntityInterface;
 
 class CustomRule
 {
-    public function __invoke(EntityInterface $entity, array $options)
+    public function __invoke(EntityInterface $entity, array $options): bool
     {
         // Do work
         return false;

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -142,7 +142,7 @@ use ContactManager\ContactManagerPlugin;
 
 class Application extends BaseApplication
 {
-    public function bootstrap()
+    public function bootstrap(): void
     {
         parent::bootstrap();
 

--- a/docs/en/tutorials-and-examples/cms/authentication.md
+++ b/docs/en/tutorials-and-examples/cms/authentication.md
@@ -55,7 +55,7 @@ class User extends Entity
     // Add this method
     protected function _setPassword(string $password) : ?string
     {
-        if (strlen($password) > 0) {
+        if (mb_strlen($password) > 0) {
             return (new DefaultPasswordHasher())->hash($password);
         }
         return null;

--- a/docs/en/tutorials-and-examples/cms/authorization.md
+++ b/docs/en/tutorials-and-examples/cms/authorization.md
@@ -109,25 +109,25 @@ use Authorization\IdentityInterface;
 
 class ArticlePolicy
 {
-    public function canAdd(IdentityInterface $user, Article $article)
+    public function canAdd(IdentityInterface $user, Article $article): bool
     {
         // All logged in users can create articles.
         return true;
     }
 
-    public function canEdit(IdentityInterface $user, Article $article)
+    public function canEdit(IdentityInterface $user, Article $article): bool
     {
         // logged in users can edit their own articles.
         return $this->isAuthor($user, $article);
     }
 
-    public function canDelete(IdentityInterface $user, Article $article)
+    public function canDelete(IdentityInterface $user, Article $article): bool
     {
         // logged in users can delete their own articles.
         return $this->isAuthor($user, $article);
     }
 
-    protected function isAuthor(IdentityInterface $user, Article $article)
+    protected function isAuthor(IdentityInterface $user, Article $article): bool
     {
         return $article->user_id === $user->getIdentifier();
     }

--- a/docs/en/tutorials-and-examples/cms/tags-and-users.md
+++ b/docs/en/tutorials-and-examples/cms/tags-and-users.md
@@ -352,7 +352,7 @@ protected array $_accessible = [
     'tag_string' => true,
 ];
 
-protected function _getTagString()
+protected function _getTagString(): string
 {
     if (isset($this->_fields['tag_string'])) {
         return $this->_fields['tag_string'];
@@ -428,7 +428,7 @@ public function beforeSave(EventInterface $event, $entity, $options): void
     // Other code
 }
 
-protected function _buildTags($tagString)
+protected function _buildTags(string $tagString): array
 {
     // Trim tags
     $newTags = array_map('trim', explode(',', $tagString));

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -751,7 +751,7 @@ use Cake\View\View;
 
 class PdfView extends View
 {
-    public function render($view = null, $layout = null)
+    public function render(?string $view = null, ?string $layout = null): string
     {
         // Custom logic here.
     }

--- a/docs/en/views/cells.md
+++ b/docs/en/views/cells.md
@@ -24,7 +24,7 @@ use Cake\View\Cell;
 
 class InboxCell extends Cell
 {
-    public function display()
+    public function display(): void
     {
     }
 }
@@ -63,7 +63,7 @@ use Cake\View\Cell;
 
 class InboxCell extends Cell
 {
-    public function display()
+    public function display(): void
     {
         $unread = $this->fetchTable('Messages')->find('unread');
         $this->set('unread_count', $unread->count());
@@ -140,7 +140,7 @@ $cell = $this->cell('Inbox::recent', ['-3 days']);
 The above would match the following function signature:
 
 ``` php
-public function recent($since)
+public function recent(string $since): void
 {
 }
 ```
@@ -225,7 +225,7 @@ use Cake\Datasource\Paging\NumericPaginator;
 
 class FavoritesCell extends Cell
 {
-    public function display($user)
+    public function display(User $user): void
     {
         // Create a paginator
         $paginator = new NumericPaginator();
@@ -263,11 +263,11 @@ use Cake\View\Cell;
 
 class FavoritesCell extends Cell
 {
-    protected $_validCellOptions = ['limit'];
+    protected array $_validCellOptions = ['limit'];
 
-    protected $limit = 3;
+    protected int $limit = 3;
 
-    public function display($userId)
+    public function display(int $userId): void
     {
         $result = $this->fetchTable('Users')->find('friends', ['for' => $userId])
             ->limit($this->limit)

--- a/docs/en/views/helpers.md
+++ b/docs/en/views/helpers.md
@@ -254,7 +254,7 @@ use Cake\View\Helper;
 
 class LinkHelper extends Helper
 {
-    public function makeEdit($title, $url)
+    public function makeEdit(string $title, string|array $url): string
     {
         // Logic to create specially formatted link goes here...
     }
@@ -278,7 +278,7 @@ class LinkHelper extends Helper
 {
     protected array $helpers = ['Html'];
 
-    public function makeEdit($title, $url)
+    public function makeEdit(string $title, string|array $url): string
     {
         // Use the HTML helper to output
         // Formatted data:
@@ -330,7 +330,7 @@ class AwesomeHelper extends Helper
 {
     public array $helpers = ['Html'];
 
-    public function someMethod()
+    public function someMethod(): string
     {
         // set meta description
         return $this->Html->meta(
@@ -348,7 +348,7 @@ If you would like to render an Element inside your Helper you can use
 ``` php
 class AwesomeHelper extends Helper
 {
-    public function someFunction()
+    public function someFunction(): string
     {
         return $this->getView()->element(
             '/path/to/element',

--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -2325,7 +2325,7 @@ option when including the helper in your controller:
 
 ``` php
 // In a View class
-$this->loadHelper('Form', [
+$this->addHelper('Form', [
     'templates' => 'app_form',
 ]);
 ```
@@ -2643,7 +2643,7 @@ class AutocompleteWidget implements WidgetInterface
      *
      * @var \Cake\View\StringTemplate
      */
-    protected $_templates;
+    protected StringTemplate $_templates;
 
     /**
      * Constructor.
@@ -2702,7 +2702,7 @@ a setting:
 
 ``` php
 // In View class
-$this->loadHelper('Form', [
+$this->addHelper('Form', [
     'widgets' => [
         'autocomplete' => ['Autocomplete'],
     ],
@@ -2713,7 +2713,7 @@ If your widget requires other widgets, you can have FormHelper populate those
 dependencies by declaring them:
 
 ``` php
-$this->loadHelper('Form', [
+$this->addHelper('Form', [
     'widgets' => [
         'autocomplete' => [
             'App\View\Widget\AutocompleteWidget',

--- a/docs/en/views/helpers/html.md
+++ b/docs/en/views/helpers/html.md
@@ -138,7 +138,7 @@ background:#633; border-bottom:1px solid #000; padding:10px;
 `method` Cake\\View\\Helper\\HtmlHelper::**meta**(string|array $type, string $url = null, array $options = []): string|null
 
 This method is handy for linking to external resources like RSS/Atom feeds
-and favicons. Like css(), you can specify whether or not you'd like this tag
+and favicons. Like css(), you can specify whether you'd like this tag
 to appear inline or appended to the `meta` block by setting the 'block'
 key in the `$attributes` parameter to `true`, ie - `['block' => true]`.
 

--- a/docs/en/views/helpers/paginator.md
+++ b/docs/en/views/helpers/paginator.md
@@ -40,7 +40,7 @@ customize multiple templates and keep your code DRY:
 public function initialize(): void
 {
     ...
-    $this->loadHelper('Paginator', ['templates' => 'paginator-templates']);
+    $this->addHelper('Paginator', ['templates' => 'paginator-templates']);
 }
 ```
 
@@ -53,7 +53,7 @@ from a plugin using `plugin syntax`:
 public function initialize(): void
 {
     ...
-    $this->loadHelper('Paginator', ['templates' => 'MyPlugin.paginator-templates']);
+    $this->addHelper('Paginator', ['templates' => 'MyPlugin.paginator-templates']);
 }
 ```
 

--- a/docs/en/views/helpers/url.md
+++ b/docs/en/views/helpers/url.md
@@ -166,7 +166,7 @@ asset cache busting parameters you can use the `assetUrlClassName` option:
 
 ``` php
 // In view initialize
-$this->loadHelper('Url', ['assetUrlClassName' => AppAsset::class]);
+$this->addHelper('Url', ['assetUrlClassName' => AppAsset::class]);
 ```
 
 When using the `assetUrlClassName` you must implement the same methods as


### PR DESCRIPTION
## Summary

- Add missing return types and parameter types to method signatures in code examples across the docs (excluding controller/command methods)
- Add missing property types to class properties in code examples
- Fix `loadHelper()` to `addHelper()` in View `initialize()` contexts (runtime `loadHelper()` usage left as-is)

Files touched: 29 across orm, core-libraries, views, development, tutorials, contributing, and appendices docs.