### PR TITLE
Add missing parameter types and return types to method signatures

### DIFF
--- a/docs/en/console-commands/input-output.md
+++ b/docs/en/console-commands/input-output.md
@@ -179,7 +179,7 @@ The `BannerHelper` was added in 5.1
 
 ## Getting User Input
 
-`method` Cake\\Console\\ConsoleIo::**ask**($question, $choices = null, $default = null): string
+`method` Cake\\Console\\ConsoleIo::**ask**(string $question, ?array $choices = null, ?string $default = null): string
 
 When building interactive console applications you'll need to get user input.
 CakePHP provides a way to do this:
@@ -196,7 +196,7 @@ Selection validation is case-insensitive.
 
 ## Creating Files
 
-`method` Cake\\Console\\ConsoleIo::**createFile**($path, $contents): bool
+`method` Cake\\Console\\ConsoleIo::**createFile**(string $path, string $contents): bool
 
 Creating files is often important part of many console commands that help
 automate development and deployment. The `createFile()` method gives you

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -75,7 +75,7 @@ are also all found in the routing parameters:
 
 ### Query String Parameters
 
-`method` Cake\\Http\\ServerRequest::**getQuery**($name, $default = null): mixed
+`method` Cake\\Http\\ServerRequest::**getQuery**(?string $name = null, mixed $default = null): mixed
 
 Query string parameters can be read using the `getQuery()` method:
 
@@ -135,7 +135,7 @@ Casting functions were added.
 
 ### Request Body Data
 
-`method` Cake\\Http\\ServerRequest::**getData**($name, $default = null): mixed
+`method` Cake\\Http\\ServerRequest::**getData**(?string $name = null, mixed $default = null): mixed
 
 All POST data normally available through PHP's `$_POST` global variable can be
 accessed using `Cake\Http\ServerRequest::getData()`. For example:
@@ -210,7 +210,7 @@ necessary. In an CLI environment, where the concept of uploading files doesn't
 exist, it will allow to move the file that you've referenced irrespective of its
 origins, which makes testing file uploads possible.
 
-`method` Cake\\Http\\ServerRequest::**getUploadedFile**($path): UploadedFileInterface|null
+`method` Cake\\Http\\ServerRequest::**getUploadedFile**(string $path): UploadedFileInterface|null
 
 Returns the uploaded file at a specific path. The path uses the same dot syntax as the
 `Cake\Http\ServerRequest::getData()` method:
@@ -296,7 +296,7 @@ types making the parsed data available in `$request->getData()` and
 
 ### Environment Variables (from $_SERVER and $_ENV)
 
-`method` Cake\\Http\\ServerRequest::**getEnv**($key, $default = null): string|null
+`method` Cake\\Http\\ServerRequest::**getEnv**(string $key, ?string $default = null): string|null
 
 `ServerRequest::getEnv()` is a wrapper for `getenv()` global function and acts as
 a getter for environment variables without possible undefined keys:
@@ -311,7 +311,7 @@ To access all the environment variables in a request use `getServerParams()`:
 $env = $this->request->getServerParams();
 ```
 
-`method` Cake\\Http\\ServerRequest::**withEnv**($key, $value): static
+`method` Cake\\Http\\ServerRequest::**withEnv**(string $key, string $value): static
 
 `ServerRequest::withEnv()` is a wrapper for `putenv()` global function and acts as
 a setter for environment variables without having to modify globals
@@ -368,7 +368,7 @@ $base = $request->getAttribute('webroot');
 
 ### Checking Request Conditions
 
-`method` Cake\\Http\\ServerRequest::**is**($type, $args...): bool
+`method` Cake\\Http\\ServerRequest::**is**(array|string $type, mixed ...$args): bool
 
 The request object provides a way to inspect certain conditions in a given
 request. By using the `is()` method you can check a number of common
@@ -395,7 +395,7 @@ detectors. There are different types of detectors that you can create:
   to handle the check. The callback will receive the request object as its only
   parameter.
 
-`method` Cake\\Http\\ServerRequest::**addDetector**($name, $options): void
+`method` Cake\\Http\\ServerRequest::**addDetector**(string $name, Closure|array $options): void
 
 Some examples would be:
 
@@ -492,7 +492,7 @@ to use the session object.
 
 ### Host and Domain Name
 
-`method` Cake\\Http\\ServerRequest::**domain**($tldLength = 1): string
+`method` Cake\\Http\\ServerRequest::**domain**(int $tldLength = 1): string
 
 Returns the domain name your application is running on:
 
@@ -501,7 +501,7 @@ Returns the domain name your application is running on:
 echo $request->domain();
 ```
 
-`method` Cake\\Http\\ServerRequest::**subdomains**($tldLength = 1): array
+`method` Cake\\Http\\ServerRequest::**subdomains**(int $tldLength = 1): array
 
 Returns the subdomains your application is running on as an array:
 
@@ -532,7 +532,7 @@ echo $request->getMethod();
 
 ### Restricting Which HTTP method an Action Accepts
 
-`method` Cake\\Http\\ServerRequest::**allowMethod**($methods): bool
+`method` Cake\\Http\\ServerRequest::**allowMethod**(array|string $methods): bool
 
 Set allowed HTTP methods. If not matched, will throw
 `MethodNotAllowedException`. The 405 response will include the required
@@ -566,7 +566,7 @@ $hasAcceptHeader = $this->request->hasHeader('Accept');
 While some apache installs don't make the `Authorization` header accessible,
 CakePHP will make it available through apache specific methods as required.
 
-`method` Cake\\Http\\ServerRequest::**referer**($local = true): string|null
+`method` Cake\\Http\\ServerRequest::**referer**(bool $local = true): string|null
 
 Returns the referring address for the request.
 
@@ -608,7 +608,7 @@ proxy.
 
 ### Checking Accept Headers
 
-`method` Cake\\Http\\ServerRequest::**accepts**($type = null): array|bool
+`method` Cake\\Http\\ServerRequest::**accepts**(?string $type = null): array|bool
 
 Find out which content types the client accepts, or check whether it accepts a
 particular type of content.
@@ -625,7 +625,7 @@ Check for a single type:
 $acceptsJson = $this->request->accepts('application/json');
 ```
 
-`method` Cake\\Http\\ServerRequest::**acceptLanguage**($language = null): array|bool
+`method` Cake\\Http\\ServerRequest::**acceptLanguage**(?string $language = null): array|bool
 
 Get all the languages accepted by the client,
 or check whether a specific language is accepted.
@@ -717,7 +717,7 @@ tasks such as:
 
 ### Dealing with Content Types
 
-`method` Cake\\Http\\Response::**withType**($contentType = null): static
+`method` Cake\\Http\\Response::**withType**(string $contentType): static
 
 You can control the Content-Type of your application's responses with
 `Cake\Http\Response::withType()`. If your application needs to deal
@@ -836,7 +836,7 @@ redirect location header.
 
 ### Setting the Body
 
-`method` Cake\\Http\\Response::**withStringBody**($string): static
+`method` Cake\\Http\\Response::**withStringBody**(string $string): static
 
 To set a string as the response body, do the following:
 
@@ -891,7 +891,7 @@ $response = $response->withBody($stream);
 
 ### Setting the Character Set
 
-`method` Cake\\Http\\Response::**withCharset**($charset): static
+`method` Cake\\Http\\Response::**withCharset**(string $charset): static
 
 Sets the charset that will be used in the response:
 
@@ -919,7 +919,7 @@ public function index()
 > Disabling caching from SSL domains while trying to send
 > files to Internet Explorer can result in errors.
 
-`method` Cake\\Http\\Response::**withCache**($since, $time = '+1 day'): static
+`method` Cake\\Http\\Response::**withCache**(string $since, string $time = '+1 day'): static
 
 You can also tell clients that you want them to cache responses. By using
 `Cake\Http\Response::withCache()`:
@@ -957,7 +957,7 @@ or reverse proxy caching.
 
 #### The Cache Control Header
 
-`method` Cake\\Http\\Response::**withSharable**($public, $time = null): static
+`method` Cake\\Http\\Response::**withSharable**(bool $public, ?int $time = null): static
 
 Used under the expiration model, this header contains multiple indicators that
 can change the way browsers or proxies use the cached content. A
@@ -998,7 +998,7 @@ the `Cache-Control` header.
 
 #### The Expiration Header
 
-`method` Cake\\Http\\Response::**withExpires**($time): static
+`method` Cake\\Http\\Response::**withExpires**(DateTimeInterface|string $time): static
 
 You can set the `Expires` header to a date and time after which the response
 is no longer considered fresh. This header can be set using the
@@ -1016,7 +1016,7 @@ be parsed by the `DateTime` class.
 
 #### The Etag Header
 
-`method` Cake\\Http\\Response::**withEtag**($tag, $weak = false): static
+`method` Cake\\Http\\Response::**withEtag**(string $tag, bool $weak = false): static
 
 Cache validation in HTTP is often used when content is constantly changing, and
 asks the application to only generate the response contents if the cache is no
@@ -1059,7 +1059,7 @@ public function index()
 
 #### The Last Modified Header
 
-`method` Cake\\Http\\Response::**withModified**($time): static
+`method` Cake\\Http\\Response::**withModified**(DateTimeInterface|string $time): static
 
 Also, under the HTTP cache validation model, you can set the `Last-Modified`
 header to indicate the date and time at which the resource was modified for the
@@ -1085,7 +1085,7 @@ public function view()
 
 #### The Vary Header
 
-`method` Cake\\Http\\Response::**withVary**($header): static
+`method` Cake\\Http\\Response::**withVary**(string $header): static
 
 In some cases, you might want to serve different content using the same URL.
 This is often the case if you have a multilingual page or respond with different
@@ -1100,7 +1100,7 @@ $response = $this->response->withVary('Accept-Language');
 
 #### Sending Not-Modified Responses
 
-`method` Cake\\Http\\Response::**isNotModified**(Request $request): bool
+`method` Cake\\Http\\Response::**isNotModified**(ServerRequest $request): bool
 
 Compares the cache headers for the request object with the cache header from the
 response and determines whether it can still be considered fresh. If so, deletes

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -672,19 +672,19 @@ The required API for a CacheEngine is
 
 `class` Cake\\Cache\\**CacheEngine**
 
-`method` Cake\\Cache\\CacheEngine::**write**($key, $value)
+`method` Cake\\Cache\\CacheEngine::**write**(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
 
-`method` Cake\\Cache\\CacheEngine::**read**($key)
+`method` Cake\\Cache\\CacheEngine::**read**(string $key, mixed $default = null): mixed
 
-`method` Cake\\Cache\\CacheEngine::**delete**($key): bool
+`method` Cake\\Cache\\CacheEngine::**delete**(string $key): bool
 
-`method` Cake\\Cache\\CacheEngine::**clear**($check): bool
+`method` Cake\\Cache\\CacheEngine::**clear**(): bool
 
-`method` Cake\\Cache\\CacheEngine::**clearGroup**($group): bool
+`method` Cake\\Cache\\CacheEngine::**clearGroup**(string $group): bool
 
-`method` Cake\\Cache\\CacheEngine::**decrement**($key, $offset = 1): int|false
+`method` Cake\\Cache\\CacheEngine::**decrement**(string $key, int $offset = 1): int|false
 
-`method` Cake\\Cache\\CacheEngine::**increment**($key, $offset = 1): int|false
+`method` Cake\\Cache\\CacheEngine::**increment**(string $key, int $offset = 1): int|false
 
 ## Cache Events
 

--- a/docs/en/core-libraries/email.md
+++ b/docs/en/core-libraries/email.md
@@ -300,7 +300,7 @@ you want the filenames to appear in the recipient's mail client:
 
 ### Mailer::addAttachment()
 
-`method` Cake\\Mailer\\Mailer::**addAttachment**(\\Psr\\Http\\Message\\UploadedFileInterface|string $path, ?string $name, ?string $mimetype, ?string $contentId, ?bool $contentDisposition)
+`method` Cake\\Mailer\\Mailer::**addAttachment**(\\Psr\\Http\\Message\\UploadedFileInterface|string $path, ?string $name = null, ?string $mimetype = null, ?string $contentId = null, ?bool $contentDisposition = null): static
 
 You can also add attachments using the `addAttachment()` method.
 
@@ -546,7 +546,7 @@ query string arguments.
 
 ### Mailer::drop()
 
-`static` Cake\\Mailer\\Mailer::**drop**($key)
+`static` Cake\\Mailer\\Mailer::**drop**(string $config): bool
 
 Once configured, transports cannot be modified. In order to modify a transport
 you must first drop it and then reconfigure it.

--- a/docs/en/core-libraries/httpclient.md
+++ b/docs/en/core-libraries/httpclient.md
@@ -596,7 +596,7 @@ $this->mockClientDelete(/* ... */);
 
 ### Response::newClientResponse()
 
-`method` Cake\\Http\\TestSuite\\Response::**newClientResponse**(int $code = 200, array $headers = [], string $body = '')
+`method` Cake\\Http\\TestSuite\\Response::**newClientResponse**(int $code = 200, array $headers = [], string $body = ''): Cake\\Http\\Client\\Response
 
 As seen above you can use the `newClientResponse()` method to create responses
 for the requests your application will make. The headers need to be a list of

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -533,7 +533,7 @@ appropriate log level.
 
 ### Log::log()
 
-`method` Cake\\Log\\Log::**log**($msg, $level = LOG_ERR): bool
+`method` Cake\\Log\\Log::**log**(string $msg, string|int $level = LOG_ERR): bool
 
 ## Using Monolog
 

--- a/docs/en/development/debugging.md
+++ b/docs/en/development/debugging.md
@@ -69,7 +69,7 @@ The `Debugger.editorBasePath` configure option was added.
 
 ## Outputting Values
 
-`static` Cake\\Error\\Debugger::**dump**($var, $depth = 3): void
+`static` Cake\\Error\\Debugger::**dump**(mixed $var, int $maxDepth = 3): void
 
 Dump prints out the contents of a variable. It will print out all
 properties and methods (if any) of the supplied variable:
@@ -118,7 +118,7 @@ output masks.
 
 ## Logging With Stack Traces
 
-`static` Cake\\Error\\Debugger::**log**($var, $level = 7, $depth = 3): void
+`static` Cake\\Error\\Debugger::**log**(mixed $var, string|int $level = 'debug', int $maxDepth = 3): void
 
 Creates a detailed stack trace log at the time of invocation. The
 `log()` method prints out data similar to that done by
@@ -128,7 +128,7 @@ writable by the web server for `log()` to work correctly.
 
 ## Generating Stack Traces
 
-`static` Cake\\Error\\Debugger::**trace**($options): array|string
+`static` Cake\\Error\\Debugger::**trace**(array $options = []): array|string
 
 Returns the current stack trace. Each line of the trace includes
 the calling method, including which file and line the call
@@ -151,7 +151,7 @@ the order of currently running functions (stack frames).
 
 ## Getting an Excerpt From a File
 
-`static` Cake\\Error\\Debugger::**excerpt**($file, $line, $context): array
+`static` Cake\\Error\\Debugger::**excerpt**(string $file, int $line, int $context = 2): array
 
 Grab an excerpt from the file at `$path` (which is an absolute
 filepath), highlights line number `$line` with `$context` number of
@@ -176,7 +176,7 @@ Although this method is used internally, it can be handy if you're
 creating your own error messages or log entries for custom
 situations.
 
-`static` Debugger::**getType**($var): string
+`static` Cake\\Error\\Debugger::**getType**(mixed $var): string
 
 Get the type of a variable. Objects will return their class name
 

--- a/docs/en/development/errors.md
+++ b/docs/en/development/errors.md
@@ -555,7 +555,7 @@ In addition, CakePHP uses the following exceptions:
 These exception classes all extend `Exception`.
 By extending Exception, you can create your own 'framework' errors.
 
-`method` Class::**responseHeader**($header = null, $value = null)
+`method` Cake\\Http\\Exception\\HttpException::**setHeader**(string $header, array|string|null $value = null): void
 
 All Http and Cake exceptions extend the Exception class, which has a method
 to add headers to the response. For instance when throwing a 405

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -681,7 +681,7 @@ named. Nameless routes will not have the `_namePrefix` applied to them.
 
 ### Prefix Routing
 
-`static` Cake\\Routing\\RouteBuilder::**prefix**($name, $callback)
+`static` Cake\\Routing\\RouteBuilder::**prefix**(string $name, Closure|array $params = [], ?Closure $callback = null): static
 
 Many applications require an administration section where
 privileged users can make changes. This is often done through a
@@ -824,7 +824,7 @@ This would link to a controller with the namespace `App\Controller\Admin\MyPrefi
 
 ### Plugin Routing
 
-`static` Cake\\Routing\\RouteBuilder::**plugin**($name, $options = [], $callback)
+`static` Cake\\Routing\\RouteBuilder::**plugin**(string $name, Closure|array $options = [], ?Closure $callback = null): static
 
 Routes for [Plugins](../plugins) should be created using the `plugin()`
 method. This method creates a new routing scope for the plugin's routes:
@@ -987,7 +987,7 @@ echo Router::url([
 
 ### Routing File Extensions
 
-`method` Cake\\Routing\\RouteBuilder::**setExtensions**(array|string $extensions)
+`method` Cake\\Routing\\RouteBuilder::**setExtensions**(array|string $extensions): static
 
 To handle different file extensions in your URLs, you can define the extensions
 using the `Cake\Routing\RouteBuilder::setExtensions()` method:
@@ -1410,9 +1410,9 @@ Since `5` has a numeric key, it is treated as a passed argument.
 
 ## Generating URLs
 
-`static` Cake\\Routing\\RouteBuilder::**url**($url = null, $full = false)
+`static` Cake\\Routing\\Router::**url**(Psr\\Http\\Message\\UriInterface|array|string|null $url = null, bool $full = false): string
 
-`static` Cake\\Routing\\RouteBuilder::**reverse**($params, $full = false)
+`static` Cake\\Routing\\Router::**reverse**(Cake\\Http\\ServerRequest|array $params, bool $full = false): string
 
 Generating URLs or Reverse routing is a feature in CakePHP that is used to
 allow you to change your URL structure without having to modify all your code.
@@ -1793,7 +1793,7 @@ standard `plugin syntax`.
 
 ### Default Route Class
 
-`static` Cake\\Routing\\RouteBuilder::**setRouteClass**($routeClass = null)
+`method` Cake\\Routing\\RouteBuilder::**setRouteClass**(string $routeClass): static
 
 If you want to use an alternate route class for your routes besides the
 default `Route`, you can do so by calling `RouteBuilder::setRouteClass()`
@@ -1811,7 +1811,7 @@ Calling the method without an argument will return current default route class.
 
 ### Fallbacks Method
 
-`method` Cake\\Routing\\RouteBuilder::**fallbacks**($routeClass = null)
+`method` Cake\\Routing\\RouteBuilder::**fallbacks**(?string $routeClass = null): static
 
 The fallbacks method is a simple shortcut for defining default routes. The
 method uses the passed routing class for the defined rules or if no class is

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -390,7 +390,7 @@ In components, use `$this->getController()->getRequest()`.
 
 ## Reading & Writing Session Data
 
-`method` Session::**read**($key, $default = null): mixed
+`method` Session::**read**(?string $key = null, mixed $default = null): mixed
 
 You can read values from the session using `Hash::extract()`
 compatible syntax:
@@ -399,7 +399,7 @@ compatible syntax:
 $session->read('Config.language', 'en');
 ```
 
-`method` Session::**readOrFail**($key): mixed
+`method` Session::**readOrFail**(string $key): mixed
 
 The same as convenience wrapper around non-nullable return value:
 
@@ -410,7 +410,7 @@ $session->readOrFail('Config.language');
 This is useful, when you know this key has to be set and you don't want to have to check
 for the existence in code itself.
 
-`method` Session::**write**($key, $value): void
+`method` Session::**write**(array|string $key, mixed $value = null): void
 
 `$key` should be the dot separated path you wish to write `$value` to:
 
@@ -427,7 +427,7 @@ $session->write([
 ]);
 ```
 
-`method` Session::**delete**($key): void
+`method` Session::**delete**(string $key): void
 
 When you need to delete data from the session, you can use `delete()`:
 
@@ -448,7 +448,7 @@ When you need to read and delete data from the session, you can use
 $session->consume('Some.value');
 ```
 
-`method` Session::**check**($key): bool
+`method` Session::**check**(?string $key = null): bool
 
 If you want to see if data exists in the session, you can use `check()`:
 

--- a/docs/en/orm/entities.md
+++ b/docs/en/orm/entities.md
@@ -304,7 +304,7 @@ see [Exposing Virtual Fields](#exposing-virtual-fields).
 
 ## Checking if an Entity Has Been Modified
 
-`method` Cake\\ORM\\Entity::**isDirty**(?string $field = null)
+`method` Cake\\ORM\\Entity::**isDirty**(?string $field = null): bool
 
 You may want to make code conditional based on whether or not fields have
 changed in an entity. For example, you may only want to validate fields when

--- a/docs/en/orm/table-objects.md
+++ b/docs/en/orm/table-objects.md
@@ -408,7 +408,7 @@ You can manage event priorities in one of a few ways:
 
 ## Behaviors
 
-`method` Cake\\ORM\\Table::**addBehavior**($name, array $options = [])
+`method` Cake\\ORM\\Table::**addBehavior**(string $name, array $options = []): static
 
 <!-- start-behaviors -->
 

--- a/docs/en/views.md
+++ b/docs/en/views.md
@@ -154,7 +154,7 @@ the `h()` function:
 
 ### Setting View Variables
 
-`method` Cake\\View\\View::**set**(string $var, mixed $value)
+`method` Cake\\View\\View::**set**(array|string $name, mixed $value = null): static
 
 Views have a `set()` method that is analogous to the `set()` found in
 Controller objects. Using set() from your view file will add the variables to


### PR DESCRIPTION
## Summary

- Add missing parameter type declarations and return types to method signatures across 13 documentation files
- Fix incorrect class references (e.g. `RouteBuilder::url()` → `Router::url()`, `Class::responseHeader()` → `HttpException::setHeader()`)
- Update signatures to match CakePHP 5.x source code

Files updated: routing, caching, sessions, debugging, email, httpclient, logging, errors, request-response, entities, table-objects, views, console I/O.