### PR TITLE
Fix remaining method signature mismatches against CakePHP 5.x source

### DIFF
--- a/docs/en/console-commands/input-output.md
+++ b/docs/en/console-commands/input-output.md
@@ -179,7 +179,7 @@ The `BannerHelper` was added in 5.1
 
 ## Getting User Input
 
-`method` Cake\\Console\\ConsoleIo::**ask**(string $question, ?array $choices = null, ?string $default = null): string
+`method` Cake\\Console\\ConsoleIo::**ask**(string $prompt, ?string $default = null): string
 
 When building interactive console applications you'll need to get user input.
 CakePHP provides a way to do this:
@@ -196,7 +196,7 @@ Selection validation is case-insensitive.
 
 ## Creating Files
 
-`method` Cake\\Console\\ConsoleIo::**createFile**(string $path, string $contents): bool
+`method` Cake\\Console\\ConsoleIo::**createFile**(string $path, string $contents, bool $forceOverwrite = false): bool
 
 Creating files is often important part of many console commands that help
 automate development and deployment. The `createFile()` method gives you

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -395,7 +395,7 @@ detectors. There are different types of detectors that you can create:
   to handle the check. The callback will receive the request object as its only
   parameter.
 
-`method` Cake\\Http\\ServerRequest::**addDetector**(string $name, Closure|array $options): void
+`method` Cake\\Http\\ServerRequest::**addDetector**(string $name, Closure|array $detector): void
 
 Some examples would be:
 
@@ -809,7 +809,7 @@ public function sendIcs()
 
 ### Setting Headers
 
-`method` Cake\\Http\\Response::**withHeader**(string $header, string $value): static
+`method` Cake\\Http\\Response::**withHeader**(string $name, string|array $value): static
 
 Setting headers is done with the `Cake\Http\Response::withHeader()`
 method. Like all the PSR-7 interface methods, this method returns a *new*
@@ -836,7 +836,7 @@ redirect location header.
 
 ### Setting the Body
 
-`method` Cake\\Http\\Response::**withStringBody**(string $string): static
+`method` Cake\\Http\\Response::**withStringBody**(?string $string): static
 
 To set a string as the response body, do the following:
 
@@ -919,7 +919,7 @@ public function index()
 > Disabling caching from SSL domains while trying to send
 > files to Internet Explorer can result in errors.
 
-`method` Cake\\Http\\Response::**withCache**(string $since, string $time = '+1 day'): static
+`method` Cake\\Http\\Response::**withCache**(string|int $since, string|int $time = '+1 day'): static
 
 You can also tell clients that you want them to cache responses. By using
 `Cake\Http\Response::withCache()`:
@@ -998,7 +998,7 @@ the `Cache-Control` header.
 
 #### The Expiration Header
 
-`method` Cake\\Http\\Response::**withExpires**(DateTimeInterface|string $time): static
+`method` Cake\\Http\\Response::**withExpires**(DateTimeInterface|string|int|null $time): static
 
 You can set the `Expires` header to a date and time after which the response
 is no longer considered fresh. This header can be set using the
@@ -1016,7 +1016,7 @@ be parsed by the `DateTime` class.
 
 #### The Etag Header
 
-`method` Cake\\Http\\Response::**withEtag**(string $tag, bool $weak = false): static
+`method` Cake\\Http\\Response::**withEtag**(string $hash, bool $weak = false): static
 
 Cache validation in HTTP is often used when content is constantly changing, and
 asks the application to only generate the response contents if the cache is no
@@ -1059,7 +1059,7 @@ public function index()
 
 #### The Last Modified Header
 
-`method` Cake\\Http\\Response::**withModified**(DateTimeInterface|string $time): static
+`method` Cake\\Http\\Response::**withModified**(DateTimeInterface|string|int $time): static
 
 Also, under the HTTP cache validation model, you can set the `Last-Modified`
 header to indicate the date and time at which the resource was modified for the
@@ -1085,7 +1085,7 @@ public function view()
 
 #### The Vary Header
 
-`method` Cake\\Http\\Response::**withVary**(string $header): static
+`method` Cake\\Http\\Response::**withVary**(array|string $cacheVariances): static
 
 In some cases, you might want to serve different content using the same URL.
 This is often the case if you have a multilingual page or respond with different

--- a/docs/en/core-libraries/caching.md
+++ b/docs/en/core-libraries/caching.md
@@ -672,9 +672,9 @@ The required API for a CacheEngine is
 
 `class` Cake\\Cache\\**CacheEngine**
 
-`method` Cake\\Cache\\CacheEngine::**write**(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
+`method` Cake\\Cache\\CacheEngine::**set**(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
 
-`method` Cake\\Cache\\CacheEngine::**read**(string $key, mixed $default = null): mixed
+`method` Cake\\Cache\\CacheEngine::**get**(string $key, mixed $default = null): mixed
 
 `method` Cake\\Cache\\CacheEngine::**delete**(string $key): bool
 

--- a/docs/en/core-libraries/httpclient.md
+++ b/docs/en/core-libraries/httpclient.md
@@ -596,7 +596,7 @@ $this->mockClientDelete(/* ... */);
 
 ### Response::newClientResponse()
 
-`method` Cake\\Http\\TestSuite\\Response::**newClientResponse**(int $code = 200, array $headers = [], string $body = ''): Cake\\Http\\Client\\Response
+`method` Cake\\Http\\TestSuite\\HttpClientTrait::**newClientResponse**(int $code = 200, array $headers = [], string $body = ''): Cake\\Http\\Client\\Response
 
 As seen above you can use the `newClientResponse()` method to create responses
 for the requests your application will make. The headers need to be a list of

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -533,7 +533,7 @@ appropriate log level.
 
 ### Log::log()
 
-`method` Cake\\Log\\Log::**log**(string $msg, string|int $level = LOG_ERR): bool
+`method` Cake\\Log\\LogTrait::**log**(Stringable|string $message, string|int $level = LogLevel::ERROR, array|string $context = []): bool
 
 ## Using Monolog
 

--- a/docs/en/development/routing.md
+++ b/docs/en/development/routing.md
@@ -681,7 +681,7 @@ named. Nameless routes will not have the `_namePrefix` applied to them.
 
 ### Prefix Routing
 
-`static` Cake\\Routing\\RouteBuilder::**prefix**(string $name, Closure|array $params = [], ?Closure $callback = null): static
+`method` Cake\\Routing\\RouteBuilder::**prefix**(string $name, Closure|array $params = [], ?Closure $callback = null): static
 
 Many applications require an administration section where
 privileged users can make changes. This is often done through a
@@ -824,7 +824,7 @@ This would link to a controller with the namespace `App\Controller\Admin\MyPrefi
 
 ### Plugin Routing
 
-`static` Cake\\Routing\\RouteBuilder::**plugin**(string $name, Closure|array $options = [], ?Closure $callback = null): static
+`method` Cake\\Routing\\RouteBuilder::**plugin**(string $name, Closure|array $options = [], ?Closure $callback = null): static
 
 Routes for [Plugins](../plugins) should be created using the `plugin()`
 method. This method creates a new routing scope for the plugin's routes:

--- a/docs/en/development/sessions.md
+++ b/docs/en/development/sessions.md
@@ -390,7 +390,7 @@ In components, use `$this->getController()->getRequest()`.
 
 ## Reading & Writing Session Data
 
-`method` Session::**read**(?string $key = null, mixed $default = null): mixed
+`method` Session::**read**(?string $name = null, mixed $default = null): mixed
 
 You can read values from the session using `Hash::extract()`
 compatible syntax:
@@ -399,7 +399,7 @@ compatible syntax:
 $session->read('Config.language', 'en');
 ```
 
-`method` Session::**readOrFail**(string $key): mixed
+`method` Session::**readOrFail**(string $name): mixed
 
 The same as convenience wrapper around non-nullable return value:
 
@@ -410,7 +410,7 @@ $session->readOrFail('Config.language');
 This is useful, when you know this key has to be set and you don't want to have to check
 for the existence in code itself.
 
-`method` Session::**write**(array|string $key, mixed $value = null): void
+`method` Session::**write**(array|string $name, mixed $value = null): void
 
 `$key` should be the dot separated path you wish to write `$value` to:
 
@@ -427,7 +427,7 @@ $session->write([
 ]);
 ```
 
-`method` Session::**delete**(string $key): void
+`method` Session::**delete**(string $name): void
 
 When you need to delete data from the session, you can use `delete()`:
 
@@ -448,7 +448,7 @@ When you need to read and delete data from the session, you can use
 $session->consume('Some.value');
 ```
 
-`method` Session::**check**(?string $key = null): bool
+`method` Session::**check**(?string $name = null): bool
 
 If you want to see if data exists in the session, you can use `check()`:
 


### PR DESCRIPTION
## Summary

Follow-up to #8215. Fixes remaining signature mismatches verified against the CakePHP 5.x source code:

- RouteBuilder::prefix/plugin are instance methods, not static
- CacheEngine: write/read renamed to set/get per PSR-16
- Session: parameter names $key -> $name to match source
- ServerRequest::addDetector: parameter $options -> $detector
- Response: fix nullable types, union types, and parameter names for withStringBody, withCache, withExpires, withEtag, withModified, withVary, withHeader
- ConsoleIo::ask: correct to 2 params ($prompt, $default), not 3
- ConsoleIo::createFile: add missing $forceOverwrite param
- LogTrait::log: add Stringable type, $context param, fix class attribution
- newClientResponse: class is HttpClientTrait, not Response