### PR TITLE
Fix Authentication plugin v4 tutorial corrections

### DIFF
--- a/docs/en/tutorials-and-examples/cms/authentication.md
+++ b/docs/en/tutorials-and-examples/cms/authentication.md
@@ -45,7 +45,7 @@ Because we want to hash the password each time it is set, we'll use a mutator/se
 CakePHP will call a convention based setter method any time a property is set in one of your
 entities. Let's add a setter for the password in **src/Model/Entity/User.php**:
 
-```php {3,12-18}
+```php {4,12-18}
 <?php
 namespace App\Model\Entity;
 
@@ -109,7 +109,7 @@ In **src/Application.php**, add the following imports:
 use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\AuthenticationServiceProviderInterface;
-use Authentication\Identifier\AbstractIdentifier;
+use Authentication\Identifier\PasswordIdentifier;
 use Authentication\Middleware\AuthenticationMiddleware;
 use Psr\Http\Message\ServerRequestInterface;
 ```
@@ -123,11 +123,9 @@ class Application extends BaseApplication
 {
 ```
 
-Then add the following methods:
+Then add the following to your `middleware()` method:
 
-::: code-group
-
-```php [middleware()]
+```php
 // src/Application.php
 public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
 {
@@ -142,7 +140,9 @@ public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
 }
 ```
 
-```php [getAuthenticationService()]
+Next, add the `getAuthenticationService()` method:
+
+```php
 // src/Application.php
 public function getAuthenticationService(ServerRequestInterface $request): AuthenticationServiceInterface
 {
@@ -160,8 +160,8 @@ public function getAuthenticationService(ServerRequestInterface $request): Authe
     ]);
 
     $fields = [
-        AbstractIdentifier::CREDENTIAL_USERNAME => 'email',
-        AbstractIdentifier::CREDENTIAL_PASSWORD => 'password',
+        PasswordIdentifier::CREDENTIAL_USERNAME => 'email',
+        PasswordIdentifier::CREDENTIAL_PASSWORD => 'password',
     ];
 
     // Load the authenticators. Session should be first.
@@ -175,17 +175,14 @@ public function getAuthenticationService(ServerRequestInterface $request): Authe
             'action' => 'login',
         ],
         'identifier' => [
-            'Authentication.Password' => [
-                'fields' => $fields,
-            ],
+            'className' => 'Authentication.Password',
+            'fields' => $fields,
         ],
     ]);
 
     return $service;
 }
 ```
-
-:::
 
 ### Configuring the AppController
 
@@ -232,9 +229,8 @@ If you visit your site, you'll get an "infinite redirect loop" so let's fix that
 
 In your `UsersController`, add the following code:
 
-::: code-group
-
-```php [UsersController.php]
+```php
+// src/Controller/UsersController.php
 public function beforeFilter(\Cake\Event\EventInterface $event): void
 {
     parent::beforeFilter($event);
@@ -260,7 +256,10 @@ public function login()
 }
 ```
 
-```php [templates/Users/login.php]
+Next, add the template for your login action:
+
+```php
+<!-- templates/Users/login.php -->
 <div class="users form content">
     <?= $this->Flash->render() ?>
     <h3>Login</h3>
@@ -276,8 +275,6 @@ public function login()
     <?= $this->Html->link("Add User", ['action' => 'add']) ?>
 </div>
 ```
-
-:::
 
 Now the login page will allow us to correctly login into the application.
 Test it by requesting any page of your site. After being redirected


### PR DESCRIPTION
## Summary

Fixes issues in the Authentication v4 tutorial that was recently updated.

### Corrections

1. **PasswordIdentifier instead of AbstractIdentifier** - The `CREDENTIAL_USERNAME` and `CREDENTIAL_PASSWORD` constants moved to `PasswordIdentifier` in v4

2. **Identifier config format** - v4 uses flat config with `className` key:
   ```php
   'identifier' => [
       'className' => 'Authentication.Password',
       'fields' => $fields,
   ],
   ```
   Not nested array format.

3. **Separate code blocks** - Split the middleware() and getAuthenticationService() code-group into separate blocks. Code-group tabs suggest "pick one" but these are "do both sequentially"

4. **Line highlighting** - Fixed `{3}` → `{4}` for User entity (line 3 is empty, line 4 is the import)