### PR TITLE
Update documentation for Migrations 5.0

### DIFF
--- a/docs/en/contents.md
+++ b/docs/en/contents.md
@@ -63,7 +63,7 @@
 - [Authorization](https://book.cakephp.org/authorization/3/)
 - [Bake](https://book.cakephp.org/bake/3/)
 - [Debug Kit](https://book.cakephp.org/debugkit/5/)
-- [Migrations](https://book.cakephp.org/migrations/4/)
+- [Migrations](https://book.cakephp.org/migrations/5/)
 - [Elasticsearch](https://book.cakephp.org/elasticsearch/4/)
 - [Phinx](https://book.cakephp.org/phinx/0/en/)
 - [Chronos](https://book.cakephp.org/chronos/3/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -144,7 +144,7 @@ bin/cake migrations migrate
 
 # Step 4: (Optional) Generate and run seed data
 bin/cake bake seed Articles
-bin/cake migrations seed
+bin/cake seeds run Articles
 ```
 
 ```php [Migration File]

--- a/docs/en/migrations.md
+++ b/docs/en/migrations.md
@@ -1,3 +1,3 @@
 # Migrations
 
-This page has [moved](https://book.cakephp.org/migrations/4/).
+This page has [moved](https://book.cakephp.org/migrations/5/).

--- a/docs/en/tutorials-and-examples/cms/database.md
+++ b/docs/en/tutorials-and-examples/cms/database.md
@@ -198,7 +198,7 @@ The seed data above stores passwords in **plain text** for initial setup purpose
 Run the seeders:
 
 ```bash
-bin/cake migrations seed
+bin/cake seeds run
 ```
 
 ### Option B: Using Raw SQL
@@ -321,7 +321,7 @@ conventions will save you time as you can leverage the convention-based defaults
 CakePHP provides.
 
 ::: tip Learn More
-Read more about database migrations and seeding in the [Migrations documentation](https://book.cakephp.org/migrations/4/).
+Read more about database migrations and seeding in the [Migrations documentation](https://book.cakephp.org/migrations/5/).
 :::
 
 With the database built, we can now build our [Models](../../tutorials-and-examples/cms/articles-model).

--- a/docs/ja/contents.md
+++ b/docs/ja/contents.md
@@ -64,7 +64,7 @@
 - [Authorization](https://book.cakephp.org/authorization/2/)
 - [Bake](https://book.cakephp.org/bake/2/ja/)
 - [Debug Kit](https://book.cakephp.org/debugkit/4/ja/)
-- [Migrations](https://book.cakephp.org/migrations/3/ja/)
+- [Migrations](https://book.cakephp.org/migrations/5/)
 - [Elasticsearch](https://book.cakephp.org/elasticsearch/3/ja/)
 - [Phinx](https://book.cakephp.org/phinx/0/ja/)
 - [Chronos](https://book.cakephp.org/chronos/2/ja/)

--- a/docs/ja/migrations.md
+++ b/docs/ja/migrations.md
@@ -1,3 +1,3 @@
 # Migrations
 
-このページは [移動しました](https://book.cakephp.org/migrations/3/ja/) 。
+このページは [移動しました](https://book.cakephp.org/migrations/5/) 。


### PR DESCRIPTION
## Summary

- Update redirect links from Migrations 4 to Migrations 5
- Update seed command syntax from `bin/cake migrations seed` to `bin/cake seeds run` (Migrations 5.0 change)
- Update Japanese documentation links (were pointing to v3)

Ref: https://github.com/cakephp/migrations/releases/tag/5.0.0