### PR TITLE
Reorder CMS Tutorial Sidebar Navigation (4.x) 

### DIFF
--- a/toc_en.json
+++ b/toc_en.json
@@ -97,16 +97,16 @@
               "link": "/tutorials-and-examples/cms/articles-controller"
             },
             {
+              "text": "Tags and Users",
+              "link": "/tutorials-and-examples/cms/tags-and-users"
+            },
+            {
               "text": "Authentication",
               "link": "/tutorials-and-examples/cms/authentication"
             },
             {
               "text": "Authorization",
               "link": "/tutorials-and-examples/cms/authorization"
-            },
-            {
-              "text": "Tags and Users",
-              "link": "/tutorials-and-examples/cms/tags-and-users"
             }
           ]
         }

--- a/toc_ja.json
+++ b/toc_ja.json
@@ -97,16 +97,16 @@
               "link": "/ja/tutorials-and-examples/cms/articles-controller"
             },
             {
+              "text": "タグとユーザー",
+              "link": "/ja/tutorials-and-examples/cms/tags-and-users"
+            },
+            {
               "text": "認証",
               "link": "/ja/tutorials-and-examples/cms/authentication"
             },
             {
               "text": "認可",
               "link": "/ja/tutorials-and-examples/cms/authorization"
-            },
-            {
-              "text": "タグとユーザー",
-              "link": "/ja/tutorials-and-examples/cms/tags-and-users"
             }
           ]
         }


### PR DESCRIPTION
### Summary

Reorders the CMS Tutorial sidebar in the documentation to improve the learning flow:
- Installation
- Database  
- Articles Controller
- Tags and Users (moved up)
- Authentication (moved after Tags and Users)
- Authorization (moved after Authentication)

This change moves "Tags and Users" before "Authentication" and "Authorization" as the content requires "Tags and Users" to be completed before "Authentication". This helps avoid confusion. 
 
### Changes

- `toc_en.json`: Reordered CMS Tutorial sidebar
- `toc_ja.json`: Reordered CMS Tutorial sidebar (Japanese)

###  Notes
- Applies to 4.x branch
- Same change may be needed for 5.x branch