### PR TITLE
Reorder CMS Tutorial Sidebar Navigation (5.x)

### DIFF
--- a/toc_en.json
+++ b/toc_en.json
@@ -30,12 +30,16 @@
                   "link": "/tutorials-and-examples/cms/database"
                 },
                 {
+                  "text": "Articles Model",
+                  "link": "/tutorials-and-examples/cms/articles-model"
+                },
+                {
                   "text": "Articles Controller",
                   "link": "/tutorials-and-examples/cms/articles-controller"
                 },
                 {
-                  "text": "Articles Model",
-                  "link": "/tutorials-and-examples/cms/articles-model"
+                  "text": "Tags and Users",
+                  "link": "/tutorials-and-examples/cms/tags-and-users"
                 },
                 {
                   "text": "Authentication",
@@ -44,10 +48,6 @@
                 {
                   "text": "Authorization",
                   "link": "/tutorials-and-examples/cms/authorization"
-                },
-                {
-                  "text": "Tags and Users",
-                  "link": "/tutorials-and-examples/cms/tags-and-users"
                 }
               ]
             }

--- a/toc_ja.json
+++ b/toc_ja.json
@@ -80,16 +80,16 @@
               "link": "/ja/tutorials-and-examples/cms/articles-controller"
             },
             {
+              "text": "タグとユーザー",
+              "link": "/ja/tutorials-and-examples/cms/tags-and-users"
+            },
+            {
               "text": "認証",
               "link": "/ja/tutorials-and-examples/cms/authentication"
             },
             {
               "text": "認可",
               "link": "/ja/tutorials-and-examples/cms/authorization"
-            },
-            {
-              "text": "タグとユーザー",
-              "link": "/ja/tutorials-and-examples/cms/tags-and-users"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Reorders the CMS Tutorial sidebar in the documentation to improve the learning flow:
- Installation
- Database
- Articles Model
- Articles Controller 
- Tags and Users
- Authentication
- Authorization

This change moves "Articles Model" before "Articles Controller", and "Tags and Users" before "Authentication" and "Authorization" as the content requires these sections to be completed in order. This helps avoid confusion and provides a better learning flow.

## Changes
- `toc_en.json`: Reordered CMS Tutorial sidebar
- `toc_ja.json`: Reordered CMS Tutorial sidebar (Japanese)

## Notes
- Applies to 5.x branch
- Same change was made for 4.x branch (PR #8235)