### PR TITLE
Fix definition list formatting after Markdown migration

### DIFF
--- a/docs/en/contributing/cakephp-coding-conventions.md
+++ b/docs/en/contributing/cakephp-coding-conventions.md
@@ -411,40 +411,18 @@ be preceded by a newline.
 
 Variable types for use in DocBlocks:
 
-Type
-Description
-
-mixed
-A variable with undefined (or multiple) type.
-
-int
-Integer type variable (whole number).
-
-float
-Float type (point number).
-
-bool
-Logical type (true or false).
-
-string
-String type (any value in " " or ' ').
-
-null
-Null type. Usually used in conjunction with another type.
-
-array
-Array type.
-
-object
-Object type. A specific class name should be used if possible.
-
-resource
-Resource type (returned by for example mysql_connect()).
-Remember that when you specify the type as mixed, you should indicate
-whether it is unknown, or what the possible types are.
-
-callable
-Callable function.
+| Type | Description |
+|------|-------------|
+| mixed | A variable with undefined (or multiple) type. |
+| int | Integer type variable (whole number). |
+| float | Float type (point number). |
+| bool | Logical type (true or false). |
+| string | String type (any value in " " or ' '). |
+| null | Null type. Usually used in conjunction with another type. |
+| array | Array type. |
+| object | Object type. A specific class name should be used if possible. |
+| resource | Resource type (returned by for example mysql_connect()). Remember that when you specify the type as mixed, you should indicate whether it is unknown, or what the possible types are. |
+| callable | Callable function. |
 
 You can also combine types using the pipe char:
 

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -782,12 +782,12 @@ $response = $this->response->withFile(
 The supported options are:
 
 name
-The name allows you to specify an alternate file name to be sent to
-the user.
+: The name allows you to specify an alternate file name to be sent to
+  the user.
 
 download
-A boolean value indicating whether headers should be set to force
-download.
+: A boolean value indicating whether headers should be set to force
+  download.
 
 ### Sending a String as a File
 

--- a/docs/en/core-libraries/logging.md
+++ b/docs/en/core-libraries/logging.md
@@ -467,7 +467,7 @@ more information.
 `static` Cake\\Log\\Log::**configured**(): array
 
 returns
-An array of configured loggers.
+: An array of configured loggers.
 
 Get the names of the configured loggers.
 

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -87,11 +87,11 @@ Below is a description of the variables and how they affect your CakePHP
 application.
 
 debug
-Changes CakePHP debugging output. `false` = Production mode. No error
-messages, errors, or warnings shown. `true` = Errors and warnings shown.
+: Changes CakePHP debugging output. `false` = Production mode. No error
+  messages, errors, or warnings shown. `true` = Errors and warnings shown.
 
 App.namespace
-The namespace to find app classes under.
+: The namespace to find app classes under.
 
 > [!NOTE]
 > When changing the namespace in your configuration, you will also
@@ -102,78 +102,77 @@ The namespace to find app classes under.
 <div id="core-configuration-baseurl">
 
 App.baseUrl
-Un-comment this definition if you **don’t** plan to use Apache’s
-mod_rewrite with CakePHP. Don’t forget to remove your .htaccess
-files too.
+: Un-comment this definition if you **don't** plan to use Apache's
+  mod_rewrite with CakePHP. Don't forget to remove your .htaccess
+  files too.
 
 App.base
-The base directory the app resides in. If `false` this
-will be auto detected. If not `false`, ensure your string starts
-with a `/` and does NOT end with a `/`. For example, `/basedir` is a valid
-App.base.
+: The base directory the app resides in. If `false` this
+  will be auto detected. If not `false`, ensure your string starts
+  with a `/` and does NOT end with a `/`. For example, `/basedir` is a valid
+  App.base.
 
 App.encoding
-Define what encoding your application uses. This encoding
-is used to generate the charset in the layout, and encode entities.
-It should match the encoding values specified for your database.
+: Define what encoding your application uses. This encoding
+  is used to generate the charset in the layout, and encode entities.
+  It should match the encoding values specified for your database.
 
 App.webroot
-The webroot directory.
+: The webroot directory.
 
 App.wwwRoot
-The file path to webroot.
+: The file path to webroot.
 
 App.fullBaseUrl
-The fully qualified domain name (including protocol) to your application's
-root. This is used when generating absolute URLs. By default, this value
-is generated using the `$_SERVER` environment. However, you should define it
-manually to optimize performance or if you are concerned about people
-manipulating the `Host` header.
-In a CLI context (from command) the `fullBaseUrl` cannot be read from $_SERVER,
-as there is no webserver involved. You do need to specify it yourself if
-you do need to generate URLs from a shell (for example, when sending emails).
+: The fully qualified domain name (including protocol) to your application's
+  root. This is used when generating absolute URLs. By default, this value
+  is generated using the `$_SERVER` environment. However, you should define it
+  manually to optimize performance or if you are concerned about people
+  manipulating the `Host` header.
+  In a CLI context (from command) the `fullBaseUrl` cannot be read from $_SERVER,
+  as there is no webserver involved. You do need to specify it yourself if
+  you do need to generate URLs from a shell (for example, when sending emails).
 
 App.imageBaseUrl
-Web path to the public images directory under webroot. If you are using
-a `CDN` you should set this value to the CDN's location.
+: Web path to the public images directory under webroot. If you are using
+  a `CDN` you should set this value to the CDN's location.
 
 App.cssBaseUrl
-Web path to the public css directory under webroot. If you are using
-a `CDN` you should set this value to the CDN's location.
+: Web path to the public css directory under webroot. If you are using
+  a `CDN` you should set this value to the CDN's location.
 
 App.jsBaseUrl
-Web path to the public js directory under webroot. If you are using
-a `CDN` you should set this value to the CDN's location.
+: Web path to the public js directory under webroot. If you are using
+  a `CDN` you should set this value to the CDN's location.
 
 App.paths
-Configure paths for non class based resources. Supports the
-`plugins`, `templates`, `locales` subkeys, which allow the definition
-of paths for plugins, view templates and locale files respectively.
+: Configure paths for non class based resources. Supports the
+  `plugins`, `templates`, `locales` subkeys, which allow the definition
+  of paths for plugins, view templates and locale files respectively.
 
 App.uploadedFilesAsObjects
-Defines whether uploaded files are being represented as objects (`true`),
-or arrays (`false`). This option is being treated as enabled by default.
-See the [File Uploads section](../controllers/request-response#request-file-uploads) in the Request &
-Response Objects chapter for more information.
+: Defines whether uploaded files are being represented as objects (`true`),
+  or arrays (`false`). This option is being treated as enabled by default.
+  See the [File Uploads section](../controllers/request-response#request-file-uploads) in the Request &
+  Response Objects chapter for more information.
 
 Security.salt
-A random string used in hashing. This value is also used as the
-HMAC salt when doing symmetric encryption.
+: A random string used in hashing. This value is also used as the
+  HMAC salt when doing symmetric encryption.
 
 Asset.timestamp
-Appends a timestamp which is last modified time of the particular
-file at the end of asset files URLs (CSS, JavaScript, Image) when
-using proper helpers. Valid values:
-
-- (bool) `false` - Doesn't do anything (default)
-- (bool) `true` - Appends the timestamp when debug is `true`
-- (string) 'force' - Always appends the timestamp.
+: Appends a timestamp which is last modified time of the particular
+  file at the end of asset files URLs (CSS, JavaScript, Image) when
+  using proper helpers. Valid values:
+  - (bool) `false` - Doesn't do anything (default)
+  - (bool) `true` - Appends the timestamp when debug is `true`
+  - (string) 'force' - Always appends the timestamp.
 
 Asset.cacheTime
-Sets the asset cache time. This determines the http header `Cache-Control`'s
-`max-age`, and the http header's `Expire`'s time for assets.
-This can take anything that you version of PHP's [strtotime function](https://php.net/manual/en/function.strtotime.php) can take.
-The default is `+1 day`.
+: Sets the asset cache time. This determines the http header `Cache-Control`'s
+  `max-age`, and the http header's `Expire`'s time for assets.
+  This can take anything that you version of PHP's [strtotime function](https://php.net/manual/en/function.strtotime.php) can take.
+  The default is `+1 day`.
 
 </div>
 

--- a/docs/en/development/configuration.md
+++ b/docs/en/development/configuration.md
@@ -164,9 +164,9 @@ Asset.timestamp
 : Appends a timestamp which is last modified time of the particular
   file at the end of asset files URLs (CSS, JavaScript, Image) when
   using proper helpers. Valid values:
-  - (bool) `false` - Doesn't do anything (default)
-  - (bool) `true` - Appends the timestamp when debug is `true`
-  - (string) 'force' - Always appends the timestamp.
+  (bool) `false` - Doesn't do anything (default),
+  (bool) `true` - Appends the timestamp when debug is `true`,
+  (string) 'force' - Always appends the timestamp.
 
 Asset.cacheTime
 : Sets the asset cache time. This determines the http header `Cache-Control`'s

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -189,98 +189,98 @@ There are a number of keys supported in database configuration. A full list is
 as follows:
 
 className
-The fully namespaced class name of the class that represents the connection to a database server.
-This class is responsible for loading the database driver, providing SQL
-transaction mechanisms and preparing SQL statements among other things.
+: The fully namespaced class name of the class that represents the connection to a database server.
+  This class is responsible for loading the database driver, providing SQL
+  transaction mechanisms and preparing SQL statements among other things.
 
 driver
-The class name of the driver used to implement all specificities for
-a database engine. This can either be a short classname using `plugin syntax`,
-a fully namespaced name, or a constructed driver instance.
-Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.
+: The class name of the driver used to implement all specificities for
+  a database engine. This can either be a short classname using `plugin syntax`,
+  a fully namespaced name, or a constructed driver instance.
+  Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.
 
 persistent
-Whether or not to use a persistent connection to the database. This option
-is not supported by SqlServer. An exception is thrown if you attempt to set
-`persistent` to `true` with SqlServer.
+: Whether or not to use a persistent connection to the database. This option
+  is not supported by SqlServer. An exception is thrown if you attempt to set
+  `persistent` to `true` with SqlServer.
 
 host
-The database server's hostname (or IP address).
+: The database server's hostname (or IP address).
 
 username
-The username for the account.
+: The username for the account.
 
 password
-The password for the account.
+: The password for the account.
 
 database
-The name of the database for this connection to use. Avoid using `.` in
-your database name. Because of how it complicates identifier quoting CakePHP
-does not support `.` in database names. The path to your SQLite database
-should be an absolute path (for example, `ROOT . DS . 'my_app.db'`) to avoid
-incorrect paths caused by relative paths.
+: The name of the database for this connection to use. Avoid using `.` in
+  your database name. Because of how it complicates identifier quoting CakePHP
+  does not support `.` in database names. The path to your SQLite database
+  should be an absolute path (for example, `ROOT . DS . 'my_app.db'`) to avoid
+  incorrect paths caused by relative paths.
 
 port (*optional*)
-The TCP port or Unix socket used to connect to the server.
+: The TCP port or Unix socket used to connect to the server.
 
 encoding
-Indicates the character set to use when sending SQL statements to
-the server. This defaults to the database's default encoding for
-all databases other than DB2.
+: Indicates the character set to use when sending SQL statements to
+  the server. This defaults to the database's default encoding for
+  all databases other than DB2.
 
 timezone
-Server timezone to set.
+: Server timezone to set.
 
 schema
-Used in PostgreSQL database setups to specify which schema to use.
+: Used in PostgreSQL database setups to specify which schema to use.
 
 unix_socket
-Used by drivers that support it to connect via Unix socket files. If you are
-using PostgreSQL and want to use Unix sockets, leave the host key blank.
+: Used by drivers that support it to connect via Unix socket files. If you are
+  using PostgreSQL and want to use Unix sockets, leave the host key blank.
 
 ssl_key
-The file path to the SSL key file. (Only supported by MySQL).
+: The file path to the SSL key file. (Only supported by MySQL).
 
 ssl_cert
-The file path to the SSL certificate file. (Only supported by MySQL).
+: The file path to the SSL certificate file. (Only supported by MySQL).
 
 ssl_ca
-The file path to the SSL certificate authority. (Only supported by MySQL).
+: The file path to the SSL certificate authority. (Only supported by MySQL).
 
 init
-A list of queries that should be sent to the database server as
-when the connection is created.
+: A list of queries that should be sent to the database server as
+  when the connection is created.
 
 log
-Set to `true` to enable query logging. When enabled queries will be logged
-at a `debug` level with the `queriesLog` scope.
+: Set to `true` to enable query logging. When enabled queries will be logged
+  at a `debug` level with the `queriesLog` scope.
 
 quoteIdentifiers
-Set to `true` if you are using reserved words or special characters in
-your table or column names. Enabling this setting will result in queries
-built using the [Query Builder](../orm/query-builder) having identifiers quoted when
-creating SQL. It should be noted that this decreases performance because
-each query needs to be traversed and manipulated before being executed.
+: Set to `true` if you are using reserved words or special characters in
+  your table or column names. Enabling this setting will result in queries
+  built using the [Query Builder](../orm/query-builder) having identifiers quoted when
+  creating SQL. It should be noted that this decreases performance because
+  each query needs to be traversed and manipulated before being executed.
 
 flags
-An associative array of PDO constants that should be passed to the
-underlying PDO instance. See the PDO documentation for the flags supported
-by the driver you are using.
+: An associative array of PDO constants that should be passed to the
+  underlying PDO instance. See the PDO documentation for the flags supported
+  by the driver you are using.
 
 cacheMetadata
-Either boolean `true`, or a string containing the cache configuration to
-store meta data in. Having metadata caching disabled by setting it to `false`
-is not advised and can result in very poor performance. See the
-[Database Metadata Cache](#database-metadata-cache) section for more information.
+: Either boolean `true`, or a string containing the cache configuration to
+  store meta data in. Having metadata caching disabled by setting it to `false`
+  is not advised and can result in very poor performance. See the
+  [Database Metadata Cache](#database-metadata-cache) section for more information.
 
 mask
-Set the permissions on the generated database file. (Only supported by SQLite)
+: Set the permissions on the generated database file. (Only supported by SQLite)
 
 cache
-The `cache` flag to send to SQLite.
+: The `cache` flag to send to SQLite.
 
 mode
-The `mode` flag value to send to SQLite.
+: The `mode` flag value to send to SQLite.
 
 ### SqlServer Entra Authentication
 
@@ -387,115 +387,115 @@ the same names for similar data types, CakePHP provides a set of abstracted
 data types for use with the database layer. The types CakePHP supports are:
 
 string
-Maps to `VARCHAR` type. In SQL Server the `NVARCHAR` types are used.
+: Maps to `VARCHAR` type. In SQL Server the `NVARCHAR` types are used.
 
 char
-Maps to `CHAR` type. In SQL Server the `NCHAR` type is used.
+: Maps to `CHAR` type. In SQL Server the `NCHAR` type is used.
 
 text
-Maps to `TEXT` types.
+: Maps to `TEXT` types.
 
 uuid
-Maps to the UUID type if a database provides one, otherwise this will
-generate a `CHAR(36)` field.
+: Maps to the UUID type if a database provides one, otherwise this will
+  generate a `CHAR(36)` field.
 
 binaryuuid
-Maps to the UUID type if the database provides one, otherwise this will
-generate a `BINARY(16)` column. Binary UUIDs provide more efficient storage
-compared to string UUIDs by storing the UUID as 16 bytes of binary data rather
-than a 36-character string. This type automatically handles conversion between
-string UUID format (with dashes) and binary format.
+: Maps to the UUID type if the database provides one, otherwise this will
+  generate a `BINARY(16)` column. Binary UUIDs provide more efficient storage
+  compared to string UUIDs by storing the UUID as 16 bytes of binary data rather
+  than a 36-character string. This type automatically handles conversion between
+  string UUID format (with dashes) and binary format.
 
 nativeuuid
-Maps to the UUID type in MySQL with MariaDb. In all other databases,
-`nativeuuid` is an alias for `uuid`.
+: Maps to the UUID type in MySQL with MariaDb. In all other databases,
+  `nativeuuid` is an alias for `uuid`.
 
 integer
-Maps to the `INTEGER` type provided by the database. BIT is not yet supported
-at this moment.
+: Maps to the `INTEGER` type provided by the database. BIT is not yet supported
+  at this moment.
 
 smallinteger
-Maps to the `SMALLINT` type provided by the database.
+: Maps to the `SMALLINT` type provided by the database.
 
 tinyinteger
-Maps to the `TINYINT` or `SMALLINT` type provided by the database. In MySQL
-`TINYINT(1)` is treated as a boolean.
+: Maps to the `TINYINT` or `SMALLINT` type provided by the database. In MySQL
+  `TINYINT(1)` is treated as a boolean.
 
 biginteger
-Maps to the `BIGINT` type provided by the database.
+: Maps to the `BIGINT` type provided by the database.
 
 float
-Maps to either `DOUBLE` or `FLOAT` depending on the database. The `precision`
-option can be used to define the precision used.
+: Maps to either `DOUBLE` or `FLOAT` depending on the database. The `precision`
+  option can be used to define the precision used.
 
 decimal
-Maps to the `DECIMAL` type. Supports the `length` and `precision`
-options. Values for decimal type ares be represented as strings (not as float
-as some might expect). This is because decimal types are used to represent
-exact numeric values in databases and using float type for them in PHP can
-potentially lead to precision loss.
+: Maps to the `DECIMAL` type. Supports the `length` and `precision`
+  options. Values for decimal type ares be represented as strings (not as float
+  as some might expect). This is because decimal types are used to represent
+  exact numeric values in databases and using float type for them in PHP can
+  potentially lead to precision loss.
 
-If you want the values to be `float` in your PHP code then consider using
-`FLOAT` or `DOUBLE` type columns in your database. Also, depending on your use
-case you can explicitly map your decimal columns to `float` type in your table
-schema.
+  If you want the values to be `float` in your PHP code then consider using
+  `FLOAT` or `DOUBLE` type columns in your database. Also, depending on your use
+  case you can explicitly map your decimal columns to `float` type in your table
+  schema.
 
 boolean
-Maps to `BOOLEAN` except in MySQL, where `TINYINT(1)` is used to represent
-booleans. `BIT(1)` is not yet supported at this moment.
+: Maps to `BOOLEAN` except in MySQL, where `TINYINT(1)` is used to represent
+  booleans. `BIT(1)` is not yet supported at this moment.
 
 binary
-Maps to the `BLOB` or `BYTEA` type provided by the database.
+: Maps to the `BLOB` or `BYTEA` type provided by the database.
 
 date
-Maps to a native `DATE` column type. The return value of this column
-type is `Cake\I18n\Date` which emulates the date related
-methods of PHP's `DateTime` class.
+: Maps to a native `DATE` column type. The return value of this column
+  type is `Cake\I18n\Date` which emulates the date related
+  methods of PHP's `DateTime` class.
 
 datetime
-See [Datetime Type](#datetime-type).
+: See [Datetime Type](#datetime-type).
 
 datetimefractional
-See [Datetime Type](#datetime-type).
+: See [Datetime Type](#datetime-type).
 
 timestamp
-Maps to the `TIMESTAMP` type.
+: Maps to the `TIMESTAMP` type.
 
 timestampfractional
-Maps to the `TIMESTAMP(N)` type.
+: Maps to the `TIMESTAMP(N)` type.
 
 time
-Maps to a `TIME` type in all databases.
+: Maps to a `TIME` type in all databases.
 
 year
-Maps to the `YEAR` type. Only supported in MySQL.
+: Maps to the `YEAR` type. Only supported in MySQL.
 
 json
-Maps to a `JSON` type if it's available, otherwise it maps to `TEXT`.
+: Maps to a `JSON` type if it's available, otherwise it maps to `TEXT`.
 
 enum
-See [Enum Type](#enum-type).
+: See [Enum Type](#enum-type).
 
 geometry
-Maps to a generic geometry storage type.
+: Maps to a generic geometry storage type.
 
 point
-Maps to a single point in geospatial storage.
+: Maps to a single point in geospatial storage.
 
 linestring
-Maps to a single line in geospatial storage.
+: Maps to a single line in geospatial storage.
 
 polygon
-Maps to a single polygon in geospatial storage.
+: Maps to a single polygon in geospatial storage.
 
 inet
-Maps to the `INET` type. Only implemented in postgres.
+: Maps to the `INET` type. Only implemented in postgres.
 
 cidr
-Maps to the `CIDR` type. Only implemented in postgres.
+: Maps to the `CIDR` type. Only implemented in postgres.
 
 macaddr
-Maps to the `MACADDR` type. Only implemented in postgres.
+: Maps to the `MACADDR` type. Only implemented in postgres.
 
 These types are used in both the schema reflection features that CakePHP
 provides, and schema generation features CakePHP uses when using test fixtures.

--- a/docs/en/orm/saving-data.md
+++ b/docs/en/orm/saving-data.md
@@ -1008,12 +1008,12 @@ inserted. For the case that the record already has associated records in the
 database, you have the choice between two saving strategies:
 
 append
-Associated records are updated in the database or, if not matching any
-existing record, inserted.
+: Associated records are updated in the database or, if not matching any
+  existing record, inserted.
 
 replace
-Any existing records that do not match the records provided will be deleted
-from the database. Only provided records will remain (or be inserted).
+: Any existing records that do not match the records provided will be deleted
+  from the database. Only provided records will remain (or be inserted).
 
 By default, the `append` saving strategy is used.
 See [Has Many Associations](../orm/associations#has-many-associations) for details on defining the `saveStrategy`.
@@ -1071,15 +1071,15 @@ When saving belongsToMany associations, you have the choice between two saving
 strategies:
 
 append
-Only new links will be created between each side of this association. This
-strategy will not destroy existing links even though they may not be present
-in the array of entities to be saved.
+: Only new links will be created between each side of this association. This
+  strategy will not destroy existing links even though they may not be present
+  in the array of entities to be saved.
 
 replace
-When saving, existing links will be removed and new links will be created in
-the junction table. If there are existing link in the database to some of
-the entities intended to be saved, those links will be updated, not deleted
-and then re-saved.
+: When saving, existing links will be removed and new links will be created in
+  the junction table. If there are existing link in the database to some of
+  the entities intended to be saved, those links will be updated, not deleted
+  and then re-saved.
 
 See [Belongs To Many Associations](../orm/associations#belongs-to-many-associations) for details on defining the `saveStrategy`.
 

--- a/docs/en/views/helpers/form.md
+++ b/docs/en/views/helpers/form.md
@@ -395,56 +395,24 @@ The type of control created (when we provide no additional options to specify th
 generated element type) is inferred via model introspection and
 depends on the column datatype:
 
-Column Type
-Resulting Form Field
-
-string, uuid (char, varchar, etc.)
-text
-
-boolean, tinyint(1)
-checkbox
-
-decimal
-number
-
-float
-number
-
-integer
-number
-
-text
-textarea
-
-text, with name of password, passwd
-password
-
-text, with name of email
-email
-
-text, with name of tel, telephone, or phone
-tel
-
-date
-date
-
-datetime, timestamp
-datetime-local
-
-datetimefractional, timestampfractional
-datetime-local
-
-time
-time
-
-month
-month
-
-year
-select with years
-
-binary
-file
+| Column Type | Resulting Form Field |
+|-------------|----------------------|
+| string, uuid (char, varchar, etc.) | text |
+| boolean, tinyint(1) | checkbox |
+| decimal | number |
+| float | number |
+| integer | number |
+| text | textarea |
+| text, with name of password, passwd | password |
+| text, with name of email | email |
+| text, with name of tel, telephone, or phone | tel |
+| date | date |
+| datetime, timestamp | datetime-local |
+| datetimefractional, timestampfractional | datetime-local |
+| time | time |
+| month | month |
+| year | select with years |
+| binary | file |
 
 The `$options` parameter allows you to choose a specific control type if
 you need to:


### PR DESCRIPTION
## Summary

- Updates definition lists to use `markdown-it-deflist` syntax for proper `<dl>/<dt>/<dd>` rendering
- Converts some two-column data structures to markdown tables where more appropriate

### Syntax Change

Before:
```markdown
term
Description text here.
```

After:
```markdown
term
: Description text here.
```

### Files Updated

| File | Changes |
|------|---------|
| `orm/database-basics.md` | Config keys, data types → deflist syntax |
| `views/helpers/form.md` | Column type mappings → markdown table |
| `contributing/cakephp-coding-conventions.md` | Variable types → markdown table |
| `orm/saving-data.md` | Save strategies → deflist syntax |
| `controllers/request-response.md` | File options → deflist syntax |
| `core-libraries/logging.md` | Return value → deflist syntax |
| `development/configuration.md` | App config keys → deflist syntax |

## Dependencies

This PR requires the `markdown-it-deflist` plugin to be added to docs-skeleton:
- https://github.com/cakephp/docs-skeleton/pull/5

Fixes #8246