### PR TITLE
fix: typo in japanese document

### DIFF
--- a/docs/ja/development/dependency-injection.md
+++ b/docs/ja/development/dependency-injection.md
@@ -211,7 +211,7 @@ class BillingServiceProvider extends ServiceProvider
 
     public function services(ContainerInterface $container): void
     {
-        $container->add(StripService::class);
+        $container->add(StripeService::class);
         $container->add('configKey', 'some value');
     }
 }


### PR DESCRIPTION
### what i have done

- fix `StripService` into `StripeService`

** before **
```php
    public function services(ContainerInterface $container): void
    {
        $container->add(StripService::class);
        $container->add('configKey', 'some value');
    }
```

** after **
```php
    public function services(ContainerInterface $container): void
    {
        $container->add(StripeService::class);
        $container->add('configKey', 'some value');
    }
```