### PR TITLE
Fix: inconsistency between condition and error message in `abort()` example

### DIFF
--- a/docs/en/console-commands/commands.md
+++ b/docs/en/console-commands/commands.md
@@ -212,7 +212,7 @@ to terminate execution:
 public function execute(Arguments $args, ConsoleIo $io): int
 {
     $name = $args->getArgument('name');
-    if (mb_strlen($name) < 5) {
+    if (mb_strlen($name) < 4) {
         // Halt execution, output to stderr, and set exit code to 1
         $io->error('Name must be at least 4 characters long.');
         $this->abort();
@@ -228,7 +228,7 @@ You can also use `abort()` on the `$io` object to emit a message and code:
 public function execute(Arguments $args, ConsoleIo $io): int
 {
     $name = $args->getArgument('name');
-    if (mb_strlen($name) < 5) {
+    if (mb_strlen($name) < 4) {
         // Halt execution, output to stderr, and set exit code to 99
         $io->abort('Name must be at least 4 characters long.', 99);
     }

--- a/docs/ja/console-commands/commands.md
+++ b/docs/ja/console-commands/commands.md
@@ -196,7 +196,7 @@ class UserCommand extends Command
 public function execute(Arguments $args, ConsoleIo $io)
 {
     $name = $args->getArgument('name');
-    if (strlen($name) < 5) {
+    if (strlen($name) < 4) {
         // 実行を停止し、標準エラーに出力し、終了コードを 1 に設定
         $io->error('Name must be at least 4 characters long.');
         $this->abort();
@@ -210,7 +210,7 @@ public function execute(Arguments $args, ConsoleIo $io)
 public function execute(Arguments $args, ConsoleIo $io)
 {
     $name = $args->getArgument('name');
-    if (strlen($name) < 5) {
+    if (strlen($name) < 4) {
         // 実行を停止しstderrに出力し、終了コードを99に設定します
         $io->abort('名前は4文字以上にする必要があります。', 99);
     }


### PR DESCRIPTION
## Summary
Fix the condition in the `abort()` examples to match the error message.

## Changes
- [Changed `strlen($name) < 5` to `strlen($name) < 4` in the Japanese documentation to match the error message "at least 4 characters long."](https://github.com/cakephp/docs/commit/766893c139ce2950f30c58d8a1d6d5c1c5858da1)
- [Changed `strlen($name) < 5` to `mb_strlen($name) < 4` in the English documentation](https://github.com/cakephp/docs/commit/7278b7f710850598ae5dfbbc1871a3e8de06b4f6)

## Related Issue
Closes #8266