### PR TITLE
re-organize plugins to navbar

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -19,6 +19,31 @@ const versions = {
   ],
 };
 
+const plugins = {
+  text: "Plugins",
+  items: [
+    {
+      text: "Core Plugins",
+      items: [
+        { text: "Authentication", link: "https://book.cakephp.org/authentication/", target: "_self" },
+        { text: "Authorization", link: "https://book.cakephp.org/authorization/", target: "_self" },
+        { text: "Bake", link: "https://book.cakephp.org/bake/", target: "_self" },
+        { text: "Chronos", link: "https://book.cakephp.org/chronos/", target: "_self" },
+        { text: "Debug Kit", link: "https://book.cakephp.org/debugkit/", target: "_self" },
+        { text: "Elasticsearch", link: "https://book.cakephp.org/elasticsearch/", target: "_self" },
+        { text: "Migrations", link: "https://book.cakephp.org/migrations/", target: "_self" },
+        { text: "Phinx", link: "https://book.cakephp.org/phinx/", target: "_self" },
+      ],
+    },
+    {
+      text: "Community",
+      items: [
+        { text: "Community Plugins", link: "https://plugins.cakephp.org/", target: "_self" },
+      ],
+    },
+  ],
+};
+
 const substitutions = {
   '|phpversion|': { value: '8.5', format: 'bold' },
   '|minphpversion|': { value: '8.2', format: 'italic' },
@@ -53,7 +78,7 @@ export default {
     nav: [
       { text: "Guide", link: "/intro" },
       { text: "API", link: "https://api.cakephp.org/" },
-      { text: "Documentation", link: "/" },
+      { ...plugins },
       { ...versions },
     ],
   },
@@ -70,6 +95,7 @@ export default {
           { text: "ガイド", link: "/ja/intro" },
           { text: "API", link: "https://api.cakephp.org/" },
           { text: "ドキュメント", link: "/ja/" },
+          { ...plugins },
           { ...versions },
         ],
         sidebar: toc_ja,

--- a/.vitepress/toc_en.json
+++ b/.vitepress/toc_en.json
@@ -306,29 +306,10 @@
           "text": "Dependency Injection",
           "link": "/development/dependency-injection"
         },
+        { "text": "plugins", "link": "/plugins" },
         { "text": "Errors", "link": "/development/errors" },
         { "text": "REST", "link": "/development/rest" },
         { "text": "Testing", "link": "/development/testing" }
-      ]
-    },
-    {
-      "text": "Plugins",
-      "collapsed": true,
-      "items": [
-        { "text": "Creating Plugins", "link": "/plugins" },
-        {
-          "text": "Core Plugins",
-          "items": [
-            { "text": "Authentication", "link": "https://book.cakephp.org/authentication/" },
-            { "text": "Authorization", "link": "https://book.cakephp.org/authorization/" },
-            { "text": "Bake", "link": "https://book.cakephp.org/bake/" },
-            { "text": "Chronos", "link": "https://book.cakephp.org/chronos/" },
-            { "text": "Debug Kit", "link": "https://book.cakephp.org/debugkit/" },
-            { "text": "Elasticsearch", "link": "https://book.cakephp.org/elasticsearch/" },
-            { "text": "Migrations", "link": "https://book.cakephp.org/migrations/" },
-            { "text": "Phinx", "link": "https://book.cakephp.org/phinx/" }
-          ]
-        }
       ]
     },
     {

--- a/.vitepress/toc_ja.json
+++ b/.vitepress/toc_ja.json
@@ -394,27 +394,10 @@
           "text": "依存性注入",
           "link": "/ja/development/dependency-injection"
         },
+        { "text": "プラグイン", "link": "/ja/plugins" },
         { "text": "エラー", "link": "/ja/development/errors" },
         { "text": "REST", "link": "/ja/development/rest" },
         { "text": "テスト", "link": "/ja/development/testing" }
-      ]
-    },
-    {
-      "text": "プラグイン",
-      "collapsed": true,
-      "items": [
-        { "text": "プラグインの作成", "link": "/ja/plugins" },
-        {
-          "text": "コアプラグイン",
-          "items": [
-            { "text": "Bake", "link": "https://book.cakephp.org/bake/2/en/index.html" },
-            { "text": "Chronos", "link": "https://book.cakephp.org/chronos/" },
-            { "text": "Debug Kit", "link": "https://book.cakephp.org/debugkit/" },
-            { "text": "Elasticsearch", "link": "https://book.cakephp.org/elasticsearch/" },
-            { "text": "マイグレーション", "link": "https://book.cakephp.org/migrations/" },
-            { "text": "Phinx", "link": "https://book.cakephp.org/phinx/" }
-          ]
-        }
       ]
     },
     {


### PR DESCRIPTION
This moves plugins into a deticated navbar dropdown + link to the new community plugins page.

<img width="2928" height="2296" alt="image" src="https://github.com/user-attachments/assets/e3ca61b2-e6db-4267-bc9a-3457f02177b3" />

And moving `Plugins > Creating plugins` under `Development > Plugins` in the sidebar
