### PR TITLE
"bin/cake seeds run" does not exist, replacing with "bin/cake migrations seed" in the CMS tutorial docs

### DIFF
--- a/docs/en/tutorials-and-examples/cms/database.md
+++ b/docs/en/tutorials-and-examples/cms/database.md
@@ -198,7 +198,7 @@ The seed data above stores passwords in **plain text** for initial setup purpose
 Run the seeders:
 
 ```bash
-bin/cake seeds run
+bin/cake migrations seed
 ```
 
 ### Option B: Using Raw SQL


### PR DESCRIPTION
The command does not exist (anymore?), instead use "bin/cake migrations seed". I found this out through "bin/cake migrations --help"