### PR TITLE
Precision about OptionParser 'separator'

### DIFF
--- a/docs/en/console-commands/option-parsers.md
+++ b/docs/en/console-commands/option-parsers.md
@@ -158,7 +158,7 @@ of the option:
 - `multiple` - The option can be provided multiple times. The parsed option
   will be an array of values when this option is enabled.
 - `separator` - A character sequence that the option value is split into an
-  array with. Require `multiple` sets to `true`.
+  array with. Requires `multiple` set to `true`.
 - `choices` - An array of valid choices for this option. If left empty all
   values are valid. An exception will be raised when parse() encounters an
   invalid value.

--- a/docs/en/console-commands/option-parsers.md
+++ b/docs/en/console-commands/option-parsers.md
@@ -158,7 +158,7 @@ of the option:
 - `multiple` - The option can be provided multiple times. The parsed option
   will be an array of values when this option is enabled.
 - `separator` - A character sequence that the option value is split into an
-  array with.
+  array with. Require `multiple` sets to `true`.
 - `choices` - An array of valid choices for this option. If left empty all
   values are valid. An exception will be raised when parse() encounters an
   invalid value.


### PR DESCRIPTION
Clarified requirement for 'separator' option to require 'multiple' to be true.