### PR TITLE
Document PostgreSQL index access method reflection

### DIFF
--- a/docs/en/appendices/5-4-migration-guide.md
+++ b/docs/en/appendices/5-4-migration-guide.md
@@ -98,6 +98,12 @@ version is reported as `unknown`), the header is omitted.
   See [Query Builder](../orm/query-builder#advanced-conditions).
 - Added `inOrNull()` and `notInOrNull()` methods for combining `IN` conditions with `IS NULL`.
 - Added `isDistinctFrom()` and `isNotDistinctFrom()` methods for null-safe comparisons.
+- Added PostgreSQL index access method reflection. Non-btree indexes (`gin`,
+  `gist`, `spgist`, `brin`, `hash`) are now reflected with an `accessMethod`
+  field and regenerated with the correct `USING` clause. The `Index` class
+  provides constants (`Index::GIN`, `Index::GIST`, `Index::SPGIST`,
+  `Index::BRIN`, `Index::HASH`) for these access methods.
+  See [Reading Indexes and Constraints](../orm/schema-system#reading-indexes-and-constraints).
 
 ### I18n
 

--- a/docs/en/orm/schema-system.md
+++ b/docs/en/orm/schema-system.md
@@ -182,6 +182,28 @@ $indexes = $schema->indexes()
 $index = $schema->index('author_id_idx')
 ```
 
+#### PostgreSQL Index Access Methods
+
+::: info Added in version 5.4.0
+:::
+
+When reflecting indexes on PostgreSQL, non-btree indexes include an
+`accessMethod` field identifying the underlying index type (`gin`, `gist`,
+`spgist`, `brin`, `hash`). Schemas generated from these reflections will emit
+the appropriate `USING` clause when recreating the index.
+
+```php
+$schema->addIndex('articles_tags_idx', [
+    'columns' => ['tags'],
+    'type' => 'index',
+    'accessMethod' => 'gin',
+]);
+```
+
+The `Cake\Database\Schema\Index` class exposes constants for the supported
+access methods: `Index::GIN`, `Index::GIST`, `Index::SPGIST`, `Index::BRIN`,
+and `Index::HASH`. Btree indexes (the default) omit the `accessMethod` field.
+
 ### Adding Table Options
 
 Some drivers (primarily MySQL) support and require additional table metadata. In


### PR DESCRIPTION
## Summary

Documents cakephp/cakephp#19369 which added PostgreSQL index access method reflection (gin, gist, spgist, brin, hash).

- Added 5.4 migration guide entry under Database
- Added new "PostgreSQL Index Access Methods" subsection in the schema system docs with example and class constants