### PR TITLE
Document EXCEPT and EXCEPT ALL set operations

### DIFF
--- a/docs/en/appendices/5-4-migration-guide.md
+++ b/docs/en/appendices/5-4-migration-guide.md
@@ -98,6 +98,10 @@ version is reported as `unknown`), the header is omitted.
   See [Query Builder](../orm/query-builder#advanced-conditions).
 - Added `inOrNull()` and `notInOrNull()` methods for combining `IN` conditions with `IS NULL`.
 - Added `isDistinctFrom()` and `isNotDistinctFrom()` methods for null-safe comparisons.
+- Added `except()` and `exceptAll()` methods on `SelectQuery` for `EXCEPT`
+  and `EXCEPT ALL` set operations. `EXCEPT ALL` is supported on PostgreSQL
+  and recent MySQL/MariaDB versions; it is not supported on SQLite or SQL Server.
+  See [Query Builder](../orm/query-builder#except).
 - Added PostgreSQL index access method reflection. Non-btree indexes (`gin`,
   `gist`, `spgist`, `brin`, `hash`) are now reflected with an `accessMethod`
   field and regenerated with the correct `USING` clause. The `Index` class

--- a/docs/en/orm/query-builder.md
+++ b/docs/en/orm/query-builder.md
@@ -2200,6 +2200,39 @@ $unpublished->intersectAll($inReview);
 `intersect()` and `intersectAll()` were added.
 :::
 
+### Except
+
+Except operations allow you to return rows from one query that do not appear
+in another query. Except queries are created by composing one or more select
+queries together:
+
+```php
+$allArticles = $articles->find();
+
+$published = $articles->find()
+    ->where(['published' => true]);
+
+$allArticles->except($published);
+```
+
+You can create `EXCEPT ALL` queries using the `exceptAll()` method:
+
+```php
+$allArticles = $articles->find();
+
+$published = $articles->find()
+    ->where(['published' => true]);
+
+$allArticles->exceptAll($published);
+```
+
+`EXCEPT ALL` is supported on PostgreSQL and recent MySQL/MariaDB versions.
+It is not supported on SQLite or SQL Server.
+
+::: info Added in version 5.4.0
+`except()` and `exceptAll()` were added.
+:::
+
 ### Subqueries
 
 Subqueries enable you to compose queries together and build conditions and


### PR DESCRIPTION
## Summary

Documents the new `except()` and `exceptAll()` methods on `SelectQuery` added
in [cakephp/cakephp#19385](https://github.com/cakephp/cakephp/pull/19385).

- Adds an "Except" subsection to the Query Builder page after Intersections
- Notes that `EXCEPT ALL` is supported on PostgreSQL and recent MySQL/MariaDB
  versions, but not on SQLite or SQL Server
- Adds an entry to the 5.4 migration guide under Database