### PR TITLE
Doc for `Text::mask()`

### DIFF
--- a/docs/en/appendices/5-4-migration-guide.md
+++ b/docs/en/appendices/5-4-migration-guide.md
@@ -71,6 +71,7 @@ version is reported as `unknown`), the header is omitted.
 - A backwards compatible Container implementation has been added to the core. You can opt-in to use it instead of the current
   `league/container` implementation by setting `App.container` to `cake` inside your `config/app.php`.
   See [Dependency Injection Container](../development/dependency-injection) for more details.
+- `Text::mask()` was added to mask a portion of a string with a repeated character. See [Text Masking](../core-libraries/text.md#text-masking) for more details.
 
 ### Commands
 

--- a/docs/en/appendices/5-4-migration-guide.md
+++ b/docs/en/appendices/5-4-migration-guide.md
@@ -71,7 +71,6 @@ version is reported as `unknown`), the header is omitted.
 - A backwards compatible Container implementation has been added to the core. You can opt-in to use it instead of the current
   `league/container` implementation by setting `App.container` to `cake` inside your `config/app.php`.
   See [Dependency Injection Container](../development/dependency-injection) for more details.
-- `Text::mask()` was added to mask a portion of a string with a repeated character. See [Text Masking](../core-libraries/text.md#text-masking) for more details.
 
 ### Commands
 
@@ -135,6 +134,7 @@ version is reported as `unknown`), the header is omitted.
   path manipulation. See [Filesystem Utilities](../core-libraries/filesystem.md).
 - `Security::encrypt()` can now be configured to use longer keys with separate encryption and authentication keys that are derived from the provided key.
   You can set `Security.encryptWithRawKey` to enable this behavior. See [here](https://github.com/cakephp/cakephp/pull/19325) for more details.
+- Added `Text::mask()` method which masks a portion of a string with a repeated character. See [Text Masking](../core-libraries/text.md#text-masking) for more details.
 
 ### Collection
 

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -453,4 +453,32 @@ Output:
 
     red, orange, yellow, green, blue, indigo and violet
 
+## Text Masking
+
+### Text::mask()
+
+`method` Cake\\Utility\\Text::**mask**(string $string, int $offset, ?int $length = null, string $maskCharacter = '*'): string
+
+Masks a portion of a string with a repeated character.
+
+Replaces characters starting at `$offset` for `$length` characters with `$maskCharacter`.
+If `$length` is `null`, masking continues to the end of the string.
+Negative offsets are supported and are calculated from the end of the string.
+
+```php
+$creditCardNumber = '4909090909091234';
+
+// Called as TextHelper
+echo $this->Text->mask($creditCardNumber, 0, 12, '*');
+
+// Called as Text
+use Cake\Utility\Text;
+
+echo Text::mask($creditCardNumber, 0, 12, '*');
+```
+
+Output:
+
+    ************1234
+
 <!-- end-text -->


### PR DESCRIPTION
## Summary
Adds documentation for the newly implemented `Text::mask()` method in `Cake\Utility\Text`, which allows masking a portion of a string using a repeated character.

Includes:
- Explanation of the function
- Examples demonstrating usage via `TextHelper` and static calls

Related:  this [PR](https://github.com/cakephp/cakephp/pull/19398).
