### PR TITLE
Doc for `Text::maskValue()`

### DIFF
--- a/docs/en/appendices/5-4-migration-guide.md
+++ b/docs/en/appendices/5-4-migration-guide.md
@@ -156,6 +156,7 @@ version is reported as `unknown`), the header is omitted.
 - `Security::encrypt()` can now be configured to use longer keys with separate encryption and authentication keys that are derived from the provided key.
   You can set `Security.encryptWithRawKey` to enable this behavior. See [here](https://github.com/cakephp/cakephp/pull/19325) for more details.
 - Added `Text::mask()` method which masks a portion of a string with a repeated character. See [Text Masking](../core-libraries/text.md#text-masking) for more details.
+- Added `Text::maskValue()` method which masks all occurrences of given substrings within a string using a repeated character. See [Text Masking](../core-libraries/text.md#text-masking) for more details.
 
 ### View
 

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -465,6 +465,22 @@ Replaces characters starting at `$offset` for `$length` characters with `$maskCh
 If `$length` is `null`, masking continues to the end of the string.
 Negative offsets are supported and are calculated from the end of the string.
 
+```php
+$creditCardNumber = '4909090909091234';
+
+// Called as TextHelper
+echo $this->Text->mask($creditCardNumber, 0, 12, '*');
+
+// Called as Text
+use Cake\Utility\Text;
+
+echo Text::mask($creditCardNumber, 0, 12, '*');
+```
+
+Output:
+
+    ************1234
+
 ### Text::maskValue()
 
 `method` Cake\\Utility\\Text::**maskValue**(string $string, array $needles, string $maskCharacter = '*'): string
@@ -486,5 +502,4 @@ echo Text::maskValue('4111111111111234', ['411', '112'], '*');
 Output:
 
     ***11111111***34
-
 <!-- end-text -->

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -465,20 +465,26 @@ Replaces characters starting at `$offset` for `$length` characters with `$maskCh
 If `$length` is `null`, masking continues to the end of the string.
 Negative offsets are supported and are calculated from the end of the string.
 
+### Text::maskValue()
+
+`method` Cake\\Utility\\Text::**maskValue**(string $string, array $needles, string $maskCharacter = '*'): string
+
+Masks all occurrences of given substring(s) within a string using a repeated character.
+Each occurrence of the provided substring(s) will be replaced by a sequence of the masking character.
+
 ```php
-$creditCardNumber = '4909090909091234';
 
 // Called as TextHelper
-echo $this->Text->mask($creditCardNumber, 0, 12, '*');
+echo $this->Text->maskValue('4111111111111234', ['411', '112'], '*');
 
 // Called as Text
 use Cake\Utility\Text;
 
-echo Text::mask($creditCardNumber, 0, 12, '*');
+echo Text::maskValue('4111111111111234', ['411', '112'], '*');
 ```
 
 Output:
 
-    ************1234
+    ***11111111***34
 
 <!-- end-text -->

--- a/docs/en/core-libraries/text.md
+++ b/docs/en/core-libraries/text.md
@@ -489,7 +489,6 @@ Masks all occurrences of given substring(s) within a string using a repeated cha
 Each occurrence of the provided substring(s) will be replaced by a sequence of the masking character.
 
 ```php
-
 // Called as TextHelper
 echo $this->Text->maskValue('4111111111111234', ['411', '112'], '*');
 


### PR DESCRIPTION
## Summary
Adds documentation for the newly implemented `Text::maskValue()` method in `Cake\Utility\Text`, which allows masking of all occurrences of given substring(s) within a string using a repeated character. 

Includes:
- Explanation of the function
- Examples demonstrating usage via `TextHelper` and static calls

Related:  this [PR](https://github.com/cakephp/cakephp/pull/19404).

This is how it looks in the function page:
<img width="676" height="431" alt="image" src="https://github.com/user-attachments/assets/65b8a8f2-0391-4e51-a73e-1871c76b2963" />

This is how it looks in the migration guide:
<img width="677" height="278" alt="image" src="https://github.com/user-attachments/assets/7d1b5808-1492-4e83-b745-dbe027b0b531" />
