### PR TITLE
Document LoggedQuery::setRedactor()

### DIFF
--- a/docs/en/appendices/5-4-migration-guide.md
+++ b/docs/en/appendices/5-4-migration-guide.md
@@ -171,6 +171,11 @@ See [Application and Plugin Events](../core-libraries/events#registering-event-l
   `label()` implementation backed by the translator and the attribute lets
   individual cases override the derived label. See
   [EnumLabelTrait and the Label Attribute](../orm/database-basics#enumlabeltrait-and-the-label-attribute).
+- Added `LoggedQuery::setRedactor()` to scrub sensitive values from query
+  logs. Applies to `__toString()`, `getContext()`, and `jsonSerialize()`,
+  so file logs, structured loggers, and anything that JSON-encodes a
+  `LoggedQuery` all see the redacted shape.
+  See [Redacting Sensitive Values from Query Logs](../orm/database-basics#redacting-sensitive-values-from-query-logs).
 
 ### Http
 

--- a/docs/en/orm/database-basics.md
+++ b/docs/en/orm/database-basics.md
@@ -1257,6 +1257,43 @@ Log::setConfig('queries', [
 > never leave query logging on in production as it will negatively impact the
 > performance of your application.
 
+### Redacting Sensitive Values from Query Logs
+
+Query log lines render the executed SQL with bound parameters spliced
+back in, so any secret bound as a parameter (encryption keys,
+passwords, OAuth tokens) ends up in every surface that consumes a
+`LoggedQuery` — file logs via `__toString()`, structured loggers via
+`getContext()`, and anything that re-serialises the LoggedQuery as JSON
+via `jsonSerialize()`.
+
+`Cake\Database\Log\LoggedQuery::setRedactor()` registers a global
+`Closure` invoked before any of those exit points are exposed. The
+closure receives the raw query string and bound params and must return
+a 2-element array `[string $query, array $params]` with sensitive
+values replaced:
+
+```php
+use Cake\Database\Log\LoggedQuery;
+
+// In Application::bootstrap() or equivalent.
+LoggedQuery::setRedactor(function (string $query, array $params): array {
+    foreach ($params as $key => $value) {
+        if (in_array($key, ['password', 'token', 'apiKey'], true)) {
+            $params[$key] = '«REDACTED»';
+        }
+    }
+    return [$query, $params];
+});
+```
+
+The hook fires in `interpolate()`, `getContext()`, and `jsonSerialize()`,
+so every public exit path is covered. Pass `null` to clear a previously
+registered redactor.
+
+A redactor that throws or returns a malformed value is silently ignored
+for that call — the raw query and params are used as a safe fallback so
+a faulty redactor cannot break logging.
+
 ## Identifier Quoting
 
 By default, CakePHP does **not** quote identifiers in generated SQL queries. The


### PR DESCRIPTION
Documents `Cake\Database\Log\LoggedQuery::setRedactor()` introduced in cakephp/cakephp#19419.

## Where the docs live

- New subsection **"Redacting Sensitive Values from Query Logs"** under the existing **Query Logging** section in `docs/en/orm/database-basics.md`. Covers:
  - Why the hook exists (bound secrets get spliced into rendered SQL via `LoggedQuery::__toString` / `getContext` / `jsonSerialize`).
  - How to register a redactor closure.
  - The three exit points it applies to.
  - Silent-fallback behaviour for redactors that throw or return malformed values.
- One-line entry in `docs/en/appendices/5-4-migration-guide.md` under the existing **Database** new-features list, linking back to the new subsection.

## Pairs with

- cakephp/cakephp#19419 (the implementation, against `5.next`).

Filed as **draft** until the implementation PR merges and a target release is tagged. Will flip to "Ready for review" then.
