### PR TITLE
chore: delete redundant particle `を`

### DIFF
--- a/docs/ja/core-libraries/hash.md
+++ b/docs/ja/core-libraries/hash.md
@@ -636,7 +636,7 @@ public function noop(array $array)
 
 `static` Cake\\Utility\\Hash::**reduce**(array $data, $path, $function)
 
-`$path` で抽出し、抽出結果を `$function` で縮小（reduce）することでを単一の値を作ります。
+`$path` で抽出し、抽出結果を `$function` で縮小（reduce）することで単一の値を作ります。
 このメソッドでは式とマッチャーの両方を使うことができます。
 
 `static` Cake\\Utility\\Hash::**apply**(array $data, $path, $function)


### PR DESCRIPTION
### Changes
- Fixed typo in `path/to/file.md`
- Removed duplicate `を` that caused grammatically incorrect Japanese

## Why
The duplicated particle made the sentence grammatically incorrect in Japanese. 
This is a minor typo fix to improve readability for Japanese readers.