### PR TITLE
Move Migration guides under 'getting started' in toc

### DIFF
--- a/.vitepress/toc_en.json
+++ b/.vitepress/toc_en.json
@@ -56,6 +56,36 @@
               ]
             }
           ]
+        },
+        {
+          "text": "Migration Guides",
+          "collapsed": true,
+          "items": [
+            {
+              "text": "Upgrading CakePHP",
+              "link": "/appendices/migration-guides"
+            },
+            {
+              "text": "5.0 Migration Guide",
+              "link": "/appendices/5-0-migration-guide"
+            },
+            {
+              "text": "5.0 Upgrade Guide",
+              "link": "/appendices/5-0-upgrade-guide"
+            },
+            {
+              "text": "5.1 Migration Guide",
+              "link": "/appendices/5-1-migration-guide"
+            },
+            {
+              "text": "5.2 Migration Guide",
+              "link": "/appendices/5-2-migration-guide"
+            },
+            {
+              "text": "5.3 Migration Guide",
+              "link": "/appendices/5-3-migration-guide"
+            }
+          ]
         }
       ]
     },
@@ -367,30 +397,6 @@
           "text": "Appendices",
           "items": [
             { "text": "Appendices", "link": "/appendices" },
-            {
-              "text": "Migration Guides",
-              "link": "/appendices/migration-guides"
-            },
-            {
-              "text": "5.0 Migration Guide",
-              "link": "/appendices/5-0-migration-guide"
-            },
-            {
-              "text": "5.0 Upgrade Guide",
-              "link": "/appendices/5-0-upgrade-guide"
-            },
-            {
-              "text": "5.1 Migration Guide",
-              "link": "/appendices/5-1-migration-guide"
-            },
-            {
-              "text": "5.2 Migration Guide",
-              "link": "/appendices/5-2-migration-guide"
-            },
-            {
-              "text": "5.3 Migration Guide",
-              "link": "/appendices/5-3-migration-guide"
-            },
             {
               "text": "CakePHP Development Process",
               "link": "/appendices/cakephp-development-process"

--- a/docs/en/appendices/migration-guides.md
+++ b/docs/en/appendices/migration-guides.md
@@ -1,5 +1,5 @@
 ---
-title: "Migration Guides"
+title: "Upgrading CakePHP"
 description: "Upgrade CakePHP versions: follow migration guides for each release, understand breaking changes, and smoothly transition between versions."
 ---
 
@@ -25,15 +25,15 @@ git checkout 5.x
 composer install --no-dev
 
 # Run rector with the desired ruleset
-bin/cake upgrade rector --rules cakephp51 <path/to/app/src>
+bin/cake upgrade rector --rules cakephp52 <path/to/app/src>
 ```
 
 Run rector before updating your `composer.json` dependencies
 to ensure the tool can resolve class names correctly.
 
-- [5 0 Upgrade Guide](5-0-upgrade-guide)
-- [5 0 Migration Guide](5-0-migration-guide)
-- [5 1 Migration Guide](5-1-migration-guide)
-- [5 2 Migration Guide](5-2-migration-guide)
-- [5 3 Migration Guide](5-3-migration-guide)
+- [5.0 Upgrade Guide](5-0-upgrade-guide)
+- [5.0 Migration Guide](5-0-migration-guide)
+- [5.1 Migration Guide](5-1-migration-guide)
+- [5.2 Migration Guide](5-2-migration-guide)
+- [5.3 Migration Guide](5-3-migration-guide)
 - [PHPUnit Upgrade](phpunit-upgrade)


### PR DESCRIPTION
Move the migration guides and upgrade tool docs to 'getting started' instead of 'appendices'. These docs are an entrypoint for returing developers. I've also retitled the migrations-guide page to focus more on the upgrading process.

Closes #8297
