### PR TITLE
Document withStringBody() vs auto-render interaction

### DIFF
--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -831,6 +831,30 @@ $response = $response->withType('application/json')
     ->withStringBody(json_encode(['Foo' => 'bar']));
 ```
 
+::: warning
+Setting a string body alone is not enough to send it. If your action neither
+returns the response nor disables view rendering, the controller still calls
+`render()` and overwrites the body you set. To make the string body take effect,
+either return the response from the action:
+
+```php
+public function export()
+{
+    return $this->response->withStringBody('My Body');
+}
+```
+
+or set it and disable auto-render:
+
+```php
+public function export()
+{
+    $this->setResponse($this->response->withStringBody('My Body'));
+    $this->disableAutoRender();
+}
+```
+:::
+
 `method` Cake\\Http\\Response::**withBody**(StreamInterface $body): static
 
 To set the response body, use the `withBody()` method, which is provided by the

--- a/docs/en/controllers/request-response.md
+++ b/docs/en/controllers/request-response.md
@@ -853,6 +853,7 @@ public function export()
     $this->disableAutoRender();
 }
 ```
+
 :::
 
 `method` Cake\\Http\\Response::**withBody**(StreamInterface $body): static


### PR DESCRIPTION
Resolves the documentation gap raised in cakephp/cakephp#19511.

`withStringBody()` sets the response body but, by itself, has no visible effect when an action neither returns the response nor disables view rendering. In that case `Controller::invokeAction()` still calls `render()` and overwrites the body. This was undocumented and unintuitive.

Adds a warning note to the "Setting the Body" section explaining the two ways to make the string body take effect: return the response, or `setResponse()` plus `disableAutoRender()`.
