### PR TITLE
Correct class name formatting in locking.md

### DIFF
--- a/docs/en/core-libraries/locking.md
+++ b/docs/en/core-libraries/locking.md
@@ -1,6 +1,6 @@
 # Locking
 
-`class` Cake\Lock\Lock
+`class` Cake\\Lock\\**Lock**
 
 Locking helps you coordinate access to shared resources across concurrent
 requests, CLI commands, queue workers, or background jobs. Use locks when you

--- a/docs/en/core-libraries/locking.md
+++ b/docs/en/core-libraries/locking.md
@@ -1,6 +1,6 @@
 # Locking
 
-`class` Cake\Lock\**Lock**
+`class` Cake\Lock\Lock
 
 Locking helps you coordinate access to shared resources across concurrent
 requests, CLI commands, queue workers, or background jobs. Use locks when you


### PR DESCRIPTION
```
`class` Cake\Lock\**Lock**
```
was making the lock page's header show up as
<img width="221" height="139" alt="image" src="https://github.com/user-attachments/assets/21313e5c-8d2f-4c66-9f03-b707ee74b65d" />
