### PR TITLE
Quickstart: run migrations after correcting the join-table migration

### DIFF
--- a/docs/en/tutorials-and-examples/cms/database.md
+++ b/docs/en/tutorials-and-examples/cms/database.md
@@ -66,9 +66,6 @@ bin/cake bake migration CreateUsers email:string password:string created modifie
 bin/cake bake migration CreateArticles user_id:integer title:string slug:string[191]:unique body:text published:boolean created modified
 bin/cake bake migration CreateTags title:string[191]:unique created modified
 bin/cake bake migration CreateArticlesTags article_id:integer:primary tag_id:integer:primary created modified
-
-# Run migrations to create tables
-bin/cake migrations migrate
 ```
 
 ```php [Migration Example]
@@ -119,6 +116,12 @@ $table->addColumn('tag_id', 'integer', [
 
 Remove the `autoIncrement` lines before running the migration to prevent foreign key problems.
 :::
+
+Once the `articles_tags` migration is corrected, run the migrations to create the tables:
+
+```bash
+bin/cake migrations migrate
+```
 
 #### Adding Seed Data
 


### PR DESCRIPTION
## Problem

In the CMS quickstart database section, the `[Commands]` block bundles `bin/cake migrations migrate` together with the bake commands:

```bash
bin/cake bake migration CreateUsers ...
bin/cake bake migration CreateArticles ...
bin/cake bake migration CreateTags ...
bin/cake bake migration CreateArticlesTags article_id:integer:primary tag_id:integer:primary created modified

# Run migrations to create tables
bin/cake migrations migrate
```

The baked `articles_tags` migration needs a manual fix first - its composite primary key columns are generated as auto-increment, which MySQL rejects with error 1075. That fix is documented in the "Composite Primary Key Adjustment" warning, but the warning comes **after** the migrate step. A reader who copies the whole block runs `migrate` before reaching the warning and hits the error.

Reported in cakephp/cakephp#19524.

## Fix

Move `bin/cake migrations migrate` out of the bake block to after the warning, so the documented order is: bake -> correct the `articles_tags` migration -> migrate.

## Note

The underlying bake behavior is fixed in cakephp/migrations#1095 (composite primary keys no longer auto-increment). Once a migrations release including that fix is out, the manual-adjustment warning here can be removed. Until then this keeps the quickstart from failing for current users.