### PR TITLE
Move Migration Guides group under Getting Started in 4.x sidebar

### DIFF
--- a/toc_en.json
+++ b/toc_en.json
@@ -31,6 +31,48 @@
         {
           "text": "Where to Get Help",
           "link": "/intro/where-to-get-help"
+        },
+        {
+          "text": "Migration Guides",
+          "collapsed": true,
+          "items": [
+            {
+              "text": "Upgrading CakePHP",
+              "link": "/appendices/migration-guides"
+            },
+            {
+              "text": "4.0 Upgrade Guide",
+              "link": "/appendices/4-0-upgrade-guide"
+            },
+            {
+              "text": "4.0 Migration Guide",
+              "link": "/appendices/4-0-migration-guide"
+            },
+            {
+              "text": "4.1 Migration Guide",
+              "link": "/appendices/4-1-migration-guide"
+            },
+            {
+              "text": "4.2 Migration Guide",
+              "link": "/appendices/4-2-migration-guide"
+            },
+            {
+              "text": "4.3 Migration Guide",
+              "link": "/appendices/4-3-migration-guide"
+            },
+            {
+              "text": "4.4 Migration Guide",
+              "link": "/appendices/4-4-migration-guide"
+            },
+            {
+              "text": "4.5 Migration Guide",
+              "link": "/appendices/4-5-migration-guide"
+            },
+            {
+              "text": "4.6 Migration Guide",
+              "link": "/appendices/4-6-migration-guide"
+            }
+          ]
         }
       ]
     },
@@ -599,42 +641,6 @@
         {
           "text": "Appendices",
           "link": "/appendices"
-        },
-        {
-          "text": "Migration Guides",
-          "link": "/appendices/migration-guides"
-        },
-        {
-          "text": "4.0 Migration Guide",
-          "link": "/appendices/4-0-migration-guide"
-        },
-        {
-          "text": "4.0 Upgrade Guide",
-          "link": "/appendices/4-0-upgrade-guide"
-        },
-        {
-          "text": "4.1 Migration Guide",
-          "link": "/appendices/4-1-migration-guide"
-        },
-        {
-          "text": "4.2 Migration Guide",
-          "link": "/appendices/4-2-migration-guide"
-        },
-        {
-          "text": "4.3 Migration Guide",
-          "link": "/appendices/4-3-migration-guide"
-        },
-        {
-          "text": "4.4 Migration Guide",
-          "link": "/appendices/4-4-migration-guide"
-        },
-        {
-          "text": "4.5 Migration Guide",
-          "link": "/appendices/4-5-migration-guide"
-        },
-        {
-          "text": "4.6 Migration Guide",
-          "link": "/appendices/4-6-migration-guide"
         },
         {
           "text": "Fixture Upgrade",


### PR DESCRIPTION
Aligns the 4.x sidebar with the 5.x/6.x layout.

Migration guides move out of the flat `Appendices` list into a collapsed **Migration Guides** group at the top, under Getting Started:

- Upgrading CakePHP (index)
- 4.0 Upgrade Guide
- 4.0 Migration Guide
- 4.1 - 4.6 Migration Guide

The 4.0 Upgrade Guide is listed before the 4.0 Migration Guide, consistent with the other branches. `Fixture Upgrade`, `CakePHP Development Process`, and `Glossary` remain under Appendices.