### PR TITLE
Move sessions & routing docs under controllers

### DIFF
--- a/.vitepress/toc_en.json
+++ b/.vitepress/toc_en.json
@@ -98,6 +98,8 @@
           "text": "Request & Response",
           "link": "/controllers/request-response"
         },
+        { "text": "Routing", "link": "/development/routing" },
+        { "text": "Sessions", "link": "/development/sessions" },
         { "text": "Middleware", "link": "/controllers/middleware" },
         {
           "text": "Pages Controller",
@@ -329,8 +331,6 @@
           "text": "Configuration",
           "link": "/development/configuration"
         },
-        { "text": "Routing", "link": "/development/routing" },
-        { "text": "Sessions", "link": "/development/sessions" },
         { "text": "Debugging", "link": "/development/debugging" },
         {
           "text": "Dependency Injection",


### PR DESCRIPTION
Move these pages under controllers in the TOC. I didn't move the files around as I didn't find a good way to do redirects with vitepress and I don't want to break any existing links to these pages.