### PR TITLE
Update supported versions table for 5.4 release

### DIFF
--- a/docs/en/intro/supported-versions.md
+++ b/docs/en/intro/supported-versions.md
@@ -4,11 +4,11 @@ See [CakePHP Development Process](../appendices/cakephp-development-process.md) 
 
 ## CakePHP Supported Versions
 
-This table was last updated in February 2026.
+This table was last updated in August 2026.
 
 | Major Version | Supported Version | PHP-Version    | Active Support | Security Support     |
 |---------------|-------------------|----------------|----------------|----------------------|
-| `5.x`         | `5.1` to `5.3`    | `8.1` to `8.5` | `5.3+`         | ✅                    |
+| `5.x`         | `5.2` to `5.4`    | `8.1` to `8.5` | `5.4+`         | ✅                    |
 | `4.x`         | `4.4` to `4.6`    | `7.2` to `8.3` | ❌              | September 10th, 2026 |
 | `3.x`         | None              | `5.6` to `7.4` | ❌              | ❌                    |
 | `2.x`         | None              | `5.4` to `7.4` | ❌              | ❌                    |


### PR DESCRIPTION
The supported versions table was last refreshed in February 2026 and still listed `5.1` to `5.3` with active support on `5.3+`.

5.4.0 was released on July 19th 2026, so per the minor version support policy on the same page ("security updates will be provided [...] till 3 new minor releases have been published"), security support for 5.1 ended with the 5.4 release, and active support moved to 5.4.

This brings the book in line with the [version map](https://github.com/cakephp/cakephp/wiki#version-map) and the supported versions table in the wiki, which already list 5.2/5.3/5.4 as supported and 5.1 as ended with "The release of 5.4 (Jul 19 2026)".

The PHP column stays `8.1` to `8.5`: 5.2 still requires PHP >= 8.1, 5.3 and 5.4 require >= 8.2.

Noticed via cakephp/cakephp#19575.
