### PR TITLE
Update migration guide for FunctionsBuilder::concat()

### DIFF
--- a/docs/en/appendices/5-5-migration-guide.md
+++ b/docs/en/appendices/5-5-migration-guide.md
@@ -18,8 +18,7 @@ bin/cake upgrade rector --rules cakephp55 <path/to/app/src>
 
 ### Database
 
-- Expressions created with `FunctionsBuilder::concat()` now use `CONCAT()` with
-  postgres instead of the `||` operator.
+- `Postgres` driver does not replace `FunctionsBuilder::concat()` expressions with `||` operations.
 
 ## Deprecations
 


### PR DESCRIPTION
Clarified what was rewriting the expression a little.