### PR TITLE
Pin action image and reduce permissions - 5.x

### DIFF
--- a/.github/workflows/deploy_5.yml
+++ b/.github/workflows/deploy_5.yml
@@ -10,6 +10,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -20,9 +23,8 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           branch: '5.x'
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/newbook-5'
-          git_push_flags: '-f'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Pin the image revision used for dokku deployments and reduce permissions for deploy jobs. Pinning the image revision reduces the chances of supply chain attacks on images with access to real credentials.

This will need to be done for other branches individually.